### PR TITLE
feat(mcp): enrich context discovery and worktree summaries

### DIFF
--- a/.changeset/mcp-context-enrichment.md
+++ b/.changeset/mcp-context-enrichment.md
@@ -4,7 +4,7 @@
 
 Enrich MCP context discovery and worktree summaries.
 
-- `detect_context` now walks up from the inspected path to auto-load `sync-worktrees.config.{js,mjs,cjs,ts}`, lists sibling repositories under the workspace root, and exposes `configPath` plus `notes[]` (renamed from `reasons`). The redundant `configLoaded` field is dropped — derive from `configPath !== null`.
+- `detect_context` now walks up from the inspected path to auto-load `sync-worktrees.config.{js,mjs,cjs}`, lists sibling repositories under the workspace root, and exposes `configPath` plus `notes[]` (renamed from `reasons`). The redundant `configLoaded` field is dropped — derive from `configPath !== null`.
 - Capabilities shape changed from `{ canX: boolean }` to `{ x: { available: boolean, reason?: string } }`, so consumers can see exactly why a capability is gated.
 - `detect_context` accepts `includeStatus` to enrich `allWorktrees` with `label`, `divergence`, and `staleHint`.
 - `list_worktrees` accepts `includeSize` (returns `sizeBytes`) and now returns `safeToRemove` as `{ safe, reason }` instead of a raw boolean.

--- a/.changeset/mcp-context-enrichment.md
+++ b/.changeset/mcp-context-enrichment.md
@@ -4,7 +4,7 @@
 
 Enrich MCP context discovery and worktree summaries.
 
-- `detect_context` now walks up from the inspected path to auto-load `sync-worktrees.config.{js,mjs,cjs,ts}`, lists sibling repositories under the workspace root, and exposes `configPath` plus `notes[]` (renamed from `reasons`).
+- `detect_context` now walks up from the inspected path to auto-load `sync-worktrees.config.{js,mjs,cjs,ts}`, lists sibling repositories under the workspace root, and exposes `configPath` plus `notes[]` (renamed from `reasons`). The redundant `configLoaded` field is dropped — derive from `configPath !== null`.
 - Capabilities shape changed from `{ canX: boolean }` to `{ x: { available: boolean, reason?: string } }`, so consumers can see exactly why a capability is gated.
 - `detect_context` accepts `includeStatus` to enrich `allWorktrees` with `label`, `divergence`, and `staleHint`.
 - `list_worktrees` accepts `includeSize` (returns `sizeBytes`) and now returns `safeToRemove` as `{ safe, reason }` instead of a raw boolean.

--- a/.changeset/mcp-context-enrichment.md
+++ b/.changeset/mcp-context-enrichment.md
@@ -1,0 +1,11 @@
+---
+"sync-worktrees": minor
+---
+
+Enrich MCP context discovery and worktree summaries.
+
+- `detect_context` now walks up from the inspected path to auto-load `sync-worktrees.config.{js,mjs,cjs,ts}`, lists sibling repositories under the workspace root, and exposes `configPath` plus `notes[]` (renamed from `reasons`).
+- Capabilities shape changed from `{ canX: boolean }` to `{ x: { available: boolean, reason?: string } }`, so consumers can see exactly why a capability is gated.
+- `detect_context` accepts `includeStatus` to enrich `allWorktrees` with `label`, `divergence`, and `staleHint`.
+- `list_worktrees` accepts `includeSize` (returns `sizeBytes`) and now returns `safeToRemove` as `{ safe, reason }` instead of a raw boolean.
+- New `ConfigLoaderService.findConfigUpward()` helper for upward config discovery.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,7 +89,6 @@ export const CONFIG_FILE_NAMES = [
   "sync-worktrees.config.js",
   "sync-worktrees.config.mjs",
   "sync-worktrees.config.cjs",
-  "sync-worktrees.config.ts",
 ] as const;
 
 export const METADATA_CONSTANTS = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,6 +85,13 @@ export const PATH_CONSTANTS = {
   README: "README",
 } as const;
 
