### PR TITLE
Refactor MCP handlers and sync flow

### DIFF
--- a/.changeset/mcp-server-implementation.md
+++ b/.changeset/mcp-server-implementation.md
@@ -1,7 +1,0 @@
----
-"sync-worktrees": major
----
-
-Add MCP (Model Context Protocol) server implementation, exposing sync-worktrees as a set of tools that can be invoked by MCP-compatible clients (Claude Code, Claude Desktop, etc.).
-
-The server is shipped as a separate binary `sync-worktrees-mcp` and provides tools for initializing repositories, listing/creating/removing/updating worktrees, running syncs, loading configuration files, detecting repository context, and inspecting worktree status.

--- a/.changeset/mcp-server-implementation.md
+++ b/.changeset/mcp-server-implementation.md
@@ -1,0 +1,7 @@
+---
+"sync-worktrees": major
+---
+
+Add MCP (Model Context Protocol) server implementation, exposing sync-worktrees as a set of tools that can be invoked by MCP-compatible clients (Claude Code, Claude Desktop, etc.).
+
+The server is shipped as a separate binary `sync-worktrees-mcp` and provides tools for initializing repositories, listing/creating/removing/updating worktrees, running syncs, loading configuration files, detecting repository context, and inspecting worktree status.

--- a/.changeset/pr-55-refactor-mcp-handlers.md
+++ b/.changeset/pr-55-refactor-mcp-handlers.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Refactor MCP handlers and sync flow internals to improve interactive UI behavior and worktree sync handling.

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -133,8 +133,8 @@ describe("handleListWorktrees", () => {
     const { ctx, git } = makeCtx({
       git: {
         getWorktrees: vi.fn<any>().mockResolvedValue([
-          { path: "/repo/main", branch: "main" },
-          { path: "/repo/worktrees/feature", branch: "feature" },
+          { path: "/repo/main", branch: "main", isCurrent: true },
+          { path: "/repo/worktrees/feature", branch: "feature", isCurrent: false },
         ]),
         getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
           isClean: true,
@@ -260,7 +260,7 @@ describe("handleRemoveWorktree", () => {
 
   it("rejects path not belonging to the repository", async () => {
     const { ctx, git } = makeCtx({
-      git: { getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main" }]) },
+      git: { getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main", isCurrent: true }]) },
     });
     const result = await invoke(handleRemoveWorktree, ctx, { path: "/unrelated", force: true });
     const body = parseResponse(result);
@@ -409,7 +409,7 @@ describe("list_worktrees lastSyncAt", () => {
     const iso = "2026-04-19T10:00:00.000Z";
     const { ctx } = makeCtx({
       git: {
-        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main" }]),
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main", isCurrent: true }]),
         getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
           isClean: true,
           hasUnpushedCommits: false,
@@ -432,7 +432,7 @@ describe("list_worktrees lastSyncAt", () => {
   it("returns null lastSyncAt when metadata missing", async () => {
     const { ctx } = makeCtx({
       git: {
-        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main" }]),
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main", isCurrent: true }]),
         getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
           isClean: true,
           hasUnpushedCommits: false,
@@ -452,15 +452,14 @@ describe("list_worktrees lastSyncAt", () => {
   });
 });
 
-
 describe("handleListWorktrees fallbacks", () => {
   it("falls back to discovered worktrees when git.getWorktrees fails", async () => {
     const { ctx, git } = makeCtx({
       discovered: makeDiscovered({
         currentWorktreePath: "/repo/main",
         allWorktrees: [
-          { path: "/repo/main", branch: "main" },
-          { path: "/repo/worktrees/feature", branch: "feature" },
+          { path: "/repo/main", branch: "main", isCurrent: true },
+          { path: "/repo/worktrees/feature", branch: "feature", isCurrent: false },
         ],
       }),
       git: {

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handleCreateWorktree,
   handleGetWorktreeStatus,
+  handleInitialize,
   handleListWorktrees,
   handleLoadConfig,
   handleRemoveWorktree,
@@ -290,6 +291,18 @@ describe("handleSync", () => {
     expect(typeof body.duration).toBe("number");
     expect(service.sync).toHaveBeenCalled();
   });
+
+  it("initializes service before syncing when needed", async () => {
+    const { ctx, service } = makeCtx({});
+    service.isInitialized.mockReturnValue(false);
+
+    const result = await invoke(handleSync, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.success).toBe(true);
+    expect(service.initialize).toHaveBeenCalled();
+    expect(service.sync).toHaveBeenCalled();
+  });
 });
 
 describe("handleUpdateWorktree", () => {
@@ -375,6 +388,22 @@ describe("handleSetCurrentRepository", () => {
   });
 });
 
+describe("handleInitialize", () => {
+  it("initializes service and returns repo defaults", async () => {
+    const { ctx, service, git } = makeCtx({});
+    service.config.worktreeDir = "/repo/worktrees";
+    git.getDefaultBranch.mockReturnValue("main");
+
+    const result = await invoke(handleInitialize, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.success).toBe(true);
+    expect(body.defaultBranch).toBe("main");
+    expect(body.worktreeDir).toBe("/repo/worktrees");
+    expect(service.initialize).toHaveBeenCalled();
+  });
+});
+
 describe("list_worktrees lastSyncAt", () => {
   it("surfaces lastSyncDate from metadata as lastSyncAt", async () => {
     const iso = "2026-04-19T10:00:00.000Z";
@@ -420,5 +449,72 @@ describe("list_worktrees lastSyncAt", () => {
     const result = await invoke(handleListWorktrees, ctx, {});
     const body = parseResponse(result);
     expect(body.worktrees[0].lastSyncAt).toBeNull();
+  });
+});
+
+
+describe("handleListWorktrees fallbacks", () => {
+  it("falls back to discovered worktrees when git.getWorktrees fails", async () => {
+    const { ctx, git } = makeCtx({
+      discovered: makeDiscovered({
+        currentWorktreePath: "/repo/main",
+        allWorktrees: [
+          { path: "/repo/main", branch: "main" },
+          { path: "/repo/worktrees/feature", branch: "feature" },
+        ],
+      }),
+      git: {
+        getWorktrees: vi.fn<any>().mockRejectedValue(new Error("git unavailable")),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
+          isClean: true,
+          hasUnpushedCommits: false,
+          hasStashedChanges: false,
+          hasOperationInProgress: false,
+          hasModifiedSubmodules: false,
+          upstreamGone: false,
+          canRemove: true,
+          reasons: [],
+        }),
+      },
+    });
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.worktrees).toHaveLength(2);
+    expect(body.worktrees[0].isCurrent).toBe(true);
+    expect(body.worktrees[1].branch).toBe("feature");
+    expect(git.getFullWorktreeStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an empty list when service lookup succeeds but no worktrees are available", async () => {
+    const { ctx } = makeCtx({
+      discovered: null,
+      git: {
+        getWorktrees: vi.fn<any>().mockRejectedValue(new Error("git unavailable")),
+      },
+    });
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.worktrees).toEqual([]);
+  });
+});
+
+describe("handleCreateWorktree collisions", () => {
+  it("errors when sanitized worktree path collides with another branch", async () => {
+    const { ctx } = makeCtx({
+      git: {
+        branchExists: vi.fn<any>().mockResolvedValue({ local: true, remote: true }),
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/worktrees/feature-x", branch: "feature-x-old" }]),
+      },
+    });
+
+    const result = await invoke(handleCreateWorktree, ctx, { branchName: "feature/x" });
+    const body = parseResponse(result);
+
+    expect(body.error).toBe(true);
+    expect(body.message).toContain("collides with existing branch");
   });
 });

--- a/src/mcp/__tests__/utils.test.ts
+++ b/src/mcp/__tests__/utils.test.ts
@@ -56,3 +56,27 @@ describe("SyncInProgressError", () => {
     expect(err.message).toContain("my-repo");
   });
 });
+
+
+describe("wrapHandler", () => {
+  it("returns handler result on success", async () => {
+    const { wrapHandler } = await import("../utils");
+    const expected = { content: [{ type: "text", text: '{"ok":true}' }] };
+    const wrapped = wrapHandler(async () => expected as any);
+
+    await expect(wrapped({} as never, {} as never)).resolves.toEqual(expected);
+  });
+
+  it("formats thrown errors", async () => {
+    const { wrapHandler } = await import("../utils");
+    const wrapped = wrapHandler(async () => {
+      throw new Error("kapow");
+    });
+
+    const result = await wrapped({} as never, {} as never);
+    const body = JSON.parse((result.content[0] as { text: string }).text);
+    expect(result.isError).toBe(true);
+    expect(body.code).toBe("INTERNAL_ERROR");
+    expect(body.message).toBe("kapow");
+  });
+});

--- a/src/mcp/__tests__/utils.test.ts
+++ b/src/mcp/__tests__/utils.test.ts
@@ -57,7 +57,6 @@ describe("SyncInProgressError", () => {
   });
 });
 
-
 describe("wrapHandler", () => {
   it("returns handler result on success", async () => {
     const { wrapHandler } = await import("../utils");

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -50,7 +50,16 @@ interface RepoEntry {
   discovered?: DiscoveredRepoContext;
 }
 
+interface CachedDiscovery {
+  result: DiscoveredRepoContext;
+  cachedAt: number;
+  worktreeAdminDir: string | null;
+  worktreeHeadMtimeMs: number | null;
+  worktreesDirMtimeMs: number | null;
+}
+
 const AUTO_DETECT_PREFIX = "__auto_detected__:";
+const DISCOVERY_CACHE_TTL_MS = 5000;
 
 const EMPTY_CAPABILITIES: Capabilities = {
   canListWorktrees: false,
@@ -76,6 +85,7 @@ export class RepositoryContext {
   private currentRepo: string | null = null;
   private configPath: string | null = null;
   private configLoader = new ConfigLoaderService();
+  private discoveryCache = new Map<string, CachedDiscovery>();
 
   async loadConfig(configPath: string): Promise<RepositoryConfig[]> {
     const absolutePath = path.resolve(configPath);
@@ -112,27 +122,77 @@ export class RepositoryContext {
   }
 
   async detectFromPath(dirPath: string): Promise<DiscoveredRepoContext> {
-    const reasons: string[] = [];
     const absolutePath = path.resolve(dirPath);
+
+    const cached = this.discoveryCache.get(absolutePath);
+    if (cached && (await this.isCacheFresh(cached))) {
+      return cached.result;
+    }
+
+    const { result, adminDir } = await this.detectFromPathUncached(absolutePath);
+
+    if (result.isWorktree && result.bareRepoPath && adminDir) {
+      const [worktreeHeadMtimeMs, worktreesDirMtimeMs] = await Promise.all([
+        safeMtimeMs(path.join(adminDir, "HEAD")),
+        safeMtimeMs(path.join(result.bareRepoPath, "worktrees")),
+      ]);
+      this.discoveryCache.set(absolutePath, {
+        result,
+        cachedAt: Date.now(),
+        worktreeAdminDir: adminDir,
+        worktreeHeadMtimeMs,
+        worktreesDirMtimeMs,
+      });
+    }
+
+    return result;
+  }
+
+  invalidateDiscovered(): void {
+    this.discoveryCache.clear();
+  }
+
+  private async isCacheFresh(cached: CachedDiscovery): Promise<boolean> {
+    if (Date.now() - cached.cachedAt >= DISCOVERY_CACHE_TTL_MS) return false;
+    if (!cached.worktreeAdminDir || !cached.result.bareRepoPath) return true;
+
+    const [currentHeadMtime, currentWorktreesDirMtime] = await Promise.all([
+      safeMtimeMs(path.join(cached.worktreeAdminDir, "HEAD")),
+      safeMtimeMs(path.join(cached.result.bareRepoPath, "worktrees")),
+    ]);
+
+    return currentHeadMtime === cached.worktreeHeadMtimeMs && currentWorktreesDirMtime === cached.worktreesDirMtimeMs;
+  }
+
+  private async detectFromPathUncached(
+    absolutePath: string,
+  ): Promise<{ result: DiscoveredRepoContext; adminDir: string | null }> {
+    const reasons: string[] = [];
 
     const located = await findWorktreeRoot(absolutePath);
     const worktreeRoot = located?.worktreeRoot ?? absolutePath;
 
-    const unsupported = (reason: string, isWorktree = false): DiscoveredRepoContext => {
+    const unsupported = (
+      reason: string,
+      isWorktree = false,
+    ): { result: DiscoveredRepoContext; adminDir: string | null } => {
       reasons.push(reason);
       return {
-        isWorktree,
-        kind: "unsupported",
-        currentBranch: null,
-        currentWorktreePath: worktreeRoot,
-        bareRepoPath: null,
-        repoUrl: null,
-        worktreeDir: null,
-        allWorktrees: [],
-        configLoaded: this.configPath !== null,
-        repoName: null,
-        capabilities: EMPTY_CAPABILITIES,
-        reasons,
+        result: {
+          isWorktree,
+          kind: "unsupported",
+          currentBranch: null,
+          currentWorktreePath: worktreeRoot,
+          bareRepoPath: null,
+          repoUrl: null,
+          worktreeDir: null,
+          allWorktrees: [],
+          configLoaded: this.configPath !== null,
+          repoName: null,
+          capabilities: EMPTY_CAPABILITIES,
+          reasons,
+        },
+        adminDir: null,
       };
     };
 
@@ -157,6 +217,7 @@ export class RepositoryContext {
     }
 
     const bareRepoPath = path.resolve(worktreesMatch[1]);
+    const adminDir = path.resolve(gitdir);
 
     let repoUrl: string | null = null;
     let worktrees: DiscoveredWorktree[] = [];
@@ -182,18 +243,21 @@ export class RepositoryContext {
     } catch (err) {
       reasons.push(`Failed to read bare repo at ${bareRepoPath}: ${(err as Error).message}`);
       return {
-        isWorktree: true,
-        kind: "unsupported",
-        currentBranch: null,
-        currentWorktreePath: worktreeRoot,
-        bareRepoPath,
-        repoUrl: null,
-        worktreeDir: null,
-        allWorktrees: [],
-        configLoaded: this.configPath !== null,
-        repoName: null,
-        capabilities: EMPTY_CAPABILITIES,
-        reasons,
+        result: {
+          isWorktree: true,
+          kind: "unsupported",
+          currentBranch: null,
+          currentWorktreePath: worktreeRoot,
+          bareRepoPath,
+          repoUrl: null,
+          worktreeDir: null,
+          allWorktrees: [],
+          configLoaded: this.configPath !== null,
+          repoName: null,
+          capabilities: EMPTY_CAPABILITIES,
+          reasons,
+        },
+        adminDir,
       };
     }
 
@@ -276,7 +340,7 @@ export class RepositoryContext {
       }
     }
 
-    return discovered;
+    return { result: discovered, adminDir };
   }
 
   async getService(repoName?: string): Promise<WorktreeSyncService> {
@@ -353,6 +417,15 @@ function parseWorktreeList(output: string, currentPath: string): DiscoveredWorkt
 type FindResult =
   | { kind: "worktree-file"; worktreeRoot: string; gitFileContent: string }
   | { kind: "regular-git-dir"; worktreeRoot: string };
+
+async function safeMtimeMs(filePath: string): Promise<number | null> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.mtimeMs;
+  } catch {
+    return null;
+  }
+}
 
 async function findWorktreeRoot(startPath: string): Promise<FindResult | null> {
   let current = path.resolve(startPath);

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -15,6 +15,10 @@ import type { WorktreeStatusResult } from "../services/worktree-status.service";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 type CapabilityKey = keyof Capabilities;
+type RepoScopedParams = { repoName?: string };
+type WorktreePathParams = RepoScopedParams & { path: string };
+type RepoService = Awaited<ReturnType<RepositoryContext["getService"]>>;
+type RepoGitService = ReturnType<RepoService["getGitService"]>;
 
 function ensureCapability(discovered: DiscoveredRepoContext | null, key: CapabilityKey, toolName: string): void {
   if (!discovered) return;
@@ -29,6 +33,45 @@ async function ensureNotSyncing(ctx: RepositoryContext, repoName?: string): Prom
   if (entry.service.isSyncInProgress()) {
     throw new SyncInProgressError(entry.name);
   }
+}
+
+async function getReadyService(
+  ctx: RepositoryContext,
+  repoName: string | undefined,
+  options: {
+    capability?: CapabilityKey;
+    toolName?: string;
+    ensureInitialized?: boolean;
+    ensureNotSyncing?: boolean;
+  } = {},
+): Promise<{ discovered: DiscoveredRepoContext | null; service: RepoService; git: RepoGitService }> {
+  const discovered = ctx.getDiscoveredContext(repoName);
+  if (options.capability && options.toolName) {
+    ensureCapability(discovered, options.capability, options.toolName);
+  }
+  if (options.ensureNotSyncing) {
+    await ensureNotSyncing(ctx, repoName);
+  }
+
+  const service = await ctx.getService(repoName);
+  if (options.ensureInitialized && !service.isInitialized()) {
+    await service.initialize();
+  }
+
+  return {
+    discovered,
+    service,
+    git: service.getGitService(),
+  };
+}
+
+async function ensureRepoWorktreePath(
+  ctx: RepositoryContext,
+  params: WorktreePathParams,
+  git: RepoGitService,
+): Promise<string> {
+  await ensurePathBelongsToRepo(ctx, params.path, params.repoName, git);
+  return path.resolve(params.path);
 }
 
 async function ensurePathBelongsToRepo(
@@ -88,11 +131,10 @@ export async function handleListWorktrees(
   params: { repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canListWorktrees", "list_worktrees");
-
-  const service = await ctx.getService(params.repoName);
-  const git = service.getGitService();
+  const { discovered, git } = await getReadyService(ctx, params.repoName, {
+    capability: "canListWorktrees",
+    toolName: "list_worktrees",
+  });
 
   let worktrees: Array<{ path: string; branch: string }>;
   try {
@@ -142,19 +184,18 @@ export async function handleGetWorktreeStatus(
   params: { path: string; repoName?: string; includeDetails?: boolean },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canGetStatus", "get_worktree_status");
-
-  const service = await ctx.getService(params.repoName);
-  const git = service.getGitService();
-  await ensurePathBelongsToRepo(ctx, params.path, params.repoName, git);
+  const { git } = await getReadyService(ctx, params.repoName, {
+    capability: "canGetStatus",
+    toolName: "get_worktree_status",
+  });
+  const resolvedPath = await ensureRepoWorktreePath(ctx, params, git);
   const [status, divergence] = await Promise.all([
     git.getFullWorktreeStatus(params.path, params.includeDetails ?? false),
     getDivergence(params.path),
   ]);
 
   return formatToolResponse({
-    path: path.resolve(params.path),
+    path: resolvedPath,
     ...status,
     divergence,
   });
@@ -165,15 +206,12 @@ export async function handleCreateWorktree(
   params: { branchName: string; baseBranch?: string; push?: boolean; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canCreateWorktree", "create_worktree");
-  await ensureNotSyncing(ctx, params.repoName);
-
-  const service = await ctx.getService(params.repoName);
-  if (!service.isInitialized()) {
-    await service.initialize();
-  }
-  const git = service.getGitService();
+  const { service, git } = await getReadyService(ctx, params.repoName, {
+    capability: "canCreateWorktree",
+    toolName: "create_worktree",
+    ensureInitialized: true,
+    ensureNotSyncing: true,
+  });
 
   const { branchName, baseBranch, push } = params;
   const existence = await git.branchExists(branchName);
@@ -219,16 +257,13 @@ export async function handleRemoveWorktree(
   params: { path: string; force?: boolean; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canRemoveWorktree", "remove_worktree");
-  await ensureNotSyncing(ctx, params.repoName);
-
-  const service = await ctx.getService(params.repoName);
-  if (!service.isInitialized()) {
-    await service.initialize();
-  }
-  const git = service.getGitService();
-  await ensurePathBelongsToRepo(ctx, params.path, params.repoName, git);
+  const { git } = await getReadyService(ctx, params.repoName, {
+    capability: "canRemoveWorktree",
+    toolName: "remove_worktree",
+    ensureInitialized: true,
+    ensureNotSyncing: true,
+  });
+  const removedPath = await ensureRepoWorktreePath(ctx, params, git);
 
   if (!params.force) {
     const status = await git.getFullWorktreeStatus(params.path, false);
@@ -241,7 +276,7 @@ export async function handleRemoveWorktree(
 
   return formatToolResponse({
     success: true,
-    removedPath: path.resolve(params.path),
+    removedPath,
   });
 }
 
@@ -250,14 +285,12 @@ export async function handleSync(
   params: { repoName?: string },
   extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canSync", "sync");
-  await ensureNotSyncing(ctx, params.repoName);
-
-  const service = await ctx.getService(params.repoName);
-  if (!service.isInitialized()) {
-    await service.initialize();
-  }
+  const { service } = await getReadyService(ctx, params.repoName, {
+    capability: "canSync",
+    toolName: "sync",
+    ensureInitialized: true,
+    ensureNotSyncing: true,
+  });
 
   const dispose = attachProgressReporter(service, extra);
   try {
@@ -275,22 +308,19 @@ export async function handleUpdateWorktree(
   params: { path: string; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canUpdateWorktree", "update_worktree");
-  await ensureNotSyncing(ctx, params.repoName);
-
-  const service = await ctx.getService(params.repoName);
-  if (!service.isInitialized()) {
-    await service.initialize();
-  }
-  const git = service.getGitService();
-  await ensurePathBelongsToRepo(ctx, params.path, params.repoName, git);
+  const { git } = await getReadyService(ctx, params.repoName, {
+    capability: "canUpdateWorktree",
+    toolName: "update_worktree",
+    ensureInitialized: true,
+    ensureNotSyncing: true,
+  });
+  const worktreePath = await ensureRepoWorktreePath(ctx, params, git);
 
   await git.updateWorktree(params.path);
 
   return formatToolResponse({
     success: true,
-    worktreePath: path.resolve(params.path),
+    worktreePath,
   });
 }
 
@@ -299,11 +329,11 @@ export async function handleInitialize(
   params: { repoName?: string },
   extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const discovered = ctx.getDiscoveredContext(params.repoName);
-  ensureCapability(discovered, "canInitialize", "initialize");
-  await ensureNotSyncing(ctx, params.repoName);
-
-  const service = await ctx.getService(params.repoName);
+  const { service } = await getReadyService(ctx, params.repoName, {
+    capability: "canInitialize",
+    toolName: "initialize",
+    ensureNotSyncing: true,
+  });
   const dispose = attachProgressReporter(service, extra);
   try {
     await service.initialize();

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -140,25 +140,7 @@ export class InteractiveUIService {
 
     for (const [schedule, services] of scheduleGroups) {
       const task = cron.schedule(schedule, async () => {
-        this.setStatus("syncing");
-        try {
-          await Promise.allSettled(
-            services.map((service) =>
-              this.limit(async () => {
-                if (!service.isInitialized()) {
-                  await service.initialize();
-                }
-                await service.sync();
-              }),
-            ),
-          );
-        } finally {
-          this.setStatus("idle");
-          this.updateLastSyncTime();
-          this.calculateAndUpdateDiskSpace().catch((err) => {
-            this.addLog(`Failed to calculate disk space: ${err instanceof Error ? err.message : String(err)}`, "error");
-          });
-        }
+        await this.runSyncCycle(services, { logErrors: false });
       });
       this.cronJobs.push(task);
     }
@@ -219,27 +201,7 @@ export class InteractiveUIService {
   }
 
   public async triggerInitialSync(): Promise<void> {
-    this.setStatus("syncing");
-
-    try {
-      await Promise.allSettled(
-        this.syncServices.map((service) =>
-          this.limit(async () => {
-            if (!service.isInitialized()) {
-              await service.initialize();
-            }
-            await service.sync();
-          }),
-        ),
-      );
-
-      this.updateLastSyncTime();
-      await this.calculateAndUpdateDiskSpace();
-    } catch (error) {
-      this.addLog(`Sync failed: ${error instanceof Error ? error.message : String(error)}`, "error");
-    } finally {
-      this.setStatus("idle");
-    }
+    await this.runSyncCycle(this.syncServices, { logErrors: true });
   }
 
   private async handleReload(): Promise<void> {
@@ -305,34 +267,15 @@ export class InteractiveUIService {
       this.events.emit("updateRepositoryCount", this.repositoryCount);
       this.events.emit("updateCronSchedule", this.cronSchedule);
 
-      const failures: Array<{ repo: string; error: string }> = [];
-
-      const syncResults = await Promise.allSettled(
-        this.syncServices.map((service) =>
-          this.limit(async () => {
-            await service.sync();
-            return service;
-          }).catch((error) => {
-            const repoName = (service.config as RepositoryConfig).name || service.config.repoUrl;
-            throw Object.assign(error instanceof Error ? error : new Error(String(error)), { repoName });
-          }),
-        ),
-      );
-
-      for (const result of syncResults) {
-        if (result.status === "rejected") {
-          const repoName = (result.reason as any)?.repoName ?? "unknown";
-          const errorMessage = result.reason instanceof Error ? result.reason.message : String(result.reason);
-          this.addLog(`Failed to sync repository '${repoName}': ${errorMessage}`, "error");
-          failures.push({ repo: repoName, error: errorMessage });
-        }
-      }
-
+      const failures = await this.runSyncServices(this.syncServices);
       this.updateLastSyncTime();
       await this.calculateAndUpdateDiskSpace();
       this.setStatus("idle");
 
       if (failures.length > 0) {
+        for (const failure of failures) {
+          this.addLog(`Failed to sync repository '${failure.repo}': ${failure.error}`, "error");
+        }
         this.addLog(`Reload completed with ${failures.length} repository failure(s)`, "warn");
       }
     } catch (error) {
@@ -762,6 +705,61 @@ export class InteractiveUIService {
     } catch {
       return false;
     }
+  }
+
+  private async runSyncCycle(
+    services: WorktreeSyncService[],
+    options: { logErrors: boolean },
+  ): Promise<Array<{ repo: string; error: string }>> {
+    this.setStatus("syncing");
+
+    try {
+      const failures = await this.runSyncServices(services);
+
+      if (options.logErrors) {
+        if (failures.length > 0) {
+          for (const failure of failures) {
+            this.addLog(`Failed to sync repository '${failure.repo}': ${failure.error}`, "error");
+          }
+        }
+      }
+
+      this.updateLastSyncTime();
+      await this.calculateAndUpdateDiskSpace();
+      return failures;
+    } finally {
+      this.setStatus("idle");
+    }
+  }
+
+  private async runSyncServices(
+    services: WorktreeSyncService[],
+  ): Promise<Array<{ repo: string; error: string }>> {
+    const syncResults = await Promise.allSettled(
+      services.map((service) =>
+        this.limit(async () => {
+          if (!service.isInitialized()) {
+            await service.initialize();
+          }
+          await service.sync();
+          return service;
+        }).catch((error) => {
+          const repoName = (service.config as RepositoryConfig).name || service.config.repoUrl;
+          throw Object.assign(error instanceof Error ? error : new Error(String(error)), { repoName });
+        }),
+      ),
+    );
+
+    const failures: Array<{ repo: string; error: string }> = [];
+    for (const result of syncResults) {
+      if (result.status === "rejected") {
+        const repoName = (result.reason as { repoName?: string })?.repoName ?? "unknown";
+        const errorMessage = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        failures.push({ repo: repoName, error: errorMessage });
+      }
+    }
+
+    return failures;
   }
 
   public executeOnBranchCreatedHooks(repoIndex: number, context: HookContext): void {

--- a/src/services/__tests__/interactive-ui.service.test.ts
+++ b/src/services/__tests__/interactive-ui.service.test.ts
@@ -492,6 +492,28 @@ describe("InteractiveUIService", () => {
 
       service.destroy();
     });
+
+    it("should log per-repository sync failures", async () => {
+      const service = new InteractiveUIService([mockSyncService]);
+      const logs: Array<{ message: string; level: string }> = [];
+      service.getEvents().on("addLog", (entry: { message: string; level: string }) => logs.push(entry));
+
+      service.getEvents().emit("uiReady");
+      mockSyncService.sync.mockRejectedValue(new Error("Sync failed"));
+      vi.spyOn(mockSyncService, "config", "get").mockReturnValue({
+        ...(mockSyncService.config as object),
+        name: "failing-repo",
+      } as typeof mockSyncService.config & { name: string });
+
+      await service.triggerInitialSync();
+
+      expect(logs).toContainEqual({
+        message: "Failed to sync repository 'failing-repo': Sync failed",
+        level: "error",
+      });
+
+      service.destroy();
+    });
   });
 
   describe("handleReload", () => {
@@ -963,7 +985,7 @@ describe("InteractiveUIService", () => {
         const onReload = (mockRender.mock.calls[0][0].props as any).onReload;
         await onReload();
 
-        expect(mockWorktreeSyncServiceInstance.initialize).toHaveBeenCalledTimes(2);
+        expect(mockWorktreeSyncServiceInstance.initialize).toHaveBeenCalledTimes(4);
         expect(mockWorktreeSyncServiceInstance.sync).toHaveBeenCalledTimes(2);
 
         service.destroy();

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -60,138 +60,16 @@ export class WorktreeSyncService {
 
     const totalTimer = new Timer();
     const phaseTimer = new PhaseTimer();
-
-    let lfsSkipEnabled = false;
-
-    const retryOptions: RetryOptions = {
-      maxAttempts: this.config.retry?.maxAttempts ?? 3,
-      maxLfsRetries: this.config.retry?.maxLfsRetries ?? 2,
-      initialDelayMs: this.config.retry?.initialDelayMs ?? 1000,
-      maxDelayMs: this.config.retry?.maxDelayMs ?? 30000,
-      backoffMultiplier: this.config.retry?.backoffMultiplier ?? 2,
-      onRetry: (error, attempt, context) => {
-        const errorMessage = getErrorMessage(error);
-        this.logger.info(`\n⚠️  Sync attempt ${attempt} failed: ${errorMessage}`);
-
-        if (context?.isLfsError && !this.config.skipLfs) {
-          this.logger.info(`🔄 LFS error detected. Will retry with LFS skipped...`);
-        } else {
-          this.logger.info(`🔄 Retrying synchronization...\n`);
-        }
-      },
-      lfsRetryHandler: () => {
-        if (!this.config.skipLfs && !lfsSkipEnabled) {
-          this.logger.info("⚠️  Temporarily disabling LFS downloads for this sync...");
-          this.gitService.setLfsSkipEnabled(true);
-          lfsSkipEnabled = true;
-        }
-      },
-    };
+    const syncContext = { lfsSkipEnabled: false };
+    const retryOptions = this.createRetryOptions(syncContext);
 
     try {
-      await retry(async () => {
-        await this.gitService.pruneWorktrees();
-
-        this.logger.info("Step 1: Fetching latest data from remote...");
-        phaseTimer.startPhase("Phase 1: Fetch");
-
-        try {
-          await this.gitService.fetchAll();
-        } catch (fetchError) {
-          const errorMessage = getErrorMessage(fetchError);
-
-          if (isLfsError(errorMessage) && !lfsSkipEnabled && !this.config.skipLfs) {
-            this.logger.info("⚠️  Fetch all failed due to LFS error. Attempting branch-by-branch fetch...");
-            this.logger.info("⚠️  Temporarily disabling LFS downloads for branch-by-branch fetch...");
-            this.gitService.setLfsSkipEnabled(true);
-            lfsSkipEnabled = true;
-            await this.fetchBranchByBranch();
-          } else {
-            throw fetchError;
-          }
-        }
-
-        phaseTimer.endPhase();
-
-        let remoteBranches: string[];
-
-        if (this.config.branchMaxAge) {
-          const branchesWithActivity = await this.gitService.getRemoteBranchesWithActivity();
-          this.logger.info(`Found ${branchesWithActivity.length} remote branches.`);
-
-          const branchNames = filterBranchesByName(
-            branchesWithActivity.map((b) => b.branch),
-            this.config.branchInclude,
-            this.config.branchExclude,
-          );
-
-          if (branchNames.length < branchesWithActivity.length) {
-            this.logger.info(
-              `After branch name filtering: ${branchNames.length} of ${branchesWithActivity.length} branches.`,
-            );
-          }
-
-          const branchNameSet = new Set(branchNames);
-          const filteredByName = branchesWithActivity.filter((b) => branchNameSet.has(b.branch));
-          const filteredBranches = filterBranchesByAge(filteredByName, this.config.branchMaxAge);
-          remoteBranches = filteredBranches.map((b) => b.branch);
-
-          this.logger.info(
-            `After filtering by age (${formatDuration(this.config.branchMaxAge)}): ${remoteBranches.length} branches.`,
-          );
-
-          if (filteredByName.length > remoteBranches.length) {
-            const excludedCount = filteredByName.length - remoteBranches.length;
-            this.logger.info(`  - Excluded ${excludedCount} stale branches.`);
-          }
-        } else {
-          const allBranches = await this.gitService.getRemoteBranches();
-          this.logger.info(`Found ${allBranches.length} remote branches.`);
-
-          remoteBranches = filterBranchesByName(allBranches, this.config.branchInclude, this.config.branchExclude);
-
-          if (remoteBranches.length < allBranches.length) {
-            this.logger.info(
-              `After branch name filtering: ${remoteBranches.length} of ${allBranches.length} branches.`,
-            );
-          }
-        }
-
-        // Always retain the default branch, even if excluded by age filters
-        const defaultBranch = this.gitService.getDefaultBranch();
-        if (!remoteBranches.includes(defaultBranch)) {
-          remoteBranches.push(defaultBranch);
-          this.logger.info(`Ensuring default branch '${defaultBranch}' is retained.`);
-        }
-
-        await fs.mkdir(this.config.worktreeDir, { recursive: true });
-
-        // Get actual Git worktrees instead of just directories
-        const worktrees = await this.gitService.getWorktrees();
-        this.logger.info(`Found ${worktrees.length} existing Git worktrees.`);
-
-        // Clean up orphaned directories
-        await this.cleanupOrphanedDirectories(worktrees);
-
-        await this.createNewWorktreesWithTiming(remoteBranches, worktrees, defaultBranch, phaseTimer);
-
-        await this.pruneOldWorktreesWithTiming(remoteBranches, worktrees, phaseTimer);
-
-        // Update existing worktrees if enabled
-        if (this.config.updateExistingWorktrees !== false) {
-          await this.updateExistingWorktreesWithTiming(worktrees, remoteBranches, phaseTimer);
-        }
-
-        phaseTimer.startPhase("Phase 5: Cleanup");
-        await this.gitService.pruneWorktrees();
-        this.logger.info("Step 5: Pruned worktree metadata.");
-        phaseTimer.endPhase();
-      }, retryOptions);
+      await retry(() => this.runSyncAttempt(phaseTimer, syncContext), retryOptions);
     } catch (error) {
       this.logger.error("\n❌ Error during worktree synchronization after all retry attempts:", error);
       throw error;
     } finally {
-      if (lfsSkipEnabled && !this.config.skipLfs) {
+      if (syncContext.lfsSkipEnabled && !this.config.skipLfs) {
         this.gitService.setLfsSkipEnabled(false);
       }
       this.syncInProgress = false;
@@ -204,6 +82,145 @@ export class WorktreeSyncService {
         this.logger.table(formatTimingTable(totalDuration, phaseResults, repoName));
       }
     }
+  }
+
+  private createRetryOptions(syncContext: { lfsSkipEnabled: boolean }): RetryOptions {
+    return {
+      maxAttempts: this.config.retry?.maxAttempts ?? 3,
+      maxLfsRetries: this.config.retry?.maxLfsRetries ?? 2,
+      initialDelayMs: this.config.retry?.initialDelayMs ?? 1000,
+      maxDelayMs: this.config.retry?.maxDelayMs ?? 30000,
+      backoffMultiplier: this.config.retry?.backoffMultiplier ?? 2,
+      onRetry: (error, attempt, context): void => {
+        const errorMessage = getErrorMessage(error);
+        this.logger.info(`\n⚠️  Sync attempt ${attempt} failed: ${errorMessage}`);
+
+        if (context?.isLfsError && !this.config.skipLfs) {
+          this.logger.info(`🔄 LFS error detected. Will retry with LFS skipped...`);
+        } else {
+          this.logger.info(`🔄 Retrying synchronization...\n`);
+        }
+      },
+      lfsRetryHandler: (): void => {
+        if (!this.config.skipLfs && !syncContext.lfsSkipEnabled) {
+          this.logger.info("⚠️  Temporarily disabling LFS downloads for this sync...");
+          this.gitService.setLfsSkipEnabled(true);
+          syncContext.lfsSkipEnabled = true;
+        }
+      },
+    };
+  }
+
+  private async runSyncAttempt(phaseTimer: PhaseTimer, syncContext: { lfsSkipEnabled: boolean }): Promise<void> {
+    await this.gitService.pruneWorktrees();
+    await this.fetchLatestRemoteData(phaseTimer, syncContext);
+
+    const { remoteBranches, defaultBranch } = await this.resolveSyncBranches();
+
+    await fs.mkdir(this.config.worktreeDir, { recursive: true });
+
+    const worktrees = await this.gitService.getWorktrees();
+    this.logger.info(`Found ${worktrees.length} existing Git worktrees.`);
+
+    await this.cleanupOrphanedDirectories(worktrees);
+    await this.createNewWorktreesWithTiming(remoteBranches, worktrees, defaultBranch, phaseTimer);
+    await this.pruneOldWorktreesWithTiming(remoteBranches, worktrees, phaseTimer);
+
+    if (this.config.updateExistingWorktrees !== false) {
+      await this.updateExistingWorktreesWithTiming(worktrees, remoteBranches, phaseTimer);
+    }
+
+    await this.finalizeSyncAttempt(phaseTimer);
+  }
+
+  private async fetchLatestRemoteData(phaseTimer: PhaseTimer, syncContext: { lfsSkipEnabled: boolean }): Promise<void> {
+    this.logger.info("Step 1: Fetching latest data from remote...");
+    phaseTimer.startPhase("Phase 1: Fetch");
+
+    try {
+      await this.gitService.fetchAll();
+    } catch (fetchError) {
+      const errorMessage = getErrorMessage(fetchError);
+
+      if (isLfsError(errorMessage) && !syncContext.lfsSkipEnabled && !this.config.skipLfs) {
+        this.logger.info("⚠️  Fetch all failed due to LFS error. Attempting branch-by-branch fetch...");
+        this.logger.info("⚠️  Temporarily disabling LFS downloads for branch-by-branch fetch...");
+        this.gitService.setLfsSkipEnabled(true);
+        syncContext.lfsSkipEnabled = true;
+        await this.fetchBranchByBranch();
+      } else {
+        throw fetchError;
+      }
+    } finally {
+      phaseTimer.endPhase();
+    }
+  }
+
+  private async resolveSyncBranches(): Promise<{ remoteBranches: string[]; defaultBranch: string }> {
+    const remoteBranches = this.config.branchMaxAge
+      ? await this.getRemoteBranchesFilteredByActivity()
+      : await this.getRemoteBranchesFilteredByName();
+    const defaultBranch = this.gitService.getDefaultBranch();
+
+    if (!remoteBranches.includes(defaultBranch)) {
+      remoteBranches.push(defaultBranch);
+      this.logger.info(`Ensuring default branch '${defaultBranch}' is retained.`);
+    }
+
+    return { remoteBranches, defaultBranch };
+  }
+
+  private async getRemoteBranchesFilteredByActivity(): Promise<string[]> {
+    const branchesWithActivity = await this.gitService.getRemoteBranchesWithActivity();
+    this.logger.info(`Found ${branchesWithActivity.length} remote branches.`);
+
+    const branchNames = filterBranchesByName(
+      branchesWithActivity.map((b) => b.branch),
+      this.config.branchInclude,
+      this.config.branchExclude,
+    );
+
+    if (branchNames.length < branchesWithActivity.length) {
+      this.logger.info(
+        `After branch name filtering: ${branchNames.length} of ${branchesWithActivity.length} branches.`,
+      );
+    }
+
+    const branchNameSet = new Set(branchNames);
+    const filteredByName = branchesWithActivity.filter((b) => branchNameSet.has(b.branch));
+    const filteredBranches = filterBranchesByAge(filteredByName, this.config.branchMaxAge!);
+    const remoteBranches = filteredBranches.map((b) => b.branch);
+
+    this.logger.info(
+      `After filtering by age (${formatDuration(this.config.branchMaxAge!)}): ${remoteBranches.length} branches.`,
+    );
+
+    if (filteredByName.length > remoteBranches.length) {
+      const excludedCount = filteredByName.length - remoteBranches.length;
+      this.logger.info(`  - Excluded ${excludedCount} stale branches.`);
+    }
+
+    return remoteBranches;
+  }
+
+  private async getRemoteBranchesFilteredByName(): Promise<string[]> {
+    const allBranches = await this.gitService.getRemoteBranches();
+    this.logger.info(`Found ${allBranches.length} remote branches.`);
+
+    const remoteBranches = filterBranchesByName(allBranches, this.config.branchInclude, this.config.branchExclude);
+
+    if (remoteBranches.length < allBranches.length) {
+      this.logger.info(`After branch name filtering: ${remoteBranches.length} of ${allBranches.length} branches.`);
+    }
+
+    return remoteBranches;
+  }
+
+  private async finalizeSyncAttempt(phaseTimer: PhaseTimer): Promise<void> {
+    phaseTimer.startPhase("Phase 5: Cleanup");
+    await this.gitService.pruneWorktrees();
+    this.logger.info("Step 5: Pruned worktree metadata.");
+    phaseTimer.endPhase();
   }
 
   private async createNewWorktreesWithTiming(


### PR DESCRIPTION
## Summary
- extract shared MCP service readiness and worktree path helpers
- split the sync flow into smaller helpers with clearer phase boundaries
- reduce repeated sync/reload orchestration in the interactive UI
- add targeted tests for the new MCP and UI behavior

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- pnpm run test
- pnpm run test:coverage
