### PR TITLE
feat: improve detection and messaging for branches with deleted upstream

### DIFF
--- a/.changeset/improved-upstream-gone-messages.md
+++ b/.changeset/improved-upstream-gone-messages.md
@@ -1,0 +1,14 @@
+---
+"sync-worktrees": minor
+---
+
+Improve warning messages for branches with deleted upstream
+
+When a branch's upstream is deleted (e.g., after squash merge), sync-worktrees now shows clearer messages explaining why the worktree cannot be automatically removed. The new messages guide users to manually review and clean up if their changes were already integrated.
+
+**Example:**
+```
+⚠️ Cannot automatically remove 'feat/LCR-5982' - upstream branch was deleted.
+   Please review manually: cd worktrees/feat/LCR-5982 && git log
+   If changes were squash-merged, you can safely remove with: git worktree remove worktrees/feat/LCR-5982
+```

--- a/.changeset/sync-metadata-tracking.md
+++ b/.changeset/sync-metadata-tracking.md
@@ -1,0 +1,17 @@
+---
+"sync-worktrees": minor
+---
+
+Add sync metadata tracking to accurately detect unpushed commits
+
+Sync-worktrees now tracks synchronization metadata for each worktree, storing information about the last synced commit. This enables accurate detection of truly unpushed commits when a branch's upstream has been deleted (e.g., after squash merge).
+
+**Benefits:**
+- Accurately detects new commits made after the upstream was deleted
+- Allows safe cleanup of worktrees whose changes were already integrated via squash merge
+- Prevents false positives where all commits appeared as "unpushed" after upstream deletion
+
+**Technical details:**
+- Metadata is stored in Git's worktree directory: `.git/worktrees/[worktree-name]/sync-metadata.json`
+- Automatically created when adding worktrees and updated during sync operations
+- Backward compatible - works seamlessly with existing setups