+export const CONFIG_FILE_NAMES = [
+  "sync-worktrees.config.js",
+  "sync-worktrees.config.mjs",
+  "sync-worktrees.config.cjs",
+  "sync-worktrees.config.ts",
+] as const;
+
 export const METADATA_CONSTANTS = {
   MAX_HISTORY_ENTRIES: 10,
   METADATA_FILENAME: "sync-metadata.json",

--- a/src/mcp/__tests__/context.test.ts
+++ b/src/mcp/__tests__/context.test.ts
@@ -94,10 +94,10 @@ describe("RepositoryContext.detectFromPath", () => {
     expect(result.repoUrl).toBe("https://github.com/test/repo.git");
     expect(result.currentBranch).toBe("feature-x");
     expect(result.allWorktrees).toHaveLength(2);
-    expect(result.capabilities.canListWorktrees).toBe(true);
-    expect(result.capabilities.canCreateWorktree).toBe(true);
-    expect(result.capabilities.canSync).toBe(false);
-    expect(result.capabilities.canInitialize).toBe(false);
+    expect(result.capabilities.listWorktrees.available).toBe(true);
+    expect(result.capabilities.createWorktree.available).toBe(true);
+    expect(result.capabilities.sync.available).toBe(false);
+    expect(result.capabilities.initialize.available).toBe(false);
   });
 
   it("returns unsupported for regular git repo (directory .git)", async () => {
@@ -109,8 +109,8 @@ describe("RepositoryContext.detectFromPath", () => {
 
     expect(result.isWorktree).toBe(false);
     expect(result.kind).toBe("unsupported");
-    expect(result.capabilities.canListWorktrees).toBe(false);
-    expect(result.reasons.some((r) => r.includes("regular repo"))).toBe(true);
+    expect(result.capabilities.listWorktrees.available).toBe(false);
+    expect(result.notes.some((r: string) => r.includes("regular repo"))).toBe(true);
 
     await fs.rm(regularRepo, { recursive: true, force: true });
   });
@@ -148,8 +148,8 @@ describe("RepositoryContext.detectFromPath", () => {
     const result = await ctx.detectFromPath(fixture.currentWorktree);
     expect(result.kind).toBe("managed");
     expect(result.repoName).toBe("configured");
-    expect(result.capabilities.canSync).toBe(true);
-    expect(result.capabilities.canInitialize).toBe(true);
+    expect(result.capabilities.sync.available).toBe(true);
+    expect(result.capabilities.initialize.available).toBe(true);
   });
 
   it("resolves relative gitdir path against the worktree root", async () => {
@@ -182,8 +182,113 @@ describe("RepositoryContext.detectFromPath", () => {
     const result = await ctx.detectFromPath(fixture.currentWorktree);
 
     expect(result.repoUrl).toBeNull();
-    expect(result.capabilities.canCreateWorktree).toBe(false);
-    expect(result.reasons.some((r) => r.includes("create_worktree"))).toBe(true);
+    expect(result.capabilities.createWorktree.available).toBe(false);
+    expect(result.capabilities.createWorktree.reason).toContain("remote origin URL");
+  });
+});
+
+describe("RepositoryContext.detectFromPath sibling discovery", () => {
+  it("discovers sibling repos with .bare directories under workspace root", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-siblings-"));
+    try {
+      const currentRepo = path.join(workspace, "repo-current");
+      const currentBare = path.join(currentRepo, ".bare");
+      const adminDir = path.join(currentBare, "worktrees", "main");
+      await fs.mkdir(adminDir, { recursive: true });
+      const currentWt = path.join(currentRepo, "worktrees", "main");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${adminDir}\n`, "utf-8");
+
+      await fs.mkdir(path.join(workspace, "repo-sibling-a", ".bare"), { recursive: true });
+      await fs.mkdir(path.join(workspace, "repo-sibling-b", ".bare"), { recursive: true });
+      await fs.mkdir(path.join(workspace, "not-a-repo"), { recursive: true });
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
+      mockWorktreeList.mockResolvedValue([`worktree ${currentWt}`, "branch refs/heads/main", ""].join("\n"));
+
+      const ctx = new RepositoryContext();
+      const result = await ctx.detectFromPath(currentWt);
+
+      expect(result.siblingRepositories.length).toBe(3);
+      const names = result.siblingRepositories.map((s) => s.name).sort();
+      expect(names).toEqual(["repo-current", "repo-sibling-a", "repo-sibling-b"]);
+      for (const sib of result.siblingRepositories) {
+        expect(sib.bareRepoPath).toMatch(/\.bare$/);
+        expect(sib.configMatched).toBe(false);
+      }
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("marks sibling as configMatched when bareRepoDir matches a loaded config repo", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-siblings-cfg-"));
+    try {
+      const currentRepo = path.join(workspace, "repo-current");
+      const currentBare = path.join(currentRepo, ".bare");
+      const adminDir = path.join(currentBare, "worktrees", "main");
+      await fs.mkdir(adminDir, { recursive: true });
+      const currentWt = path.join(currentRepo, "worktrees", "main");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${adminDir}\n`, "utf-8");
+
+      const siblingA = path.join(workspace, "repo-sibling-a");
+      await fs.mkdir(path.join(siblingA, ".bare"), { recursive: true });
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
+      mockWorktreeList.mockResolvedValue([`worktree ${currentWt}`, "branch refs/heads/main", ""].join("\n"));
+
+      const ctx = new RepositoryContext();
+      ctx.__registerForTest("named-sibling", {
+        config: {
+          repoUrl: "https://github.com/test/sibling.git",
+          bareRepoDir: path.join(siblingA, ".bare"),
+          worktreeDir: path.join(siblingA, "worktrees"),
+          cronSchedule: "0 * * * *",
+          runOnce: true,
+        },
+        source: "config" as const,
+      });
+
+      const result = await ctx.detectFromPath(currentWt);
+      const matched = result.siblingRepositories.find((s) => s.configMatched);
+      expect(matched).toBeDefined();
+      expect(matched?.name).toBe("named-sibling");
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("RepositoryContext.detectFromPath config auto-discovery", () => {
+  it("auto-loads sync-worktrees.config.js found by walking up", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-auto-cfg-"));
+    try {
+      const currentRepo = path.join(workspace, "repo-current");
+      const currentBare = path.join(currentRepo, ".bare");
+      const adminDir = path.join(currentBare, "worktrees", "main");
+      await fs.mkdir(adminDir, { recursive: true });
+      const currentWt = path.join(currentRepo, "worktrees", "main");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${adminDir}\n`, "utf-8");
+
+      const configPath = path.join(workspace, "sync-worktrees.config.js");
+      const cfgBody = `export default { repositories: [{ name: "auto-loaded", repoUrl: "https://github.com/test/repo.git", bareRepoDir: ${JSON.stringify(currentBare)}, worktreeDir: ${JSON.stringify(path.join(currentRepo, "worktrees"))}, cronSchedule: "0 * * * *", runOnce: true }] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
+      mockWorktreeList.mockResolvedValue([`worktree ${currentWt}`, "branch refs/heads/main", ""].join("\n"));
+
+      const ctx = new RepositoryContext();
+      const result = await ctx.detectFromPath(currentWt);
+
+      expect(result.configLoaded).toBe(true);
+      expect(result.configPath).toBe(configPath);
+      expect(result.kind).toBe("managed");
+      expect(result.repoName).toBe("auto-loaded");
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/mcp/__tests__/context.test.ts
+++ b/src/mcp/__tests__/context.test.ts
@@ -282,7 +282,6 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
       const ctx = new RepositoryContext();
       const result = await ctx.detectFromPath(currentWt);
 
-      expect(result.configLoaded).toBe(true);
       expect(result.configPath).toBe(configPath);
       expect(result.kind).toBe("managed");
       expect(result.repoName).toBe("auto-loaded");

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -92,7 +92,6 @@ function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): Discove
     worktreeDir: "/repo/worktrees",
     allWorktrees: [],
     siblingRepositories: [],
-    configLoaded: true,
     configPath: null,
     repoName: "test",
     capabilities: makeCapabilities(),

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   handleCreateWorktree,
+  handleDetectContext,
   handleGetWorktreeStatus,
   handleInitialize,
   handleListWorktrees,
@@ -34,15 +35,48 @@ vi.mock("simple-git", () => ({
   })),
 }));
 
+vi.mock("../../utils/disk-space", () => ({
+  calculateDirectorySize: vi.fn().mockResolvedValue(123456),
+  formatBytes: vi.fn().mockReturnValue("123 KB"),
+  calculateSyncDiskSpace: vi.fn().mockResolvedValue("N/A"),
+}));
+
+vi.mock("../../services/worktree-status.service", () => {
+  class FakeStatusService {
+    async getFullWorktreeStatus(): Promise<{
+      isClean: boolean;
+      hasUnpushedCommits: boolean;
+      hasStashedChanges: boolean;
+      hasOperationInProgress: boolean;
+      hasModifiedSubmodules: boolean;
+      upstreamGone: boolean;
+      canRemove: boolean;
+      reasons: string[];
+    }> {
+      return {
+        isClean: true,
+        hasUnpushedCommits: false,
+        hasStashedChanges: false,
+        hasOperationInProgress: false,
+        hasModifiedSubmodules: false,
+        upstreamGone: false,
+        canRemove: true,
+        reasons: [],
+      };
+    }
+  }
+  return { WorktreeStatusService: FakeStatusService };
+});
+
 function makeCapabilities(overrides: Partial<Capabilities> = {}): Capabilities {
   return {
-    canListWorktrees: true,
-    canGetStatus: true,
-    canCreateWorktree: true,
-    canRemoveWorktree: true,
-    canUpdateWorktree: true,
-    canSync: true,
-    canInitialize: true,
+    listWorktrees: { available: true },
+    getStatus: { available: true },
+    createWorktree: { available: true },
+    removeWorktree: { available: true },
+    updateWorktree: { available: true },
+    sync: { available: true },
+    initialize: { available: true },
     ...overrides,
   };
 }
@@ -57,10 +91,12 @@ function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): Discove
     repoUrl: "https://example.com/repo.git",
     worktreeDir: "/repo/worktrees",
     allWorktrees: [],
+    siblingRepositories: [],
     configLoaded: true,
+    configPath: null,
     repoName: "test",
     capabilities: makeCapabilities(),
-    reasons: [],
+    notes: [],
     ...overrides,
   };
 }
@@ -155,15 +191,16 @@ describe("handleListWorktrees", () => {
     expect(body.worktrees).toHaveLength(2);
     expect(body.worktrees[0].label).toBe("current");
     expect(body.worktrees[1].label).toBe("clean");
-    expect(body.worktrees[1].safeToRemove).toBe(true);
+    expect(body.worktrees[1].safeToRemove).toEqual({ safe: true, reason: expect.any(String) });
+    expect(body.worktrees[1].sizeBytes).toBeNull();
     expect(git.getWorktrees).toHaveBeenCalled();
   });
 
   it("fails with CAPABILITY_UNAVAILABLE when canListWorktrees is false", async () => {
     const { ctx } = makeCtx({
       discovered: makeDiscovered({
-        capabilities: makeCapabilities({ canListWorktrees: false }),
-        reasons: ["test reason"],
+        capabilities: makeCapabilities({ listWorktrees: { available: false, reason: "test reason" } }),
+        notes: ["test reason"],
       }),
     });
 
@@ -346,8 +383,8 @@ describe("handleSync", () => {
   it("fails when canSync=false", async () => {
     const { ctx } = makeCtx({
       discovered: makeDiscovered({
-        capabilities: makeCapabilities({ canSync: false }),
-        reasons: ["no config"],
+        capabilities: makeCapabilities({ sync: { available: false, reason: "no config" } }),
+        notes: ["no config"],
       }),
     });
     const result = await invoke(handleSync, ctx, {});
@@ -699,5 +736,116 @@ describe("handleCreateWorktree collisions", () => {
     const secondPath = (git.addWorktree as any).mock.calls[0][1];
 
     expect(firstPath).not.toBe(secondPath);
+  });
+});
+
+describe("handleListWorktrees includeSize", () => {
+  it("returns sizeBytes when includeSize=true", async () => {
+    const { ctx } = makeCtx({
+      git: {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/main", branch: "main", isCurrent: true }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
+          isClean: true,
+          hasUnpushedCommits: false,
+          hasStashedChanges: false,
+          hasOperationInProgress: false,
+          hasModifiedSubmodules: false,
+          upstreamGone: false,
+          canRemove: true,
+          reasons: [],
+        }),
+      },
+    });
+
+    const result = await invoke(handleListWorktrees, ctx, { includeSize: true });
+    const body = parseResponse(result);
+    expect(body.worktrees[0].sizeBytes).toBe(123456);
+  });
+});
+
+describe("handleListWorktrees structured safeToRemove", () => {
+  it("returns unsafe with joined reasons when canRemove=false", async () => {
+    const { ctx } = makeCtx({
+      git: {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/feat", branch: "feat" }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
+          isClean: false,
+          hasUnpushedCommits: true,
+          hasStashedChanges: false,
+          hasOperationInProgress: false,
+          hasModifiedSubmodules: false,
+          upstreamGone: false,
+          canRemove: false,
+          reasons: ["uncommitted changes", "unpushed commits"],
+        }),
+      },
+    });
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+    expect(body.worktrees[0].safeToRemove.safe).toBe(false);
+    expect(body.worktrees[0].safeToRemove.reason).toContain("uncommitted changes");
+  });
+
+  it("returns unsafe + 'deleted upstream' reason when upstream gone", async () => {
+    const { ctx } = makeCtx({
+      git: {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repo/feat", branch: "feat" }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue({
+          isClean: true,
+          hasUnpushedCommits: false,
+          hasStashedChanges: false,
+          hasOperationInProgress: false,
+          hasModifiedSubmodules: false,
+          upstreamGone: true,
+          canRemove: true,
+          reasons: [],
+        }),
+      },
+    });
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+    expect(body.worktrees[0].safeToRemove.safe).toBe(false);
+    expect(body.worktrees[0].safeToRemove.reason).toContain("deleted upstream");
+  });
+});
+
+describe("handleDetectContext includeStatus", () => {
+  it("returns allWorktrees as-is when includeStatus is false/omitted", async () => {
+    const ctx = {
+      detectFromPath: vi.fn<any>().mockResolvedValue(
+        makeDiscovered({
+          allWorktrees: [
+            { path: "/repo/main", branch: "main", isCurrent: true },
+            { path: "/repo/feat", branch: "feat", isCurrent: false },
+          ],
+        }),
+      ),
+    } as unknown as RepositoryContext;
+
+    const result = await invoke(handleDetectContext, ctx, {});
+    const body = parseResponse(result);
+    expect(body.allWorktrees[0].label).toBeUndefined();
+    expect(body.allWorktrees[1].divergence).toBeUndefined();
+  });
+
+  it("enriches allWorktrees with label/divergence/staleHint when includeStatus=true", async () => {
+    const ctx = {
+      detectFromPath: vi.fn<any>().mockResolvedValue(
+        makeDiscovered({
+          allWorktrees: [
+            { path: "/repo/main", branch: "main", isCurrent: true },
+            { path: "/repo/feat", branch: "feat", isCurrent: false },
+          ],
+        }),
+      ),
+    } as unknown as RepositoryContext;
+
+    const result = await invoke(handleDetectContext, ctx, { includeStatus: true });
+    const body = parseResponse(result);
+    expect(body.allWorktrees[0].label).toBe("current");
+    expect(body.allWorktrees[1].label).toBe("clean");
+    expect(body.allWorktrees[0].staleHint).toBe(false);
   });
 });

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -87,8 +87,8 @@ describe("createServer", () => {
 
     expect(payload.isWorktree).toBe(false);
     expect(payload.kind).toBe("unsupported");
-    expect(Array.isArray(payload.reasons)).toBe(true);
-    expect(payload.reasons.join(" ")).toContain("boom");
+    expect(Array.isArray(payload.notes)).toBe(true);
+    expect(payload.notes.join(" ")).toContain("boom");
   });
 
   it("workspace resource returns discovered context when cwd is inside a worktree", async () => {

--- a/src/mcp/__tests__/worktree-summary.test.ts
+++ b/src/mcp/__tests__/worktree-summary.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveLabel, deriveSafeToRemove } from "../worktree-summary";
+
+import type { WorktreeStatusResult } from "../../services/worktree-status.service";
+
+function makeStatus(overrides: Partial<WorktreeStatusResult> = {}): WorktreeStatusResult {
+  return {
+    isClean: true,
+    hasUnpushedCommits: false,
+    hasStashedChanges: false,
+    hasOperationInProgress: false,
+    hasModifiedSubmodules: false,
+    upstreamGone: false,
+    canRemove: true,
+    reasons: [],
+    ...overrides,
+  };
+}
+
+describe("deriveLabel", () => {
+  it("returns 'current' when worktree is current", () => {
+    expect(deriveLabel(makeStatus(), true)).toBe("current");
+  });
+
+  it("returns 'dirty' when uncommitted changes", () => {
+    expect(deriveLabel(makeStatus({ isClean: false, reasons: ["uncommitted changes"] }), false)).toBe("dirty");
+  });
+
+  it("returns 'dirty' when unpushed commits", () => {
+    expect(deriveLabel(makeStatus({ hasUnpushedCommits: true, reasons: ["unpushed commits"] }), false)).toBe("dirty");
+  });
+
+  it("returns 'stale' when upstream gone but tree clean", () => {
+    expect(deriveLabel(makeStatus({ upstreamGone: true }), false)).toBe("stale");
+  });
+
+  it("returns 'clean' when all good", () => {
+    expect(deriveLabel(makeStatus(), false)).toBe("clean");
+  });
+});
+
+describe("deriveSafeToRemove", () => {
+  it("safe + reason when clean and upstream present", () => {
+    const result = deriveSafeToRemove(makeStatus());
+    expect(result.safe).toBe(true);
+    expect(result.reason).toContain("clean");
+  });
+
+  it("unsafe when upstream gone (still has remote, but deleted)", () => {
+    const result = deriveSafeToRemove(makeStatus({ upstreamGone: true }));
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain("deleted upstream");
+  });
+
+  it("unsafe with joined reasons when canRemove=false", () => {
+    const result = deriveSafeToRemove(
+      makeStatus({
+        canRemove: false,
+        isClean: false,
+        hasUnpushedCommits: true,
+        reasons: ["uncommitted changes", "unpushed commits"],
+      }),
+    );
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain("uncommitted changes");
+    expect(result.reason).toContain("unpushed commits");
+  });
+
+  it("unsafe with fallback when canRemove=false but no reasons", () => {
+    const result = deriveSafeToRemove(makeStatus({ canRemove: false }));
+    expect(result.safe).toBe(false);
+    expect(result.reason).toBe("not safe to remove");
+  });
+});

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -3,11 +3,11 @@ import * as path from "path";
 
 import simpleGit from "simple-git";
 
-import { DEFAULT_CONFIG } from "../constants";
+import { DEFAULT_CONFIG, GIT_CONSTANTS } from "../constants";
 import { ConfigLoaderService } from "../services/config-loader.service";
 import { Logger } from "../services/logger.service";
 import { WorktreeSyncService } from "../services/worktree-sync.service";
-import { isCaseInsensitiveFs } from "../utils/path-compare";
+import { normalizePathForCompare } from "../utils/path-compare";
 import { parseWorktreeListPorcelain } from "../utils/worktree-list-parser";
 
 import type { Config, RepositoryConfig } from "../types";
@@ -53,7 +53,6 @@ export interface DiscoveredRepoContext {
   worktreeDir: string | null;
   allWorktrees: DiscoveredWorktree[];
   siblingRepositories: SiblingRepository[];
-  configLoaded: boolean;
   configPath: string | null;
   repoName: string | null;
   capabilities: Capabilities;
@@ -103,7 +102,6 @@ export function buildUnsupportedContext(currentPath: string, reason: string): Di
     worktreeDir: null,
     allWorktrees: [],
     siblingRepositories: [],
-    configLoaded: false,
     configPath: null,
     repoName: null,
     capabilities: emptyCapabilities(reason),
@@ -126,6 +124,7 @@ export class RepositoryContext {
   private configPath: string | null = null;
   private configLoader = new ConfigLoaderService();
   private discoveryCache = new Map<string, CachedDiscovery>();
+  private configAutoDetectAttempted = false;
 
   async loadConfig(configPath: string): Promise<RepositoryConfig[]> {
     const absolutePath = path.resolve(configPath);
@@ -138,6 +137,7 @@ export class RepositoryContext {
     }
 
     this.configPath = absolutePath;
+    this.configAutoDetectAttempted = true;
     const configDir = path.dirname(absolutePath);
     const globalDefaults = configFile.defaults;
 
@@ -169,7 +169,8 @@ export class RepositoryContext {
       return cached.result;
     }
 
-    if (this.configPath === null) {
+    if (this.configPath === null && !this.configAutoDetectAttempted) {
+      this.configAutoDetectAttempted = true;
       const found = await this.configLoader.findConfigUpward(absolutePath);
       if (found) {
         try {
@@ -236,11 +237,10 @@ export class RepositoryContext {
       return [];
     }
 
-    const fold = (p: string): string => (isCaseInsensitiveFs() ? p.toLowerCase() : p);
     const configBares = new Map<string, string>();
     for (const entry of this.repos.values()) {
       if (entry.source === "config" && entry.config.bareRepoDir) {
-        configBares.set(fold(path.resolve(entry.config.bareRepoDir)), entry.name);
+        configBares.set(normalizePathForCompare(entry.config.bareRepoDir), entry.name);
       }
     }
 
@@ -248,7 +248,7 @@ export class RepositoryContext {
     await Promise.all(
       entries.map(async (entry) => {
         const candidate = path.join(workspaceRoot, entry);
-        const bareCandidate = path.join(candidate, ".bare");
+        const bareCandidate = path.join(candidate, GIT_CONSTANTS.BARE_DIR_NAME);
         try {
           const stat = await fs.stat(bareCandidate);
           if (!stat.isDirectory()) return;
@@ -257,7 +257,7 @@ export class RepositoryContext {
         }
 
         const resolvedBare = path.resolve(bareCandidate);
-        const matchedName = configBares.get(fold(resolvedBare));
+        const matchedName = configBares.get(normalizePathForCompare(resolvedBare));
         results.push({
           name: matchedName ?? entry,
           bareRepoPath: resolvedBare,
@@ -314,7 +314,6 @@ export class RepositoryContext {
           worktreeDir: null,
           allWorktrees: [],
           siblingRepositories: [],
-          configLoaded: this.configPath !== null,
           configPath: this.configPath,
           repoName: null,
           capabilities: emptyCapabilities(reason),
@@ -383,7 +382,6 @@ export class RepositoryContext {
           worktreeDir: null,
           allWorktrees: [],
           siblingRepositories: [],
-          configLoaded: this.configPath !== null,
           configPath: this.configPath,
           repoName: null,
           capabilities: emptyCapabilities(reason),
@@ -406,13 +404,11 @@ export class RepositoryContext {
       initialize: { available: false, reason: "no config and no remote URL" },
     };
 
-    const foldPath = (p: string): string => (isCaseInsensitiveFs() ? p.toLowerCase() : p);
-    const foldedBare = foldPath(bareRepoPath);
+    const foldedBare = normalizePathForCompare(bareRepoPath);
     let matchedConfig: RepoEntry | null = null;
     for (const entry of this.repos.values()) {
-      if (entry.source === "config") {
-        const entryBare = entry.config.bareRepoDir ? path.resolve(entry.config.bareRepoDir) : null;
-        if (entryBare && foldPath(entryBare) === foldedBare) {
+      if (entry.source === "config" && entry.config.bareRepoDir) {
+        if (normalizePathForCompare(entry.config.bareRepoDir) === foldedBare) {
           matchedConfig = entry;
           break;
         }
@@ -465,7 +461,6 @@ export class RepositoryContext {
       worktreeDir,
       allWorktrees: worktrees,
       siblingRepositories,
-      configLoaded: this.configPath !== null,
       configPath: this.configPath,
       repoName,
       capabilities,
@@ -538,9 +533,7 @@ export class RepositoryContext {
 }
 
 function parseWorktreeList(output: string, currentPath: string): DiscoveredWorktree[] {
-  const resolvedCurrent = path.resolve(currentPath);
-  const fold = (p: string): string => (isCaseInsensitiveFs() ? p.toLowerCase() : p);
-  const foldedCurrent = fold(resolvedCurrent);
+  const foldedCurrent = normalizePathForCompare(currentPath);
   const results: DiscoveredWorktree[] = [];
   for (const wt of parseWorktreeListPorcelain(output)) {
     const resolved = path.resolve(wt.path);
@@ -549,7 +542,7 @@ function parseWorktreeList(output: string, currentPath: string): DiscoveredWorkt
     results.push({
       path: resolved,
       branch,
-      isCurrent: fold(resolved) === foldedCurrent,
+      isCurrent: normalizePathForCompare(resolved) === foldedCurrent,
     });
   }
   return results;

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -11,21 +11,36 @@ import { isCaseInsensitiveFs } from "../utils/path-compare";
 import { parseWorktreeListPorcelain } from "../utils/worktree-list-parser";
 
 import type { Config, RepositoryConfig } from "../types";
+import type { Divergence, WorktreeLabel } from "./worktree-summary";
+
+export interface CapabilityState {
+  available: boolean;
+  reason?: string;
+}
 
 export interface Capabilities {
-  canListWorktrees: boolean;
-  canGetStatus: boolean;
-  canCreateWorktree: boolean;
-  canRemoveWorktree: boolean;
-  canUpdateWorktree: boolean;
-  canSync: boolean;
-  canInitialize: boolean;
+  listWorktrees: CapabilityState;
+  getStatus: CapabilityState;
+  createWorktree: CapabilityState;
+  removeWorktree: CapabilityState;
+  updateWorktree: CapabilityState;
+  sync: CapabilityState;
+  initialize: CapabilityState;
 }
 
 export interface DiscoveredWorktree {
   path: string;
   branch: string;
   isCurrent: boolean;
+  label?: WorktreeLabel;
+  divergence?: Divergence | null;
+  staleHint?: boolean;
+}
+
+export interface SiblingRepository {
+  name: string;
+  bareRepoPath: string;
+  configMatched: boolean;
 }
 
 export interface DiscoveredRepoContext {
@@ -37,10 +52,12 @@ export interface DiscoveredRepoContext {
   repoUrl: string | null;
   worktreeDir: string | null;
   allWorktrees: DiscoveredWorktree[];
+  siblingRepositories: SiblingRepository[];
   configLoaded: boolean;
+  configPath: string | null;
   repoName: string | null;
   capabilities: Capabilities;
-  reasons: string[];
+  notes: string[];
 }
 
 interface RepoEntry {
@@ -62,15 +79,18 @@ interface CachedDiscovery {
 const AUTO_DETECT_PREFIX = "__auto_detected__:";
 const DISCOVERY_CACHE_TTL_MS = 5000;
 
-const EMPTY_CAPABILITIES: Capabilities = {
-  canListWorktrees: false,
-  canGetStatus: false,
-  canCreateWorktree: false,
-  canRemoveWorktree: false,
-  canUpdateWorktree: false,
-  canSync: false,
-  canInitialize: false,
-};
+function emptyCapabilities(reason?: string): Capabilities {
+  const state: CapabilityState = reason ? { available: false, reason } : { available: false };
+  return {
+    listWorktrees: { ...state },
+    getStatus: { ...state },
+    createWorktree: { ...state },
+    removeWorktree: { ...state },
+    updateWorktree: { ...state },
+    sync: { ...state },
+    initialize: { ...state },
+  };
+}
 
 export function buildUnsupportedContext(currentPath: string, reason: string): DiscoveredRepoContext {
   return {
@@ -82,10 +102,12 @@ export function buildUnsupportedContext(currentPath: string, reason: string): Di
     repoUrl: null,
     worktreeDir: null,
     allWorktrees: [],
+    siblingRepositories: [],
     configLoaded: false,
+    configPath: null,
     repoName: null,
-    capabilities: EMPTY_CAPABILITIES,
-    reasons: [reason],
+    capabilities: emptyCapabilities(reason),
+    notes: [reason],
   };
 }
 
@@ -147,6 +169,17 @@ export class RepositoryContext {
       return cached.result;
     }
 
+    if (this.configPath === null) {
+      const found = await this.configLoader.findConfigUpward(absolutePath);
+      if (found) {
+        try {
+          await this.loadConfig(found);
+        } catch (err) {
+          process.stderr.write(`[sync-worktrees] auto-loaded config failed: ${(err as Error).message}\n`);
+        }
+      }
+    }
+
     const { result, adminDir } = await this.detectFromPathUncached(absolutePath);
 
     if (result.isWorktree && result.bareRepoPath && adminDir) {
@@ -190,6 +223,53 @@ export class RepositoryContext {
     return this.discoveryCache.size;
   }
 
+  private async discoverSiblingRepositories(currentBareRepoPath: string): Promise<SiblingRepository[]> {
+    const repoDir = path.dirname(currentBareRepoPath);
+    const workspaceRoot = path.dirname(repoDir);
+
+    if (workspaceRoot === repoDir) return [];
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(workspaceRoot);
+    } catch {
+      return [];
+    }
+
+    const fold = (p: string): string => (isCaseInsensitiveFs() ? p.toLowerCase() : p);
+    const configBares = new Map<string, string>();
+    for (const entry of this.repos.values()) {
+      if (entry.source === "config" && entry.config.bareRepoDir) {
+        configBares.set(fold(path.resolve(entry.config.bareRepoDir)), entry.name);
+      }
+    }
+
+    const results: SiblingRepository[] = [];
+    await Promise.all(
+      entries.map(async (entry) => {
+        const candidate = path.join(workspaceRoot, entry);
+        const bareCandidate = path.join(candidate, ".bare");
+        try {
+          const stat = await fs.stat(bareCandidate);
+          if (!stat.isDirectory()) return;
+        } catch {
+          return;
+        }
+
+        const resolvedBare = path.resolve(bareCandidate);
+        const matchedName = configBares.get(fold(resolvedBare));
+        results.push({
+          name: matchedName ?? entry,
+          bareRepoPath: resolvedBare,
+          configMatched: matchedName !== undefined,
+        });
+      }),
+    );
+
+    results.sort((a, b) => a.name.localeCompare(b.name));
+    return results;
+  }
+
   private bootstrapCurrentRepo(candidate: string): void {
     if (this.currentRepo !== null) return;
     if (!this.repos.has(candidate)) return;
@@ -212,7 +292,7 @@ export class RepositoryContext {
   private async detectFromPathUncached(
     absolutePath: string,
   ): Promise<{ result: DiscoveredRepoContext; adminDir: string | null }> {
-    const reasons: string[] = [];
+    const notes: string[] = [];
 
     const located = await findWorktreeRoot(absolutePath);
     const worktreeRoot = located?.worktreeRoot ?? absolutePath;
@@ -220,22 +300,25 @@ export class RepositoryContext {
     const unsupported = (
       reason: string,
       isWorktree = false,
+      bareRepoPath: string | null = null,
     ): { result: DiscoveredRepoContext; adminDir: string | null } => {
-      reasons.push(reason);
+      notes.push(reason);
       return {
         result: {
           isWorktree,
           kind: "unsupported",
           currentBranch: null,
           currentWorktreePath: worktreeRoot,
-          bareRepoPath: null,
+          bareRepoPath,
           repoUrl: null,
           worktreeDir: null,
           allWorktrees: [],
+          siblingRepositories: [],
           configLoaded: this.configPath !== null,
+          configPath: this.configPath,
           repoName: null,
-          capabilities: EMPTY_CAPABILITIES,
-          reasons,
+          capabilities: emptyCapabilities(reason),
+          notes,
         },
         adminDir: null,
       };
@@ -277,7 +360,7 @@ export class RepositoryContext {
         const urlStr = typeof remoteResult === "string" ? remoteResult.trim() : "";
         repoUrl = urlStr || null;
       } catch {
-        reasons.push("Could not read remote origin URL");
+        notes.push("Could not read remote origin URL");
       }
 
       const listOutput = await bareGit.raw(["worktree", "list", "--porcelain"]);
@@ -287,7 +370,8 @@ export class RepositoryContext {
         currentBranch = current.branch;
       }
     } catch (err) {
-      reasons.push(`Failed to read bare repo at ${bareRepoPath}: ${(err as Error).message}`);
+      const reason = `Failed to read bare repo at ${bareRepoPath}: ${(err as Error).message}`;
+      notes.push(reason);
       return {
         result: {
           isWorktree: true,
@@ -298,10 +382,12 @@ export class RepositoryContext {
           repoUrl: null,
           worktreeDir: null,
           allWorktrees: [],
+          siblingRepositories: [],
           configLoaded: this.configPath !== null,
+          configPath: this.configPath,
           repoName: null,
-          capabilities: EMPTY_CAPABILITIES,
-          reasons,
+          capabilities: emptyCapabilities(reason),
+          notes,
         },
         adminDir,
       };
@@ -309,19 +395,16 @@ export class RepositoryContext {
 
     const worktreeDir = path.dirname(worktreeRoot);
 
+    const noUrlReason = "no remote origin URL detected";
     const capabilities: Capabilities = {
-      canListWorktrees: true,
-      canGetStatus: true,
-      canCreateWorktree: repoUrl !== null,
-      canRemoveWorktree: true,
-      canUpdateWorktree: true,
-      canSync: false,
-      canInitialize: false,
+      listWorktrees: { available: true },
+      getStatus: { available: true },
+      createWorktree: repoUrl !== null ? { available: true } : { available: false, reason: noUrlReason },
+      removeWorktree: { available: true },
+      updateWorktree: { available: true },
+      sync: { available: false, reason: "no config and no remote URL" },
+      initialize: { available: false, reason: "no config and no remote URL" },
     };
-
-    if (!repoUrl) {
-      reasons.push("create_worktree unavailable: no remote origin URL detected");
-    }
 
     const foldPath = (p: string): string => (isCaseInsensitiveFs() ? p.toLowerCase() : p);
     const foldedBare = foldPath(bareRepoPath);
@@ -342,8 +425,8 @@ export class RepositoryContext {
     if (matchedConfig) {
       repoName = matchedConfig.name;
       kind = "managed";
-      capabilities.canSync = true;
-      capabilities.canInitialize = true;
+      capabilities.sync = { available: true };
+      capabilities.initialize = { available: true };
     } else if (repoUrl) {
       const syntheticConfig: Config = {
         repoUrl,
@@ -361,14 +444,16 @@ export class RepositoryContext {
         });
       }
       repoName = detectedKey;
-      reasons.push("sync/initialize unavailable: no config file loaded (running in auto-detect mode)");
-    } else {
-      reasons.push("sync/initialize unavailable: no config file and no remote URL");
+      const autoReason = "no config file loaded (running in auto-detect mode)";
+      capabilities.sync = { available: false, reason: autoReason };
+      capabilities.initialize = { available: false, reason: autoReason };
     }
 
     if (repoName) {
       this.bootstrapCurrentRepo(repoName);
     }
+
+    const siblingRepositories = await this.discoverSiblingRepositories(bareRepoPath);
 
     const discovered: DiscoveredRepoContext = {
       isWorktree: true,
@@ -379,10 +464,12 @@ export class RepositoryContext {
       repoUrl,
       worktreeDir,
       allWorktrees: worktrees,
+      siblingRepositories,
       configLoaded: this.configPath !== null,
+      configPath: this.configPath,
       repoName,
       capabilities,
-      reasons,
+      notes,
     };
 
     if (repoName) {

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -124,9 +124,9 @@ export class RepositoryContext {
   private configPath: string | null = null;
   private configLoader = new ConfigLoaderService();
   private discoveryCache = new Map<string, CachedDiscovery>();
-  private configAutoDetectAttempted = false;
 
-  async loadConfig(configPath: string): Promise<RepositoryConfig[]> {
+  async loadConfig(configPath: string, options: { setDefaultCurrent?: boolean } = {}): Promise<RepositoryConfig[]> {
+    const setDefaultCurrent = options.setDefaultCurrent ?? true;
     const absolutePath = path.resolve(configPath);
     const configFile = await this.configLoader.loadConfigFile(absolutePath);
 
@@ -137,7 +137,6 @@ export class RepositoryContext {
     }
 
     this.configPath = absolutePath;
-    this.configAutoDetectAttempted = true;
     const configDir = path.dirname(absolutePath);
     const globalDefaults = configFile.defaults;
 
@@ -154,9 +153,11 @@ export class RepositoryContext {
       this.currentRepo = null;
     }
 
-    if (!this.currentRepo && configFile.repositories.length > 0) {
+    if (setDefaultCurrent && !this.currentRepo && configFile.repositories.length > 0) {
       this.currentRepo = configFile.repositories[0].name;
     }
+
+    this.discoveryCache.clear();
 
     return configFile.repositories;
   }
@@ -169,12 +170,11 @@ export class RepositoryContext {
       return cached.result;
     }
 
-    if (this.configPath === null && !this.configAutoDetectAttempted) {
-      this.configAutoDetectAttempted = true;
+    if (this.configPath === null) {
       const found = await this.configLoader.findConfigUpward(absolutePath);
       if (found) {
         try {
-          await this.loadConfig(found);
+          await this.loadConfig(found, { setDefaultCurrent: false });
         } catch (err) {
           process.stderr.write(`[sync-worktrees] auto-loaded config failed: ${(err as Error).message}\n`);
         }
@@ -270,10 +270,10 @@ export class RepositoryContext {
     return results;
   }
 
-  private bootstrapCurrentRepo(candidate: string): void {
+  private bootstrapCurrentRepo(candidate: string, force = false): void {
     if (this.currentRepo !== null) return;
     if (!this.repos.has(candidate)) return;
-    if (this.repos.size !== 1) return;
+    if (!force && this.repos.size !== 1) return;
     this.currentRepo = candidate;
   }
 
@@ -297,19 +297,15 @@ export class RepositoryContext {
     const located = await findWorktreeRoot(absolutePath);
     const worktreeRoot = located?.worktreeRoot ?? absolutePath;
 
-    const unsupported = (
-      reason: string,
-      isWorktree = false,
-      bareRepoPath: string | null = null,
-    ): { result: DiscoveredRepoContext; adminDir: string | null } => {
+    const unsupported = (reason: string): { result: DiscoveredRepoContext; adminDir: string | null } => {
       notes.push(reason);
       return {
         result: {
-          isWorktree,
+          isWorktree: false,
           kind: "unsupported",
           currentBranch: null,
           currentWorktreePath: worktreeRoot,
-          bareRepoPath,
+          bareRepoPath: null,
           repoUrl: null,
           worktreeDir: null,
           allWorktrees: [],
@@ -446,7 +442,7 @@ export class RepositoryContext {
     }
 
     if (repoName) {
-      this.bootstrapCurrentRepo(repoName);
+      this.bootstrapCurrentRepo(repoName, matchedConfig !== null);
     }
 
     const siblingRepositories = await this.discoverSiblingRepositories(bareRepoPath);

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -1,18 +1,19 @@
 import * as path from "path";
 
 import pLimit from "p-limit";
-import simpleGit from "simple-git";
 
 import { DEFAULT_CONFIG } from "../constants";
 import { PathResolutionService } from "../services/path-resolution.service";
+import { WorktreeStatusService } from "../services/worktree-status.service";
+import { calculateDirectorySize } from "../utils/disk-space";
 import { isValidGitBranchName } from "../utils/git-validation";
 import { pathsEqual } from "../utils/path-compare";
 
 import { CapabilityUnavailableError, SyncInProgressError, formatToolResponse } from "./utils";
+import { deriveLabel, deriveSafeToRemove, getDivergence } from "./worktree-summary";
 
-import type { Capabilities, DiscoveredRepoContext, RepositoryContext } from "./context";
+import type { Capabilities, DiscoveredRepoContext, DiscoveredWorktree, RepositoryContext } from "./context";
 import type { HandlerExtra } from "./utils";
-import type { WorktreeStatusResult } from "../services/worktree-status.service";
 import type { ProgressEvent } from "../services/worktree-sync.service";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -26,8 +27,10 @@ const pathResolution = new PathResolutionService();
 
 function ensureCapability(discovered: DiscoveredRepoContext | null, key: CapabilityKey, toolName: string): void {
   if (!discovered) return;
-  if (!discovered.capabilities[key]) {
-    throw new CapabilityUnavailableError(toolName, discovered.reasons);
+  const cap = discovered.capabilities[key];
+  if (!cap.available) {
+    const reasons = cap.reason ? [cap.reason] : discovered.notes;
+    throw new CapabilityUnavailableError(toolName, reasons);
   }
 }
 
@@ -100,41 +103,48 @@ async function ensurePathBelongsToRepo(
   throw new Error(`Path '${targetPath}' is not a registered worktree of the current repository`);
 }
 
-function deriveLabel(status: WorktreeStatusResult, isCurrent: boolean): string {
-  if (isCurrent) return "current";
-  if (!status.isClean || status.hasUnpushedCommits || status.hasStashedChanges) return "dirty";
-  if (status.upstreamGone) return "stale";
-  return "clean";
-}
-
-async function getDivergence(worktreePath: string): Promise<{ ahead: number; behind: number } | null> {
-  try {
-    const git = simpleGit(worktreePath);
-    const output = await git.raw(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"]);
-    const [aheadStr, behindStr] = output.trim().split(/\s+/);
-    return { ahead: parseInt(aheadStr, 10), behind: parseInt(behindStr, 10) };
-  } catch {
-    return null;
-  }
-}
-
 export async function handleDetectContext(
   ctx: RepositoryContext,
-  params: { path?: string },
+  params: { path?: string; includeStatus?: boolean },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const target = params.path ?? process.cwd();
   const discovered = await ctx.detectFromPath(target);
-  return formatToolResponse(discovered);
+
+  if (!params.includeStatus || discovered.allWorktrees.length === 0) {
+    return formatToolResponse(discovered);
+  }
+
+  const statusService = new WorktreeStatusService();
+  const limit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
+
+  const enriched: DiscoveredWorktree[] = await Promise.all(
+    discovered.allWorktrees.map((wt) =>
+      limit(async () => {
+        const [status, divergence] = await Promise.all([
+          statusService.getFullWorktreeStatus(wt.path, false).catch(() => null),
+          getDivergence(wt.path),
+        ]);
+        return {
+          ...wt,
+          label: status ? deriveLabel(status, wt.isCurrent) : ("unknown" as const),
+          divergence,
+          staleHint: status?.upstreamGone ?? false,
+        };
+      }),
+    ),
+  );
+
+  return formatToolResponse({ ...discovered, allWorktrees: enriched });
 }
 
 export async function handleListWorktrees(
   ctx: RepositoryContext,
-  params: { repoName?: string },
+  params: { repoName?: string; includeSize?: boolean },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { discovered, git } = await getReadyService(ctx, params.repoName, {
-    capability: "canListWorktrees",
+    capability: "listWorktrees",
     toolName: "list_worktrees",
   });
 
@@ -158,10 +168,11 @@ export async function handleListWorktrees(
         const resolvedPath = path.resolve(wt.path);
         const isCurrent = currentPath !== null && pathsEqual(wt.path, currentPath);
 
-        const [status, divergence, metadata] = await Promise.all([
+        const [status, divergence, metadata, sizeBytes] = await Promise.all([
           git.getFullWorktreeStatus(wt.path, false).catch(() => null),
           getDivergence(wt.path),
           git.getWorktreeMetadata(wt.path).catch(() => null),
+          params.includeSize ? calculateDirectorySize(wt.path).catch(() => null) : Promise.resolve(null),
         ]);
 
         return {
@@ -171,8 +182,9 @@ export async function handleListWorktrees(
           label: status ? deriveLabel(status, isCurrent) : "unknown",
           status,
           divergence,
-          safeToRemove: status ? status.canRemove && !status.upstreamGone : false,
+          safeToRemove: status ? deriveSafeToRemove(status) : { safe: false, reason: "status unavailable" },
           lastSyncAt: metadata?.lastSyncDate ?? null,
+          sizeBytes,
         };
       }),
     ),
@@ -187,7 +199,7 @@ export async function handleGetWorktreeStatus(
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { git } = await getReadyService(ctx, params.repoName, {
-    capability: "canGetStatus",
+    capability: "getStatus",
     toolName: "get_worktree_status",
   });
   const resolvedPath = await ensureRepoWorktreePath(ctx, params, git);
@@ -216,7 +228,7 @@ export async function handleCreateWorktree(
   }
 
   const { service, git } = await getReadyService(ctx, params.repoName, {
-    capability: "canCreateWorktree",
+    capability: "createWorktree",
     toolName: "create_worktree",
     ensureInitialized: true,
     ensureNotSyncing: true,
@@ -267,7 +279,7 @@ export async function handleRemoveWorktree(
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { git } = await getReadyService(ctx, params.repoName, {
-    capability: "canRemoveWorktree",
+    capability: "removeWorktree",
     toolName: "remove_worktree",
     ensureInitialized: true,
     ensureNotSyncing: true,
@@ -296,7 +308,7 @@ export async function handleSync(
   extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { service } = await getReadyService(ctx, params.repoName, {
-    capability: "canSync",
+    capability: "sync",
     toolName: "sync",
     ensureInitialized: true,
   });
@@ -322,7 +334,7 @@ export async function handleUpdateWorktree(
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { git } = await getReadyService(ctx, params.repoName, {
-    capability: "canUpdateWorktree",
+    capability: "updateWorktree",
     toolName: "update_worktree",
     ensureInitialized: true,
     ensureNotSyncing: true,
@@ -344,7 +356,7 @@ export async function handleInitialize(
   extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const { service } = await getReadyService(ctx, params.repoName, {
-    capability: "canInitialize",
+    capability: "initialize",
     toolName: "initialize",
     ensureNotSyncing: true,
   });

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -127,7 +127,11 @@ export async function handleDetectContext(
         ]);
         return {
           ...wt,
-          label: status ? deriveLabel(status, wt.isCurrent) : ("unknown" as const),
+          label: status
+            ? deriveLabel(status, wt.isCurrent)
+            : wt.isCurrent
+              ? ("current" as const)
+              : ("unknown" as const),
           divergence,
           staleHint: status?.upstreamGone ?? false,
         };
@@ -179,7 +183,7 @@ export async function handleListWorktrees(
           path: resolvedPath,
           branch: wt.branch,
           isCurrent,
-          label: status ? deriveLabel(status, isCurrent) : "unknown",
+          label: status ? deriveLabel(status, isCurrent) : isCurrent ? "current" : "unknown",
           status,
           divergence,
           safeToRemove: status ? deriveSafeToRemove(status) : { safe: false, reason: "status unavailable" },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,8 +24,8 @@ const REPO_NAME_DESCRIBE =
 const PATH_DESCRIBE_SUFFIX = "Absolute path preferred; relative paths resolve from the server's CWD.";
 
 const SERVER_INSTRUCTIONS =
-  "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, and which capabilities are available. " +
-  "It reports whether the working directory is inside a sync-worktrees-managed workspace, lists sibling worktrees, and explains why any capability is disabled.";
+  "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, sibling repositories under the workspace root, and which capabilities are available. " +
+  "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, lists sibling worktrees, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
 
 export function createServer(context: RepositoryContext): McpServer {
   const server = new McpServer(
@@ -44,7 +44,7 @@ export function createServer(context: RepositoryContext): McpServer {
     {
       title: "Workspace context",
       description:
-        "Current sync-worktrees workspace context: whether CWD is inside a managed worktree, the current branch, sibling worktrees, and available capabilities. Returns { isWorktree: false } when CWD is outside any workspace.",
+        "Current sync-worktrees workspace context: whether CWD is inside a managed worktree, the current branch, sibling worktrees, sibling repositories, auto-discovered configPath, and per-capability {available, reason}. Returns { isWorktree: false } when CWD is outside any workspace.",
       mimeType: "application/json",
     },
     async (uri) => {
@@ -70,11 +70,17 @@ export function createServer(context: RepositoryContext): McpServer {
     "detect_context",
     {
       description:
-        "Detect sync-worktrees structure from a filesystem path. Reads .git file, resolves bare repo, discovers sibling worktrees. Defaults to CWD. " +
-        "Use when: bootstrapping from an unknown checkout with no config loaded. " +
-        "Returns: discovered repo root, bare repo path, all sibling worktrees, current worktree path, capabilities.",
+        "Detect sync-worktrees structure from a filesystem path. Reads .git file, resolves bare repo, discovers sibling worktrees, walks up for a sync-worktrees.config.{js,mjs,cjs,ts}, and lists sibling bare repos under the workspace root. Defaults to CWD. " +
+        "Use when: bootstrapping from an unknown checkout. " +
+        "Returns: discovered repo root, bare repo path, all sibling worktrees, sibling repositories, current worktree path, configPath (auto-found), per-capability {available, reason}, notes[].",
       inputSchema: {
         path: z.string().optional().describe("Directory path to inspect. Defaults to the server's CWD."),
+        includeStatus: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, enriches each entry in allWorktrees with label, divergence, and staleHint. Adds one git status + rev-list per worktree. Default: false (cheap path).",
+          ),
       },
       annotations: {
         title: "Detect sync-worktrees context",
@@ -91,9 +97,15 @@ export function createServer(context: RepositoryContext): McpServer {
     {
       description:
         "List all worktrees of a repository with enriched status. " +
-        "Returns: array of { path, branch, isCurrent, label (clean|dirty|stale|current|unknown), status, divergence (ahead/behind), safeToRemove, lastSyncAt }.",
+        "Returns: array of { path, branch, isCurrent, label (clean|dirty|stale|current|unknown), status, divergence (ahead/behind), safeToRemove: { safe, reason }, lastSyncAt, sizeBytes }.",
       inputSchema: {
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
+        includeSize: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, computes the on-disk size of each worktree (in bytes). Slow on large worktrees. Default: false (sizeBytes returned as null).",
+          ),
       },
       annotations: {
         title: "List worktrees with status",

--- a/src/mcp/worktree-summary.ts
+++ b/src/mcp/worktree-summary.ts
@@ -22,22 +22,12 @@ export function deriveLabel(status: WorktreeStatusResult, isCurrent: boolean): W
 }
 
 export function deriveSafeToRemove(status: WorktreeStatusResult): SafeToRemove {
-  const safe = status.canRemove && !status.upstreamGone;
-
-  if (safe) {
-    return {
-      safe: true,
-      reason: status.upstreamGone
-        ? "branch deleted upstream, clean tree, no unpushed commits"
-        : "clean tree, no unpushed commits",
-    };
+  if (status.canRemove && !status.upstreamGone) {
+    return { safe: true, reason: "clean tree, no unpushed commits" };
   }
 
-  if (status.upstreamGone && status.canRemove) {
-    return {
-      safe: false,
-      reason: "branch deleted upstream — verify no work is lost before removal",
-    };
+  if (status.canRemove && status.upstreamGone) {
+    return { safe: false, reason: "branch deleted upstream — verify no work is lost before removal" };
   }
 
   if (status.reasons.length > 0) {

--- a/src/mcp/worktree-summary.ts
+++ b/src/mcp/worktree-summary.ts
@@ -1,0 +1,59 @@
+import simpleGit from "simple-git";
+
+import type { WorktreeStatusResult } from "../services/worktree-status.service";
+
+export type WorktreeLabel = "current" | "dirty" | "stale" | "clean" | "unknown";
+
+export interface Divergence {
+  ahead: number;
+  behind: number;
+}
+
+export interface SafeToRemove {
+  safe: boolean;
+  reason: string;
+}
+
+export function deriveLabel(status: WorktreeStatusResult, isCurrent: boolean): WorktreeLabel {
+  if (isCurrent) return "current";
+  if (!status.isClean || status.hasUnpushedCommits || status.hasStashedChanges) return "dirty";
+  if (status.upstreamGone) return "stale";
+  return "clean";
+}
+
+export function deriveSafeToRemove(status: WorktreeStatusResult): SafeToRemove {
+  const safe = status.canRemove && !status.upstreamGone;
+
+  if (safe) {
+    return {
+      safe: true,
+      reason: status.upstreamGone
+        ? "branch deleted upstream, clean tree, no unpushed commits"
+        : "clean tree, no unpushed commits",
+    };
+  }
+
+  if (status.upstreamGone && status.canRemove) {
+    return {
+      safe: false,
+      reason: "branch deleted upstream — verify no work is lost before removal",
+    };
+  }
+
+  if (status.reasons.length > 0) {
+    return { safe: false, reason: status.reasons.join(", ") };
+  }
+
+  return { safe: false, reason: "not safe to remove" };
+}
+
+export async function getDivergence(worktreePath: string): Promise<Divergence | null> {
+  try {
+    const git = simpleGit(worktreePath);
+    const output = await git.raw(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"]);
+    const [aheadStr, behindStr] = output.trim().split(/\s+/);
+    return { ahead: parseInt(aheadStr, 10), behind: parseInt(behindStr, 10) };
+  } catch {
+    return null;
+  }
+}

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -521,7 +521,7 @@ export class InteractiveUIService {
           }
         }
 
-        const sizeBytes = await calculateDirectorySize(fullPath);
+        const sizeBytes = await calculateDirectorySize(fullPath).catch(() => 0);
         const sizeFormatted = formatBytes(sizeBytes);
 
         return {

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -1444,4 +1444,43 @@ describe("ConfigLoaderService", () => {
       expect(resolved.branchExclude).toBeUndefined();
     });
   });
+
+  describe("findConfigUpward", () => {
+    it("returns null when no config exists in path or any parent", async () => {
+      const startDir = path.join(tempDir, "deep", "nested");
+      await fs.mkdir(startDir, { recursive: true });
+
+      const result = await configLoader.findConfigUpward(startDir);
+      expect(result).toBeNull();
+    });
+
+    it("finds config file in same directory", async () => {
+      const configPath = path.join(tempDir, "sync-worktrees.config.js");
+      await fs.writeFile(configPath, "export default { repositories: [] };", "utf-8");
+
+      const result = await configLoader.findConfigUpward(tempDir);
+      expect(result).toBe(configPath);
+    });
+
+    it("finds config file in parent directory", async () => {
+      const configPath = path.join(tempDir, "sync-worktrees.config.js");
+      await fs.writeFile(configPath, "export default { repositories: [] };", "utf-8");
+      const childDir = path.join(tempDir, "child", "grandchild");
+      await fs.mkdir(childDir, { recursive: true });
+
+      const result = await configLoader.findConfigUpward(childDir);
+      expect(result).toBe(configPath);
+    });
+
+    it("matches all four extensions (.js, .mjs, .cjs, .ts)", async () => {
+      for (const ext of ["js", "mjs", "cjs", "ts"]) {
+        const dir = await createTempDirectory(`config-ext-${ext}-`);
+        const configPath = path.join(dir, `sync-worktrees.config.${ext}`);
+        await fs.writeFile(configPath, "// fake", "utf-8");
+
+        const result = await configLoader.findConfigUpward(dir);
+        expect(result).toBe(configPath);
+      }
+    });
+  });
 });

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -1472,8 +1472,8 @@ describe("ConfigLoaderService", () => {
       expect(result).toBe(configPath);
     });
 
-    it("matches all four extensions (.js, .mjs, .cjs, .ts)", async () => {
-      for (const ext of ["js", "mjs", "cjs", "ts"]) {
+    it("matches all supported extensions (.js, .mjs, .cjs)", async () => {
+      for (const ext of ["js", "mjs", "cjs"]) {
         const dir = await createTempDirectory(`config-ext-${ext}-`);
         const configPath = path.join(dir, `sync-worktrees.config.${ext}`);
         await fs.writeFile(configPath, "// fake", "utf-8");

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -9,7 +9,35 @@ import { matchesPattern } from "../utils/branch-filter";
 
 import type { Config, ConfigFile, RepositoryConfig } from "../types";
 
+const CONFIG_FILE_NAMES = [
+  "sync-worktrees.config.js",
+  "sync-worktrees.config.mjs",
+  "sync-worktrees.config.cjs",
+  "sync-worktrees.config.ts",
+] as const;
+
 export class ConfigLoaderService {
+  async findConfigUpward(startDir: string): Promise<string | null> {
+    let current = path.resolve(startDir);
+    const root = path.parse(current).root;
+
+    while (true) {
+      for (const name of CONFIG_FILE_NAMES) {
+        const candidate = path.join(current, name);
+        try {
+          await fs.access(candidate);
+          return candidate;
+        } catch {
+          // continue
+        }
+      }
+      if (current === root) return null;
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      current = parent;
+    }
+  }
+
   async loadConfigFile(configPath: string): Promise<ConfigFile> {
     const absolutePath = path.resolve(configPath);
 

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -4,17 +4,10 @@ import { pathToFileURL } from "url";
 
 import * as cron from "node-cron";
 
-import { DEFAULT_CONFIG } from "../constants";
+import { CONFIG_FILE_NAMES, DEFAULT_CONFIG } from "../constants";
 import { matchesPattern } from "../utils/branch-filter";
 
 import type { Config, ConfigFile, RepositoryConfig } from "../types";
-
-const CONFIG_FILE_NAMES = [
-  "sync-worktrees.config.js",
-  "sync-worktrees.config.mjs",
-  "sync-worktrees.config.cjs",
-  "sync-worktrees.config.ts",
-] as const;
 
 export class ConfigLoaderService {
   async findConfigUpward(startDir: string): Promise<string | null> {
@@ -28,7 +21,7 @@ export class ConfigLoaderService {
           await fs.access(candidate);
           return candidate;
         } catch {
-          // continue
+          /* try next */
         }
       }
       if (current === root) return null;

--- a/src/services/worktree-status.service.ts
+++ b/src/services/worktree-status.service.ts
@@ -138,6 +138,7 @@ export class WorktreeStatusService {
     if (hasUnpushedCommits) reasons.push("unpushed commits");
     if (hasOperationInProgress) reasons.push("operation in progress");
     if (hasModifiedSubmodules) reasons.push("modified submodules");
+    if (upstreamGone) reasons.push("upstream gone");
 
     const canRemove = isClean && !hasUnpushedCommits && !hasOperationInProgress && !hasModifiedSubmodules;
 

--- a/src/utils/__tests__/disk-space.test.ts
+++ b/src/utils/__tests__/disk-space.test.ts
@@ -52,15 +52,14 @@ describe("disk-space", () => {
   });
 
   describe("calculateDirectorySize", () => {
-    it("should return 0 for non-existent directory", async () => {
+    it("should reject for non-existent directory", async () => {
       const fastFolderSize = (await import("fast-folder-size")).default;
       vi.mocked(fastFolderSize).mockImplementationOnce((_path: string, callback: any) => {
         callback(new Error("ENOENT"));
         return {} as any;
       });
 
-      const size = await calculateDirectorySize(path.join(tempDir, "nonexistent"));
-      expect(size).toBe(0);
+      await expect(calculateDirectorySize(path.join(tempDir, "nonexistent"))).rejects.toThrow("ENOENT");
     });
 
     it("should return size for a directory", async () => {
@@ -88,26 +87,24 @@ describe("disk-space", () => {
       expect(size).toBe(0);
     });
 
-    it("should handle undefined bytes from fastFolderSize", async () => {
+    it("should reject when fastFolderSize returns undefined bytes", async () => {
       const fastFolderSize = (await import("fast-folder-size")).default;
       vi.mocked(fastFolderSize).mockImplementationOnce((_path: string, callback: any) => {
         callback(null, undefined);
         return {} as any;
       });
 
-      const size = await calculateDirectorySize(tempDir);
-      expect(size).toBe(0);
+      await expect(calculateDirectorySize(tempDir)).rejects.toThrow("returned no bytes");
     });
 
-    it("should handle errors gracefully", async () => {
+    it("should reject on errors", async () => {
       const fastFolderSize = (await import("fast-folder-size")).default;
       vi.mocked(fastFolderSize).mockImplementationOnce((_path: string, callback: any) => {
         callback(new Error("Permission denied"));
         return {} as any;
       });
 
-      const size = await calculateDirectorySize(tempDir);
-      expect(size).toBe(0);
+      await expect(calculateDirectorySize(tempDir)).rejects.toThrow("Permission denied");
     });
   });
 

--- a/src/utils/config-generator.ts
+++ b/src/utils/config-generator.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
+import { CONFIG_FILE_NAMES } from "../constants";
+
 import { extractRepoNameFromUrl } from "./git-url";
 
 import type { Config } from "../types";
@@ -95,16 +97,14 @@ export function getDefaultConfigPath(): string {
   return path.join(process.cwd(), "sync-worktrees.config.js");
 }
 
-const CONFIG_CANDIDATES = ["sync-worktrees.config.js", "sync-worktrees.config.mjs", "sync-worktrees.config.cjs"];
-
 export async function findConfigInCwd(cwd: string = process.cwd()): Promise<string | null> {
-  for (const name of CONFIG_CANDIDATES) {
+  for (const name of CONFIG_FILE_NAMES) {
     const full = path.join(cwd, name);
     try {
       await fs.access(full);
       return full;
     } catch {
-      // try next
+      /* try next */
     }
   }
   return null;

--- a/src/utils/disk-space.ts
+++ b/src/utils/disk-space.ts
@@ -7,13 +7,17 @@ import fastFolderSize from "fast-folder-size";
  * @returns The total size in bytes
  */
 export async function calculateDirectorySize(dirPath: string): Promise<number> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     fastFolderSize(dirPath, (err, bytes) => {
-      if (err || bytes === undefined) {
-        resolve(0);
-      } else {
-        resolve(bytes);
+      if (err) {
+        reject(err);
+        return;
       }
+      if (bytes === undefined) {
+        reject(new Error(`fast-folder-size returned no bytes for ${dirPath}`));
+        return;
+      }
+      resolve(bytes);
     });
   });
 }
@@ -48,16 +52,20 @@ export async function calculateSyncDiskSpace(repoPaths: string[], worktreeDirs: 
   try {
     let totalBytes = 0;
 
-    // Calculate size of all bare repository directories
     for (const repoPath of repoPaths) {
-      const bareSize = await calculateDirectorySize(repoPath);
-      totalBytes += bareSize;
+      try {
+        totalBytes += await calculateDirectorySize(repoPath);
+      } catch {
+        /* skip unreadable bare repo */
+      }
     }
 
-    // Calculate size of all worktree directories
     for (const worktreeDir of worktreeDirs) {
-      const worktreeSize = await calculateDirectorySize(worktreeDir);
-      totalBytes += worktreeSize;
+      try {
+        totalBytes += await calculateDirectorySize(worktreeDir);
+      } catch {
+        /* skip unreadable worktree dir */
+      }
     }
 
     return formatBytes(totalBytes);


### PR DESCRIPTION
## Summary

- Enriches MCP `detect_context` with upward config auto-discovery, sibling repos, capability gating with reasons, and optional per-worktree status
- Adds `includeSize` + structured `safeToRemove` to `list_worktrees`
- Consolidates context helpers and fixes `deriveSafeToRemove` dead branches
- Addresses ultrareview findings: config auto-detect latching, stale discovery cache, dropped upstream-gone reason, mislabeled current worktree on status failure, dead `.catch` on `calculateDirectorySize`, `.ts` config that cannot load on Node 22.0-22.17, and unused helper params

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` — 983 tests pass
- [ ] Manual: `detect_context` from worktree without config still walks up after first miss
- [ ] Manual: `load_config` followed by `detect_context` returns managed kind within 5s TTL
- [ ] Manual: dirty worktree with deleted upstream shows both reasons in `safeToRemove.reason`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-discovers configuration files in parent directories
  * Detects sibling repositories within your workspace
  * Enriches worktree status with labels, divergence, and staleness indicators (optional via `includeStatus`)
  * Adds per-worktree size calculation (optional via `includeSize`)

* **Improvements**
  * Capability availability now includes specific reasons for unavailability
  * Removal safety indicators now provide structured reason text instead of simple yes/no

<!-- end of auto-generated comment: release notes by coderabbit.ai -->