### PR TITLE
Enable npm OIDC trusted publishing for release workflow

### DIFF
--- a/.changeset/ci-npm-oidc-toolchain.md
+++ b/.changeset/ci-npm-oidc-toolchain.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: switch npm publish to OIDC trusted publishing and bump CI toolchain to Node 24 LTS + pnpm 10. No runtime changes.

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -4,11 +4,11 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '22'
+    default: '24'
   pnpm-version:
     description: 'pnpm version to use'
     required: false
-    default: '9'
+    default: '10'
   registry-url:
     description: 'npm registry URL to configure in .npmrc for auth (e.g. https://registry.npmjs.org)'
     required: false

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'pnpm version to use'
     required: false
     default: '9'
+  registry-url:
+    description: 'npm registry URL to configure in .npmrc for auth (e.g. https://registry.npmjs.org)'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -16,6 +20,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Check for changeset
         id: check
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Run Linter
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       # npm OIDC trusted publishing requires npm CLI >= 11.5.1; Node 22 ships

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # npm OIDC trusted publishing requires npm CLI >= 11.5.1; Node 22 ships
+      # with npm 10.x. Upgrade before `changeset publish` shells out to npm.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install --global npm@latest
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -41,8 +46,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Release Summary
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -41,6 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Release Summary
         if: steps.changesets.outputs.published == 'true'

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yordan-kanchelov/sync-worktrees.git"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,13 @@
     "yargs": "^18.0.0",
     "zod": "^4.3.6"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "fast-folder-size",
+      "unrs-resolver"
+    ]
+  },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Summary
This PR updates the release workflow and package configuration to use npm's OIDC trusted publishing instead of token-based authentication, improving security by eliminating the need to manage NPM_TOKEN secrets.

## Key Changes
- **Release workflow**: Added `registry-url` configuration to the Node.js setup action and upgraded npm to the latest version (required for OIDC support in npm CLI >= 11.5.1)
- **Removed NPM_TOKEN**: Eliminated the `NPM_TOKEN` environment variable from the changesets publish step, as OIDC authentication will be used instead
- **Setup action enhancement**: Added `registry-url` input parameter to the `setup-node-pnpm` action to support npm registry configuration
- **Package configuration**: Added `publishConfig` to `package.json` with:
  - `access: "public"` - ensures the package is published as public
  - `registry: "https://registry.npmjs.org/"` - explicitly sets the npm registry
  - `provenance: true` - enables provenance attestation for supply chain security

## Implementation Details
The npm CLI version shipped with Node 22 is 10.x, which doesn't support OIDC trusted publishing. The workflow now explicitly upgrades npm to the latest version before running the changesets publish command to ensure OIDC authentication works correctly.

https://claude.ai/code/session_01DMKj1vkppvvSXsRTwYVeeW