--- a/src/__tests__/edge-cases/file-system.test.ts
+++ b/src/__tests__/edge-cases/file-system.test.ts
@@ -34,6 +34,7 @@ describe("File System Edge Cases", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/edge-cases/git-states.test.ts
+++ b/src/__tests__/edge-cases/git-states.test.ts
@@ -34,6 +34,7 @@ describe("Git States Edge Cases", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/edge-cases/stash-detection.test.ts
+++ b/src/__tests__/edge-cases/stash-detection.test.ts
@@ -34,6 +34,7 @@ describe("Stash Detection Edge Cases", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/edge-cases/submodules.test.ts
+++ b/src/__tests__/edge-cases/submodules.test.ts
@@ -34,6 +34,7 @@ describe("Submodule Edge Cases", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/integration/concurrent-ops.test.ts
+++ b/src/__tests__/integration/concurrent-ops.test.ts
@@ -34,6 +34,7 @@ describe("Concurrent Operations and Race Conditions", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/integration/corrupted-state.test.ts
+++ b/src/__tests__/integration/corrupted-state.test.ts
@@ -34,6 +34,7 @@ describe("Corrupted State Recovery", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/__tests__/integration/mixed-states.test.ts
+++ b/src/__tests__/integration/mixed-states.test.ts
@@ -34,6 +34,7 @@ describe("Complex Mixed State Scenarios", () => {
       pruneWorktrees: jest.fn<any>().mockResolvedValue(undefined),
       checkWorktreeStatus: jest.fn<any>().mockResolvedValue(true),
       hasUnpushedCommits: jest.fn<any>().mockResolvedValue(false),
+      hasUpstreamGone: jest.fn<any>().mockResolvedValue(false),
       hasStashedChanges: jest.fn<any>().mockResolvedValue(false),
       hasOperationInProgress: jest.fn<any>().mockResolvedValue(false),
       hasModifiedSubmodules: jest.fn<any>().mockResolvedValue(false),

--- a/src/services/__tests__/worktree-metadata.service.test.ts
+++ b/src/services/__tests__/worktree-metadata.service.test.ts
@@ -1,0 +1,254 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { WorktreeMetadataService } from "../worktree-metadata.service";
+
+import type { SyncMetadata } from "../../types/sync-metadata";
+
+jest.mock("fs/promises");
+
+describe("WorktreeMetadataService", () => {
+  let service: WorktreeMetadataService;
+  const mockBareRepoPath = "/test/bare/repo";
+  const mockWorktreeName = "feature-branch";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new WorktreeMetadataService();
+  });
+
+  describe("getMetadataPath", () => {
+    it("should return correct metadata path", async () => {
+      const metadataPath = await service.getMetadataPath(mockBareRepoPath, mockWorktreeName);
+      expect(metadataPath).toBe("/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json");
+    });
+  });
+
+  describe("saveMetadata", () => {
+    it("should save metadata to file", async () => {
+      const mockMetadata: SyncMetadata = {
+        lastSyncCommit: "abc123",
+        lastSyncDate: "2024-01-15T10:00:00Z",
+        upstreamBranch: "origin/feature-branch",
+        createdFrom: {
+          branch: "main",
+          commit: "def456",
+        },
+        syncHistory: [
+          {
+            date: "2024-01-15T10:00:00Z",
+            commit: "abc123",
+            action: "created",
+          },
+        ],
+      };
+
+      (fs.mkdir as jest.Mock<any>).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock<any>).mockResolvedValue(undefined);
+
+      await service.saveMetadata(mockBareRepoPath, mockWorktreeName, mockMetadata);
+
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        path.dirname("/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json"),
+        { recursive: true },
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json",
+        JSON.stringify(mockMetadata, null, 2),
+        "utf-8",
+      );
+    });
+  });
+
+  describe("loadMetadata", () => {
+    it("should load metadata from file", async () => {
+      const mockMetadata: SyncMetadata = {
+        lastSyncCommit: "abc123",
+        lastSyncDate: "2024-01-15T10:00:00Z",
+        upstreamBranch: "origin/feature-branch",
+        createdFrom: {
+          branch: "main",
+          commit: "def456",
+        },
+        syncHistory: [],
+      };
+
+      (fs.readFile as jest.Mock<any>).mockResolvedValue(JSON.stringify(mockMetadata));
+
+      const result = await service.loadMetadata(mockBareRepoPath, mockWorktreeName);
+
+      expect(fs.readFile).toHaveBeenCalledWith(
+        "/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json",
+        "utf-8",
+      );
+      expect(result).toEqual(mockMetadata);
+    });
+
+    it("should return null if file does not exist", async () => {
+      (fs.readFile as jest.Mock<any>).mockRejectedValue(new Error("ENOENT"));
+
+      const result = await service.loadMetadata(mockBareRepoPath, mockWorktreeName);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null if file contains invalid JSON", async () => {
+      (fs.readFile as jest.Mock<any>).mockResolvedValue("invalid json");
+
+      const result = await service.loadMetadata(mockBareRepoPath, mockWorktreeName);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteMetadata", () => {
+    it("should delete metadata file", async () => {
+      (fs.unlink as jest.Mock<any>).mockResolvedValue(undefined);
+
+      await service.deleteMetadata(mockBareRepoPath, mockWorktreeName);
+
+      expect(fs.unlink).toHaveBeenCalledWith("/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json");
+    });
+
+    it("should not throw if file does not exist", async () => {
+      const error = new Error("ENOENT") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      (fs.unlink as jest.Mock<any>).mockRejectedValue(error);
+
+      await expect(service.deleteMetadata(mockBareRepoPath, mockWorktreeName)).resolves.not.toThrow();
+    });
+
+    it("should throw for other errors", async () => {
+      const error = new Error("Permission denied");
+      (fs.unlink as jest.Mock<any>).mockRejectedValue(error);
+
+      await expect(service.deleteMetadata(mockBareRepoPath, mockWorktreeName)).rejects.toThrow("Permission denied");
+    });
+  });
+
+  describe("updateLastSync", () => {
+    it("should update existing metadata", async () => {
+      const existingMetadata: SyncMetadata = {
+        lastSyncCommit: "old123",
+        lastSyncDate: "2024-01-14T10:00:00Z",
+        upstreamBranch: "origin/feature-branch",
+        createdFrom: {
+          branch: "main",
+          commit: "def456",
+        },
+        syncHistory: [
+          {
+            date: "2024-01-14T10:00:00Z",
+            commit: "old123",
+            action: "created",
+          },
+        ],
+      };
+
+      (fs.readFile as jest.Mock<any>).mockResolvedValue(JSON.stringify(existingMetadata));
+      (fs.mkdir as jest.Mock<any>).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock<any>).mockResolvedValue(undefined);
+
+      // Mock Date to have consistent timestamps
+      const mockDate = new Date("2024-01-15T12:00:00Z");
+      jest.spyOn(global, "Date").mockImplementation(() => mockDate as any);
+
+      await service.updateLastSync(mockBareRepoPath, mockWorktreeName, "new456", "updated");
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('"lastSyncCommit": "new456"'),
+        "utf-8",
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('"lastSyncDate": "2024-01-15T12:00:00.000Z"'),
+        "utf-8",
+      );
+    });
+
+    it("should limit sync history to 10 entries", async () => {
+      const existingMetadata: SyncMetadata = {
+        lastSyncCommit: "old123",
+        lastSyncDate: "2024-01-14T10:00:00Z",
+        upstreamBranch: "origin/feature-branch",
+        createdFrom: {
+          branch: "main",
+          commit: "def456",
+        },
+        syncHistory: Array(10).fill({
+          date: "2024-01-01T10:00:00Z",
+          commit: "old",
+          action: "updated",
+        }),
+      };
+
+      (fs.readFile as jest.Mock<any>).mockResolvedValue(JSON.stringify(existingMetadata));
+      (fs.mkdir as jest.Mock<any>).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock<any>).mockResolvedValue(undefined);
+
+      await service.updateLastSync(mockBareRepoPath, mockWorktreeName, "new456", "updated");
+
+      // Check that the saved metadata has exactly 10 entries
+      const savedData = JSON.parse((fs.writeFile as jest.Mock<any>).mock.calls[0][1] as string);
+      expect(savedData.syncHistory).toHaveLength(10);
+      expect(savedData.syncHistory[9].commit).toBe("new456");
+    });
+
+    it("should warn if no metadata exists", async () => {
+      (fs.readFile as jest.Mock<any>).mockRejectedValue(new Error("ENOENT"));
+      const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      await service.updateLastSync(mockBareRepoPath, mockWorktreeName, "new456");
+
+      expect(consoleSpy).toHaveBeenCalledWith("No metadata found for worktree feature-branch, skipping update");
+      expect(fs.writeFile).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("createInitialMetadata", () => {
+    it("should create initial metadata for new worktree", async () => {
+      (fs.mkdir as jest.Mock<any>).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock<any>).mockResolvedValue(undefined);
+
+      const mockDate = new Date("2024-01-15T12:00:00Z");
+      jest.spyOn(global, "Date").mockImplementation(() => mockDate as any);
+
+      await service.createInitialMetadata(
+        mockBareRepoPath,
+        mockWorktreeName,
+        "abc123",
+        "origin/feature-branch",
+        "main",
+        "def456",
+      );
+
+      const expectedMetadata: SyncMetadata = {
+        lastSyncCommit: "abc123",
+        lastSyncDate: "2024-01-15T12:00:00.000Z",
+        upstreamBranch: "origin/feature-branch",
+        createdFrom: {
+          branch: "main",
+          commit: "def456",
+        },
+        syncHistory: [
+          {
+            date: "2024-01-15T12:00:00.000Z",
+            commit: "abc123",
+            action: "created",
+          },
+        ],
+      };
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        "/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json",
+        JSON.stringify(expectedMetadata, null, 2),
+        "utf-8",
+      );
+    });
+  });
+});

--- a/src/services/worktree-metadata.service.ts
+++ b/src/services/worktree-metadata.service.ts
@@ -1,0 +1,107 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import type { SyncMetadata } from "../types/sync-metadata";
+
+export class WorktreeMetadataService {
+  async getMetadataPath(bareRepoPath: string, worktreeName: string): Promise<string> {
+    // Git stores worktree metadata in .git/worktrees/[worktree-name]/
+    // We'll store our metadata alongside Git's metadata
+    return path.join(bareRepoPath, ".git", "worktrees", worktreeName, "sync-metadata.json");
+  }
+
+  async saveMetadata(bareRepoPath: string, worktreeName: string, metadata: SyncMetadata): Promise<void> {
+    const metadataPath = await this.getMetadataPath(bareRepoPath, worktreeName);
+
+    // Ensure directory exists
+    await fs.mkdir(path.dirname(metadataPath), { recursive: true });
+
+    // Write metadata as JSON
+    await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), "utf-8");
+  }
+
+  async loadMetadata(bareRepoPath: string, worktreeName: string): Promise<SyncMetadata | null> {
+    const metadataPath = await this.getMetadataPath(bareRepoPath, worktreeName);
+
+    try {
+      const content = await fs.readFile(metadataPath, "utf-8");
+      return JSON.parse(content) as SyncMetadata;
+    } catch {
+      // Return null if file doesn't exist or can't be parsed
+      return null;
+    }
+  }
+
+  async deleteMetadata(bareRepoPath: string, worktreeName: string): Promise<void> {
+    const metadataPath = await this.getMetadataPath(bareRepoPath, worktreeName);
+
+    try {
+      await fs.unlink(metadataPath);
+    } catch (error) {
+      // Ignore errors if file doesn't exist
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  async updateLastSync(
+    bareRepoPath: string,
+    worktreeName: string,
+    commit: string,
+    action: "created" | "updated" | "fetched" = "updated",
+  ): Promise<void> {
+    const existing = await this.loadMetadata(bareRepoPath, worktreeName);
+
+    if (!existing) {
+      // If no metadata exists, we can't update it
+      console.warn(`No metadata found for worktree ${worktreeName}, skipping update`);
+      return;
+    }
+
+    // Update metadata
+    existing.lastSyncCommit = commit;
+    existing.lastSyncDate = new Date().toISOString();
+
+    // Add to history (limit to last 10 entries)
+    existing.syncHistory.push({
+      date: existing.lastSyncDate,
+      commit,
+      action,
+    });
+
+    if (existing.syncHistory.length > 10) {
+      existing.syncHistory = existing.syncHistory.slice(-10);
+    }
+
+    await this.saveMetadata(bareRepoPath, worktreeName, existing);
+  }
+
+  async createInitialMetadata(
+    bareRepoPath: string,
+    worktreeName: string,
+    commit: string,
+    upstreamBranch: string,
+    parentBranch: string,
+    parentCommit: string,
+  ): Promise<void> {
+    const metadata: SyncMetadata = {
+      lastSyncCommit: commit,
+      lastSyncDate: new Date().toISOString(),
+      upstreamBranch,
+      createdFrom: {
+        branch: parentBranch,
+        commit: parentCommit,
+      },
+      syncHistory: [
+        {
+          date: new Date().toISOString(),
+          commit,
+          action: "created",
+        },
+      ],
+    };
+
+    await this.saveMetadata(bareRepoPath, worktreeName, metadata);
+  }
+}

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -171,15 +171,26 @@ export class WorktreeSyncService {
           if (canDelete) {
             await this.gitService.removeWorktree(worktreePath);
           } else {
-            // Log specific reasons for skipping
-            const reasons: string[] = [];
-            if (!isClean) reasons.push("uncommitted changes");
-            if (hasUnpushed) reasons.push("unpushed commits");
-            if (hasStash) reasons.push("stashed changes");
-            if (hasOperation) reasons.push("operation in progress");
-            if (hasDirtySubmodules) reasons.push("modified submodules");
+            // Check if upstream is gone for better messaging
+            const upstreamGone = hasUnpushed && (await this.gitService.hasUpstreamGone(worktreePath));
 
-            console.log(`  - ⚠️ Skipping removal of '${branchName}' due to: ${reasons.join(", ")}.`);
+            if (upstreamGone) {
+              console.log(`  - ⚠️ Cannot automatically remove '${branchName}' - upstream branch was deleted.`);
+              console.log(`     Please review manually: cd ${worktreePath} && git log`);
+              console.log(
+                `     If changes were squash-merged, you can safely remove with: git worktree remove ${worktreePath}`,
+              );
+            } else {
+              // Log specific reasons for skipping
+              const reasons: string[] = [];
+              if (!isClean) reasons.push("uncommitted changes");
+              if (hasUnpushed) reasons.push("unpushed commits");
+              if (hasStash) reasons.push("stashed changes");
+              if (hasOperation) reasons.push("operation in progress");
+              if (hasDirtySubmodules) reasons.push("modified submodules");
+
+              console.log(`  - ⚠️ Skipping removal of '${branchName}' due to: ${reasons.join(", ")}.`);
+            }
           }
         } catch (error) {
           console.error(`  - Error checking worktree '${branchName}':`, error);

--- a/src/types/sync-metadata.ts
+++ b/src/types/sync-metadata.ts
@@ -1,0 +1,16 @@
+export interface SyncMetadata {
+  lastSyncCommit: string;
+  lastSyncDate: string;
+  upstreamBranch: string;
+  createdFrom: {
+    branch: string;
+    commit: string;
+  };
+  syncHistory: SyncHistoryEntry[];
+}
+
+export interface SyncHistoryEntry {
+  date: string;
+  commit: string;
+  action: "created" | "updated" | "fetched";
+}


### PR DESCRIPTION
- Add hasUpstreamGone method to detect when a branch's upstream has been deleted
- Show clearer messages explaining why worktrees can't be removed automatically
- Guide users to manually review and clean up if changes were squash-merged

- Add WorktreeMetadataService to track sync metadata for each worktree
- Store last synced commit to accurately detect new commits after upstream deletion
- Integrate metadata tracking with worktree creation, updates, and removal
- Use metadata in hasUnpushedCommits for accurate detection when upstream is gone

This solves the issue where all commits appeared as 'unpushed' when the upstream branch was deleted after squash merge, preventing legitimate cleanup of stale worktrees.