### PR TITLE
feat: add branch age filtering for syncing active branches

### DIFF
--- a/.changeset/branch-age-filtering.md
+++ b/.changeset/branch-age-filtering.md
@@ -1,0 +1,11 @@
+---
+"sync-worktrees": minor
+---
+
+Add branch age filtering feature to only sync recently active branches
+
+- Added `--branchMaxAge` CLI option to filter branches by last commit activity
+- Support for duration formats: hours (h), days (d), weeks (w), months (m), years (y)
+- Can be configured globally or per-repository in config files
+- Helps reduce clutter and save disk space by ignoring stale branches
+- Example: `--branchMaxAge 30d` only syncs branches active in the last 30 days

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -167,7 +167,7 @@ export class GitService {
       .filter((line) => line);
 
     for (const line of lines) {
-      const [ref, dateStr] = line.split("|");
+      const [ref, dateStr] = line.split("|", 2);
       if (ref && dateStr) {
         const branch = ref.replace("origin/", "");
         const lastActivity = new Date(dateStr);

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -151,6 +151,36 @@ export class GitService {
     return branches.all.filter((b) => b.startsWith("origin/")).map((b) => b.replace("origin/", ""));
   }
 
+  async getRemoteBranchesWithActivity(): Promise<{ branch: string; lastActivity: Date }[]> {
+    const git = this.getGit();
+    // Use for-each-ref to get branch names with their last commit dates
+    const result = await git.raw([
+      "for-each-ref",
+      "--format=%(refname:short)|%(committerdate:iso8601)",
+      "refs/remotes/origin",
+    ]);
+
+    const branches: { branch: string; lastActivity: Date }[] = [];
+    const lines = result
+      .trim()
+      .split("\n")
+      .filter((line) => line);
+
+    for (const line of lines) {
+      const [ref, dateStr] = line.split("|");
+      if (ref && dateStr) {
+        const branch = ref.replace("origin/", "");
+        const lastActivity = new Date(dateStr);
+        // Skip if the date is invalid
+        if (!isNaN(lastActivity.getTime())) {
+          branches.push({ branch, lastActivity });
+        }
+      }
+    }
+
+    return branches;
+  }
+
   async addWorktree(branchName: string, worktreePath: string): Promise<void> {
     const bareGit = simpleGit(this.bareRepoPath);
     // Use absolute path for worktree add to avoid relative path issues

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export interface Config {
   runOnce: boolean;
   bareRepoDir?: string;
   retry?: RetryConfig;
+  branchMaxAge?: string;
 }
 
 export interface RepositoryConfig extends Config {

--- a/src/utils/__tests__/date-filter.test.ts
+++ b/src/utils/__tests__/date-filter.test.ts
@@ -1,0 +1,116 @@
+import { filterBranchesByAge, formatDuration, parseDuration } from "../date-filter";
+
+describe("date-filter", () => {
+  describe("parseDuration", () => {
+    it("should parse hours correctly", () => {
+      expect(parseDuration("24h")).toBe(24 * 60 * 60 * 1000);
+      expect(parseDuration("1h")).toBe(60 * 60 * 1000);
+    });
+
+    it("should parse days correctly", () => {
+      expect(parseDuration("30d")).toBe(30 * 24 * 60 * 60 * 1000);
+      expect(parseDuration("1d")).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it("should parse weeks correctly", () => {
+      expect(parseDuration("4w")).toBe(4 * 7 * 24 * 60 * 60 * 1000);
+      expect(parseDuration("1w")).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should parse months correctly", () => {
+      expect(parseDuration("6m")).toBe(6 * 30 * 24 * 60 * 60 * 1000);
+      expect(parseDuration("1m")).toBe(30 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should parse years correctly", () => {
+      expect(parseDuration("2y")).toBe(2 * 365 * 24 * 60 * 60 * 1000);
+      expect(parseDuration("1y")).toBe(365 * 24 * 60 * 60 * 1000);
+    });
+
+    it("should return null for invalid formats", () => {
+      expect(parseDuration("30")).toBeNull();
+      expect(parseDuration("d30")).toBeNull();
+      expect(parseDuration("30 days")).toBeNull();
+      expect(parseDuration("")).toBeNull();
+      expect(parseDuration("30x")).toBeNull();
+    });
+  });
+
+  describe("filterBranchesByAge", () => {
+    const now = new Date();
+    const dayInMs = 24 * 60 * 60 * 1000;
+
+    const branches = [
+      { branch: "main", lastActivity: new Date(now.getTime() - 5 * dayInMs) },
+      { branch: "feature-1", lastActivity: new Date(now.getTime() - 20 * dayInMs) },
+      { branch: "feature-2", lastActivity: new Date(now.getTime() - 40 * dayInMs) },
+      { branch: "old-branch", lastActivity: new Date(now.getTime() - 100 * dayInMs) },
+    ];
+
+    it("should filter branches older than specified age", () => {
+      const result = filterBranchesByAge(branches, "30d");
+      expect(result).toHaveLength(2);
+      expect(result.map((b) => b.branch)).toEqual(["main", "feature-1"]);
+    });
+
+    it("should include all branches if max age is very large", () => {
+      const result = filterBranchesByAge(branches, "1y");
+      expect(result).toHaveLength(4);
+    });
+
+    it("should exclude all branches if max age is very small", () => {
+      const result = filterBranchesByAge(branches, "1h");
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return all branches if duration format is invalid", () => {
+      const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+      const result = filterBranchesByAge(branches, "invalid");
+      expect(result).toHaveLength(4);
+      expect(consoleSpy).toHaveBeenCalledWith("Invalid duration format: invalid. Using all branches.");
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle edge case of exact cutoff", () => {
+      // Use a fixed date to avoid timing issues
+      const fixedNow = new Date("2024-01-15T12:00:00Z");
+      const exactCutoffDate = new Date(fixedNow.getTime() - 30 * dayInMs);
+      const exactCutoffBranches = [{ branch: "exact", lastActivity: exactCutoffDate }];
+
+      // Mock Date.now() to return our fixed date
+      const originalDateNow = Date.now;
+      Date.now = jest.fn(() => fixedNow.getTime());
+
+      const result = filterBranchesByAge(exactCutoffBranches, "30d");
+
+      // Restore Date.now()
+      Date.now = originalDateNow;
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("formatDuration", () => {
+    it("should format singular units correctly", () => {
+      expect(formatDuration("1h")).toBe("1 hour");
+      expect(formatDuration("1d")).toBe("1 day");
+      expect(formatDuration("1w")).toBe("1 week");
+      expect(formatDuration("1m")).toBe("1 month");
+      expect(formatDuration("1y")).toBe("1 year");
+    });
+
+    it("should format plural units correctly", () => {
+      expect(formatDuration("24h")).toBe("24 hours");
+      expect(formatDuration("30d")).toBe("30 days");
+      expect(formatDuration("4w")).toBe("4 weeks");
+      expect(formatDuration("6m")).toBe("6 months");
+      expect(formatDuration("2y")).toBe("2 years");
+    });
+
+    it("should return original string for invalid formats", () => {
+      expect(formatDuration("invalid")).toBe("invalid");
+      expect(formatDuration("30")).toBe("30");
+      expect(formatDuration("")).toBe("");
+    });
+  });
+});

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -8,6 +8,7 @@ export interface CliOptions extends Partial<Config> {
   filter?: string;
   list?: boolean;
   bareRepoDir?: string;
+  branchMaxAge?: string;
 }
 
 export function parseArguments(): CliOptions {
@@ -54,6 +55,11 @@ export function parseArguments(): CliOptions {
       description: "Run the sync process once and then exit, without scheduling.",
       default: false,
     })
+    .option("branchMaxAge", {
+      alias: "a",
+      type: "string",
+      description: "Maximum age of branches to sync (e.g., '30d', '6m', '1y').",
+    })
     .help()
     .alias("help", "h")
     .parseSync();
@@ -67,6 +73,7 @@ export function parseArguments(): CliOptions {
     cronSchedule: argv.cronSchedule,
     runOnce: argv.runOnce,
     bareRepoDir: argv.bareRepoDir,
+    branchMaxAge: argv.branchMaxAge,
   };
 }
 
@@ -95,6 +102,10 @@ export function reconstructCliCommand(config: Config): string {
 
   if (config.runOnce) {
     args.push("--runOnce");
+  }
+
+  if (config.branchMaxAge) {
+    args.push(`--branchMaxAge "${config.branchMaxAge}"`);
   }
 
   return `${executable} ${args.join(" ")}`;

--- a/src/utils/date-filter.ts
+++ b/src/utils/date-filter.ts
@@ -1,0 +1,54 @@
+export function parseDuration(durationStr: string): number | null {
+  const match = durationStr.match(/^(\d+)([hdwmy])$/);
+  if (!match) {
+    return null;
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  const multipliers: Record<string, number> = {
+    h: 60 * 60 * 1000, // hours
+    d: 24 * 60 * 60 * 1000, // days
+    w: 7 * 24 * 60 * 60 * 1000, // weeks
+    m: 30 * 24 * 60 * 60 * 1000, // months (approximate)
+    y: 365 * 24 * 60 * 60 * 1000, // years (approximate)
+  };
+
+  return value * multipliers[unit];
+}
+
+export function filterBranchesByAge(
+  branches: { branch: string; lastActivity: Date }[],
+  maxAge: string,
+): { branch: string; lastActivity: Date }[] {
+  const maxAgeMs = parseDuration(maxAge);
+  if (maxAgeMs === null) {
+    console.warn(`Invalid duration format: ${maxAge}. Using all branches.`);
+    return branches;
+  }
+
+  const cutoffDate = new Date(Date.now() - maxAgeMs);
+
+  return branches.filter(({ lastActivity }) => lastActivity >= cutoffDate);
+}
+
+export function formatDuration(durationStr: string): string {
+  const match = durationStr.match(/^(\d+)([hdwmy])$/);
+  if (!match) {
+    return durationStr;
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  const unitNames: Record<string, string> = {
+    h: value === 1 ? "hour" : "hours",
+    d: value === 1 ? "day" : "days",
+    w: value === 1 ? "week" : "weeks",
+    m: value === 1 ? "month" : "months",
+    y: value === 1 ? "year" : "years",
+  };
+
+  return `${value} ${unitNames[unit]}`;
+}

--- a/sync-worktrees.config.example.js
+++ b/sync-worktrees.config.example.js
@@ -14,7 +14,9 @@ module.exports = {
     // Default cron schedule: every hour
     cronSchedule: "0 * * * *",
     // By default, run as a scheduled job (not one-time)
-    runOnce: false
+    runOnce: false,
+    // Maximum age of branches to sync (optional)
+    // branchMaxAge: "30d",  // Only sync branches active in last 30 days
   },
   
   // Retry configuration for handling transient errors (optional)
@@ -86,6 +88,32 @@ module.exports = {
         maxAttempts: 10,        // Try 10 times for experimental repo
         initialDelayMs: 2000    // Start with 2 second delay
       }
+    },
+    
+    {
+      name: "active-development",
+      
+      repoUrl: "https://github.com/user/active-dev.git",
+      worktreeDir: "./worktrees/active-dev",
+      
+      // Only sync branches that have been active in the last 2 weeks
+      branchMaxAge: "14d",
+      
+      // Check for updates every 30 minutes
+      cronSchedule: "*/30 * * * *"
+    },
+    
+    {
+      name: "legacy-project",
+      
+      repoUrl: "https://github.com/user/legacy.git",
+      worktreeDir: "./worktrees/legacy",
+      
+      // For legacy projects, only sync branches active in last 6 months
+      branchMaxAge: "6m",
+      
+      // Check less frequently - once per day
+      cronSchedule: "0 0 * * *"
     }
   ]
 };


### PR DESCRIPTION
Introduce a feature to filter branches based on their last commit activity, allowing synchronization of only recently active branches. This includes a new CLI option `--branchMaxAge` to specify the maximum age of branches to sync, supporting various duration formats. The implementation helps reduce clutter by ignoring stale branches.