### PR TITLE
feat: add interactive mode

### DIFF
--- a/.changeset/some-chicken-punch.md
+++ b/.changeset/some-chicken-punch.md
@@ -1,0 +1,16 @@
+---
+"sync-worktrees": minor
+---
+
+Added interactive mode for easier configuration
+
+- When run without arguments, the tool now launches an interactive setup wizard
+- Prompts users for all required configuration values:
+  - Repository path (supports relative paths, automatically converted to absolute)
+  - Repository URL (only prompted if the repository doesn't exist)
+  - Worktree directory (supports relative paths)
+  - Run mode (once or scheduled with cron)
+  - Cron schedule (if scheduled mode is selected)
+- Shows a configuration summary before proceeding
+- Makes the tool more user-friendly for first-time users
+- Existing command-line argument usage remains unchanged

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "homepage": "https://github.com/yordan-kanchelov/sync-worktrees#readme",
   "dependencies": {
+    "@inquirer/prompts": "^7.6.0",
     "node-cron": "^4.2.0",
     "simple-git": "^3.28.0",
     "yargs": "^18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^7.6.0
+        version: 7.6.0(@types/node@24.0.10)
       node-cron:
         specifier: ^4.2.0
         version: 4.2.0
@@ -380,6 +383,127 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@inquirer/checkbox@4.1.9':
+    resolution: {integrity: sha512-DBJBkzI5Wx4jFaYm221LHvAhpKYkhVS0k9plqHwaHhofGNxvYB7J3Bz8w+bFJ05zaMb0sZNHo4KdmENQFlNTuQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.13':
+    resolution: {integrity: sha512-EkCtvp67ICIVVzjsquUiVSd+V5HRGOGQfsqA4E4vMWhYnB7InUL0pa0TIWt1i+OfP16Gkds8CdIu6yGZwOM1Yw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.14':
+    resolution: {integrity: sha512-Ma+ZpOJPewtIYl6HZHZckeX1STvDnHTCB2GVINNUlSEn2Am6LddWwfPkIGY0IUFVjUUrr/93XlBwTK6mfLjf0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.14':
+    resolution: {integrity: sha512-yd2qtLl4QIIax9DTMZ1ZN2pFrrj+yL3kgIWxm34SS6uwCr0sIhsNyudUjAo5q3TqI03xx4SEBkUJqZuAInp9uA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.16':
+    resolution: {integrity: sha512-oiDqafWzMtofeJyyGkb1CTPaxUkjIcSxePHHQCfif8t3HV9pHcw1Kgdw3/uGpDvaFfeTluwQtWiqzPVjAqS3zA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.12':
+    resolution: {integrity: sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.2.0':
+    resolution: {integrity: sha512-opqpHPB1NjAmDISi3uvZOTrjEEU5CWVu/HBkDby8t93+6UxYX0Z7Ps0Ltjm5sZiEbWenjubwUkivAEYQmy9xHw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.16':
+    resolution: {integrity: sha512-kMrXAaKGavBEoBYUCgualbwA9jWUx2TjMA46ek+pEKy38+LFpL9QHlTd8PO2kWPUgI/KB+qi02o4y2rwXbzr3Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.16':
+    resolution: {integrity: sha512-g8BVNBj5Zeb5/Y3cSN+hDUL7CsIFDIuVxb9EPty3lkxBaYpjL5BNRKSYOF9yOLe+JOcKFd+TSVeADQ4iSY7rbg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.6.0':
+    resolution: {integrity: sha512-jAhL7tyMxB3Gfwn4HIJ0yuJ5pvcB5maYUcouGcgd/ub79f9MqZ+aVnBtuFf+VC2GTkCBF+R+eo7Vi63w5VZlzw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.4':
+    resolution: {integrity: sha512-5GGvxVpXXMmfZNtvWw4IsHpR7RzqAR624xtkPd1NxxlV5M+pShMqzL4oRddRkg8rVEOK9fKdJp1jjVML2Lr7TQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.0.16':
+    resolution: {integrity: sha512-POCmXo+j97kTGU6aeRjsPyuCpQQfKcMXdeTMw708ZMtWrj5aykZvlUxH4Qgz3+Y1L/cAVZsSpA+UgZCu2GMOMg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.2.4':
+    resolution: {integrity: sha512-unTppUcTjmnbl/q+h8XeQDhAqIOmwWYWNyiiP2e3orXrg6tOaa5DHXja9PChCSbChOsktyKgOieRZFnajzxoBg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.7':
+    resolution: {integrity: sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -963,6 +1087,10 @@ packages:
 
   cjs-module-lexer@2.1.0:
     resolution: {integrity: sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1942,6 +2070,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   napi-postinstall@0.3.0:
     resolution: {integrity: sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2525,6 +2657,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -2574,6 +2710,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -2995,6 +3135,122 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@inquirer/checkbox@4.1.9(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/confirm@5.1.13(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/core@10.1.14(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/editor@4.2.14(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      external-editor: 3.1.0
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/expand@4.0.16(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/figures@1.0.12': {}
+
+  '@inquirer/input@4.2.0(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/number@3.0.16(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/password@4.0.16(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/prompts@7.6.0(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/checkbox': 4.1.9(@types/node@24.0.10)
+      '@inquirer/confirm': 5.1.13(@types/node@24.0.10)
+      '@inquirer/editor': 4.2.14(@types/node@24.0.10)
+      '@inquirer/expand': 4.0.16(@types/node@24.0.10)
+      '@inquirer/input': 4.2.0(@types/node@24.0.10)
+      '@inquirer/number': 3.0.16(@types/node@24.0.10)
+      '@inquirer/password': 4.0.16(@types/node@24.0.10)
+      '@inquirer/rawlist': 4.1.4(@types/node@24.0.10)
+      '@inquirer/search': 3.0.16(@types/node@24.0.10)
+      '@inquirer/select': 4.2.4(@types/node@24.0.10)
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/rawlist@4.1.4(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/search@3.0.16(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/select@4.2.4(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/type@3.0.7(@types/node@24.0.10)':
+    optionalDependencies:
+      '@types/node': 24.0.10
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3734,6 +3990,8 @@ snapshots:
   ci-info@4.3.0: {}
 
   cjs-module-lexer@2.1.0: {}
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -4960,6 +5218,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@2.0.0: {}
+
   napi-postinstall@0.3.0: {}
 
   natural-compare@1.4.0: {}
@@ -5605,6 +5865,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5660,3 +5926,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.2: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,8 @@ async function main(): Promise<void> {
   const syncService = new WorktreeSyncService(config);
 
   try {
-    // Initialize the repository (clone if needed)
     await syncService.initialize();
 
-    // Decide whether to run once or schedule the job
     if (config.runOnce) {
       console.log("Running the sync process once as requested by --runOnce flag.");
       await syncService.sync();
@@ -50,7 +48,6 @@ async function main(): Promise<void> {
   }
 }
 
-// Run the main function
 main().catch((error) => {
   console.error("❌ Unhandled error:", error);
   process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,21 @@ import * as path from "path";
 import * as cron from "node-cron";
 
 import { WorktreeSyncService } from "./services/worktree-sync.service";
-import { parseArguments } from "./utils/cli";
+import { isInteractiveMode, parseArguments } from "./utils/cli";
+import { promptForConfig } from "./utils/interactive";
+
+import type { Config } from "./types";
 
 async function main(): Promise<void> {
-  const config = parseArguments();
+  const partialConfig = parseArguments();
+
+  let config: Config;
+  if (isInteractiveMode(partialConfig)) {
+    config = await promptForConfig(partialConfig);
+  } else {
+    config = partialConfig as Config;
+  }
+
   const syncService = new WorktreeSyncService(config);
 
   try {

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -20,26 +20,20 @@ export class WorktreeSyncService {
     console.log(`[${new Date().toISOString()}] Starting worktree synchronization...`);
 
     try {
-      // 1. Fetch latest changes and prune deleted remote branches
       console.log("Step 1: Fetching latest data from remote...");
       await this.gitService.fetchAll();
 
-      // 2. Get remote branches
       const remoteBranches = await this.gitService.getRemoteBranches();
       console.log(`Found ${remoteBranches.length} remote branches.`);
 
-      // 3. Get existing worktree directories
       await fs.mkdir(this.config.worktreeDir, { recursive: true });
       const worktreeDirs = await fs.readdir(this.config.worktreeDir);
       console.log(`Found ${worktreeDirs.length} existing worktree directories.`);
 
-      // 4. Create new worktrees
       await this.createNewWorktrees(remoteBranches, worktreeDirs);
 
-      // 5. Prune old worktrees (with safety check)
       await this.pruneOldWorktrees(remoteBranches, worktreeDirs);
 
-      // 6. Cleanup
       await this.gitService.pruneWorktrees();
       console.log("Step 4: Pruned worktree metadata.");
     } catch (error) {

--- a/src/utils/__tests__/cli.test.ts
+++ b/src/utils/__tests__/cli.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "@jest/globals";
-
-// Skip these tests due to ESM module issues with yargs
-describe.skip("CLI Parser", () => {
-  it("tests are skipped due to ESM module issues", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/utils/__tests__/interactive.test.ts
+++ b/src/utils/__tests__/interactive.test.ts
@@ -1,0 +1,150 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { promptForConfig } from "../interactive";
+
+// Mock fs module
+jest.mock("fs");
+
+// Mock the inquirer prompts
+jest.mock("@inquirer/prompts", () => ({
+  input: jest.fn(),
+  select: jest.fn(),
+}));
+
+describe("Interactive prompt utility", () => {
+  const mockExistsSync = jest.mocked(fs.existsSync);
+
+  // Get the mocked functions with proper typing
+  const { input, select } = jest.requireMock("@inquirer/prompts") as {
+    input: jest.MockedFunction<() => Promise<string>>;
+    select: jest.MockedFunction<() => Promise<string>>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("promptForConfig", () => {
+    it("should prompt for all missing fields", async () => {
+      input
+        .mockResolvedValueOnce("/path/to/repo") // repoPath
+        .mockResolvedValueOnce("/path/to/worktrees") // worktreeDir
+        .mockResolvedValueOnce("*/10 * * * *"); // cronSchedule
+
+      select.mockResolvedValueOnce("scheduled"); // runMode
+
+      const result = await promptForConfig({});
+
+      expect(input).toHaveBeenCalledTimes(3);
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        repoPath: "/path/to/repo",
+        repoUrl: undefined,
+        worktreeDir: "/path/to/worktrees",
+        cronSchedule: "*/10 * * * *",
+        runOnce: false,
+      });
+    });
+
+    it("should not prompt for provided fields", async () => {
+      const partialConfig = {
+        repoPath: "/existing/repo",
+        worktreeDir: "/existing/worktrees",
+      };
+
+      select.mockResolvedValueOnce("once"); // runMode
+
+      const result = await promptForConfig(partialConfig);
+
+      expect(input).not.toHaveBeenCalled();
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        repoPath: "/existing/repo",
+        repoUrl: undefined,
+        worktreeDir: "/existing/worktrees",
+        cronSchedule: "0 * * * *",
+        runOnce: true,
+      });
+    });
+
+    it("should prompt for repo URL when repo path doesn't exist", async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      input
+        .mockResolvedValueOnce("/new/repo") // repoPath
+        .mockResolvedValueOnce("https://github.com/user/repo.git") // repoUrl
+        .mockResolvedValueOnce("/worktrees"); // worktreeDir
+
+      select.mockResolvedValueOnce("once"); // runMode
+
+      const result = await promptForConfig({});
+
+      expect(input).toHaveBeenCalledTimes(3);
+      expect(result.repoUrl).toBe("https://github.com/user/repo.git");
+    });
+
+    it("should convert relative paths to absolute paths", async () => {
+      const cwd = process.cwd();
+
+      input
+        .mockResolvedValueOnce("./my-repo") // repoPath (relative)
+        .mockResolvedValueOnce("../worktrees"); // worktreeDir (relative)
+
+      select.mockResolvedValueOnce("once"); // runMode
+
+      const result = await promptForConfig({});
+
+      expect(result.repoPath).toBe(path.resolve(cwd, "./my-repo"));
+      expect(result.worktreeDir).toBe(path.resolve(cwd, "../worktrees"));
+    });
+
+    it("should not prompt for cron schedule when runOnce is true", async () => {
+      select.mockResolvedValueOnce("once"); // runMode
+
+      const result = await promptForConfig({
+        repoPath: "/repo",
+        worktreeDir: "/worktrees",
+      });
+
+      // Should not prompt for cronSchedule
+      expect(input).not.toHaveBeenCalled();
+      expect(result.runOnce).toBe(true);
+      expect(result.cronSchedule).toBe("0 * * * *"); // default value
+    });
+
+    it("should use provided runOnce value", async () => {
+      const result = await promptForConfig({
+        repoPath: "/repo",
+        worktreeDir: "/worktrees",
+        runOnce: true,
+      });
+
+      // Should not prompt for runMode
+      expect(select).not.toHaveBeenCalled();
+      expect(result.runOnce).toBe(true);
+    });
+
+    it("should use provided cronSchedule", async () => {
+      select.mockResolvedValueOnce("scheduled"); // runMode
+
+      const result = await promptForConfig({
+        repoPath: "/repo",
+        worktreeDir: "/worktrees",
+        cronSchedule: "0 0 * * *",
+      });
+
+      // Should not prompt for cronSchedule
+      expect(input).not.toHaveBeenCalled();
+      expect(result.cronSchedule).toBe("0 0 * * *");
+    });
+  });
+});

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -3,13 +3,12 @@ import { hideBin } from "yargs/helpers";
 
 import type { Config } from "../types";
 
-export function parseArguments(): Config {
-  return yargs(hideBin(process.argv))
+export function parseArguments(): Partial<Config> {
+  const argv = yargs(hideBin(process.argv))
     .option("repoPath", {
       alias: "r",
       type: "string",
       description: "Absolute path to the target local repository directory.",
-      demandOption: true,
     })
     .option("repoUrl", {
       alias: "u",
@@ -20,7 +19,6 @@ export function parseArguments(): Config {
       alias: "w",
       type: "string",
       description: "Absolute path to the directory for storing worktrees.",
-      demandOption: true,
     })
     .option("cronSchedule", {
       alias: "s",
@@ -35,5 +33,17 @@ export function parseArguments(): Config {
     })
     .help()
     .alias("help", "h")
-    .parseSync() as Config;
+    .parseSync();
+
+  return {
+    repoPath: argv.repoPath,
+    repoUrl: argv.repoUrl,
+    worktreeDir: argv.worktreeDir,
+    cronSchedule: argv.cronSchedule,
+    runOnce: argv.runOnce,
+  };
+}
+
+export function isInteractiveMode(config: Partial<Config>): boolean {
+  return !config.repoPath || !config.worktreeDir;
 }

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -1,0 +1,112 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { input, select } from "@inquirer/prompts";
+
+import type { Config } from "../types";
+
+export async function promptForConfig(partialConfig: Partial<Config>): Promise<Config> {
+  console.log("🔧 Welcome to sync-worktrees interactive setup!\n");
+
+  let repoPath = partialConfig.repoPath;
+  if (!repoPath) {
+    repoPath = await input({
+      message: "Enter the path to your Git repository:",
+      validate: (value: string) => {
+        if (!value.trim()) {
+          return "Repository path is required";
+        }
+        return true;
+      },
+    });
+    // Convert relative path to absolute
+    if (!path.isAbsolute(repoPath)) {
+      repoPath = path.resolve(repoPath);
+    }
+  }
+
+  let repoUrl = partialConfig.repoUrl;
+  if (repoPath && !fs.existsSync(repoPath)) {
+    repoUrl = await input({
+      message: "Enter the Git repository URL (leave empty if repository already exists):",
+      default: partialConfig.repoUrl || "",
+      validate: (value: string) => {
+        if (!value.trim()) {
+          return "Repository URL is required since the repository path doesn't exist";
+        }
+        return true;
+      },
+    });
+  }
+
+  let worktreeDir = partialConfig.worktreeDir;
+  if (!worktreeDir) {
+    worktreeDir = await input({
+      message: "Enter the directory for storing worktrees:",
+      validate: (value: string) => {
+        if (!value.trim()) {
+          return "Worktree directory is required";
+        }
+        return true;
+      },
+    });
+    // Convert relative path to absolute
+    if (!path.isAbsolute(worktreeDir)) {
+      worktreeDir = path.resolve(worktreeDir);
+    }
+  }
+
+  let runOnce = partialConfig.runOnce;
+  let cronSchedule = partialConfig.cronSchedule || "0 * * * *";
+
+  if (runOnce === undefined) {
+    const runMode = await select({
+      message: "How would you like to run the sync?",
+      choices: [
+        { name: "Run once", value: "once" },
+        { name: "Schedule with cron", value: "scheduled" },
+      ],
+    });
+    runOnce = runMode === "once";
+
+    if (!runOnce && !partialConfig.cronSchedule) {
+      cronSchedule = await input({
+        message: "Enter the cron schedule (or press enter for default):",
+        default: "0 * * * *",
+        validate: (value: string) => {
+          if (!value.trim()) {
+            return "Cron schedule is required";
+          }
+          const parts = value.trim().split(" ");
+          if (parts.length < 5) {
+            return "Invalid cron pattern. Expected format: '* * * * *'";
+          }
+          return true;
+        },
+      });
+    }
+  }
+
+  const finalConfig: Config = {
+    repoPath,
+    repoUrl,
+    worktreeDir,
+    cronSchedule,
+    runOnce: runOnce || false,
+  };
+
+  console.log("\n📋 Configuration summary:");
+  console.log(`   Repository: ${finalConfig.repoPath}`);
+  if (finalConfig.repoUrl) {
+    console.log(`   Clone from: ${finalConfig.repoUrl}`);
+  }
+  console.log(`   Worktrees:  ${finalConfig.worktreeDir}`);
+  if (finalConfig.runOnce) {
+    console.log(`   Mode:       Run once`);
+  } else {
+    console.log(`   Mode:       Scheduled (${finalConfig.cronSchedule})`);
+  }
+  console.log("");
+
+  return finalConfig;
+}

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -19,7 +19,6 @@ export async function promptForConfig(partialConfig: Partial<Config>): Promise<C
         return true;
       },
     });
-    // Convert relative path to absolute
     if (!path.isAbsolute(repoPath)) {
       repoPath = path.resolve(repoPath);
     }
@@ -50,7 +49,6 @@ export async function promptForConfig(partialConfig: Partial<Config>): Promise<C
         return true;
       },
     });
-    // Convert relative path to absolute
     if (!path.isAbsolute(worktreeDir)) {
       worktreeDir = path.resolve(worktreeDir);
     }


### PR DESCRIPTION
This pull request introduces an interactive mode for the `sync-worktrees` tool, enhances its usability, and updates dependencies to support the new functionality. The key changes include adding an interactive setup wizard, modifying the CLI argument parsing logic, and implementing comprehensive tests for the new features.

### Interactive Mode Enhancements:
* [`.changeset/some-chicken-punch.md`](diffhunk://#diff-29e45cd11ec6c329b15a7ce45595ff676312e48d301650df891f82cba0f78e82R1-R16): Added an interactive setup wizard that prompts users for configuration values (e.g., repository path, URL, worktree directory, run mode, and cron schedule) when the tool is run without arguments. This makes the tool more user-friendly for first-time users while retaining existing command-line argument functionality.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L8-R22): Updated the main function to support interactive mode by checking for missing configuration values and invoking `promptForConfig` to gather them dynamically.
* [`src/utils/cli.ts`](diffhunk://#diff-e73cdeee46ab1f69d799626d022665669b44665cf80c4e35412a780ecbf39f25L6-L12): Modified the `parseArguments` function to return partial configurations and added an `isInteractiveMode` function to detect when interactive mode should be used. [[1]](diffhunk://#diff-e73cdeee46ab1f69d799626d022665669b44665cf80c4e35412a780ecbf39f25L6-L12) [[2]](diffhunk://#diff-e73cdeee46ab1f69d799626d022665669b44665cf80c4e35412a780ecbf39f25L23) [[3]](diffhunk://#diff-e73cdeee46ab1f69d799626d022665669b44665cf80c4e35412a780ecbf39f25L38-R48)

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50): Added `@inquirer/prompts` as a dependency to enable interactive prompts.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13): Included various `@inquirer` dependencies and other related packages (e.g., `cli-width`, `mute-stream`, `wrap-ansi`, `yoctocolors-cjs`) required for interactive functionality. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR387-R507) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1091-R1094) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2073-R2076) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2660-R2663) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2714-R2717) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3139-R3254) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3994-R3995) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5221-R5222) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5868-R5873) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5929-R5930)

### Testing Improvements:
* [`src/utils/__tests__/interactive.test.ts`](diffhunk://#diff-165f177622afdb17a74ccd462014293aaa6d93c5feb96f6e9bfdebdd5da33b6dR1-R150): Added extensive tests for the new interactive mode, covering scenarios such as missing fields, relative path conversion, and default values for `cronSchedule` and `runOnce`. Mocked dependencies like `fs` and `@inquirer/prompts` to simulate user inputs.
* [`src/utils/__tests__/cli.test.ts`](diffhunk://#diff-99bd4590f26d1abcfe5063e67880d8bcfe62f8ec2cdcd83e4992944bcd5df7e9L1-L8): Removed skipped tests for CLI parsing due to ESM module issues.