### PR TITLE
feat(mcp,git): inline connect-time context + show-ref worktree tracking

### DIFF
--- a/.changeset/lean-mcp-instructions.md
+++ b/.changeset/lean-mcp-instructions.md
@@ -1,0 +1,11 @@
+---
+"sync-worktrees": minor
+---
+
+feat(mcp): inline connect-time worktree context into MCP `instructions`
+
+When the MCP server starts inside a managed sync-worktrees worktree, the `instructions` field served to the client now includes a `Connect-time context` block with `kind`, `currentWorktreePath`, `currentBranch`, and `configPath`. This lets agents orient without an initial `detect_context` round-trip.
+
+Snapshot is captured once at server construction. Sibling worktree lists, sibling repository lists, and capability state are intentionally **not** inlined — they belong behind a tool call to avoid prompt staleness and false-authority risk. Base guidance still directs the agent to call `detect_context` for live state.
+
+Falls back to the original static instructions when started outside a managed worktree.

--- a/.changeset/show-ref-worktree-tracking.md
+++ b/.changeset/show-ref-worktree-tracking.md
@@ -1,0 +1,16 @@
+---
+"sync-worktrees": patch
+---
+
+fix(git): skip upstream tracking when remote branch missing in `addWorktree`
+
+`GitService.addWorktree` previously always attempted upstream tracking against `origin/<branch>`, even when the remote ref didn't exist (e.g. MCP `create_worktree` with `push: false` for a brand-new branch). Tracking failed and the code fell back to a non-tracking worktree add with a noisy warning.
+
+Now `addWorktree` probes both refs explicitly via `git show-ref --verify` and branches on `(localExists, remoteExists)`:
+
+- both exist → `worktree add` + `--set-upstream-to`
+- local-only → `worktree add` without upstream (push later via `pushBranch -u` to set tracking)
+- remote-only → `worktree add --track -b`
+- neither → throws a clear `WorktreeError`
+
+The `branchName.includes("/")` shortcut and the prune-retry path were updated to use the same matrix. No status/metadata service changes needed — `rev-list --not --remotes` already handles no-upstream worktrees correctly.

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -260,7 +260,16 @@ branch refs/heads/dirty-branch
         const argsArray = args as string[];
         mockRawCalls.push(argsArray);
 
-        // Handle different git commands
+        if (argsArray[0] === "show-ref" && argsArray[1] === "--verify") {
+          const ref = argsArray[3];
+          if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
+            throw new Error("show-ref: not found");
+          }
+          if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
+            return "";
+          }
+        }
+
         if (argsArray[0] === "worktree" && argsArray[1] === "list" && argsArray[2] === "--porcelain") {
           return `worktree /test/repo
 branch refs/heads/main

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -265,6 +265,31 @@ describe("handleCreateWorktree", () => {
     expect(body.code).toBe("SYNC_IN_PROGRESS");
   });
 
+  it("creates branch and worktree without pushing when push:false (push:false flow)", async () => {
+    const { ctx, git } = makeCtx({
+      git: {
+        branchExists: vi.fn<any>().mockResolvedValue({ local: false, remote: false }),
+      },
+    });
+
+    const result = await invoke(handleCreateWorktree, ctx, {
+      branchName: "feat/ws-communication",
+      baseBranch: "main",
+      push: false,
+    });
+    const body = parseResponse(result);
+
+    expect(body.success).toBe(true);
+    expect(body.created).toBe(true);
+    expect(body.pushed).toBe(false);
+    expect(git.createBranch).toHaveBeenCalledWith("feat/ws-communication", "main");
+    expect(git.addWorktree).toHaveBeenCalledWith(
+      "feat/ws-communication",
+      expect.stringContaining("feat-ws-communication"),
+    );
+    expect(git.pushBranch).not.toHaveBeenCalled();
+  });
+
   it("does not push when addWorktree fails", async () => {
     const addWorktreeError = new Error("addWorktree failed");
     const { ctx, git } = makeCtx({

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -5,7 +5,9 @@ import * as path from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RepositoryContext } from "../context";
-import { createServer } from "../server";
+import { buildInstructions, createServer } from "../server";
+
+import type { DiscoveredRepoContext } from "../context";
 
 const mockRemoteUrl = vi.fn<any>();
 const mockWorktreeList = vi.fn<any>();
@@ -125,5 +127,96 @@ describe("createServer", () => {
       process.chdir(originalCwd);
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("buildInstructions", () => {
+  const baseInstructions =
+    "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, sibling repositories under the workspace root, and which capabilities are available. " +
+    "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, lists sibling worktrees, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
+
+  function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): DiscoveredRepoContext {
+    return {
+      isWorktree: true,
+      kind: "managed",
+      currentBranch: "feature-x",
+      currentWorktreePath: "/repos/my-repo/worktrees/feature-x",
+      bareRepoPath: null,
+      repoUrl: null,
+      worktreeDir: null,
+      allWorktrees: [],
+      siblingRepositories: [],
+      configPath: "/repos/sync-worktrees.config.js",
+      repoName: "my-repo",
+      capabilities: {
+        listWorktrees: { available: true },
+        getStatus: { available: true },
+        createWorktree: { available: true },
+        removeWorktree: { available: true },
+        updateWorktree: { available: true },
+        sync: { available: true },
+        initialize: { available: true },
+      },
+      notes: [],
+      ...overrides,
+    };
+  }
+
+  it("returns base instructions when snapshot is undefined", () => {
+    expect(buildInstructions()).toBe(baseInstructions);
+  });
+
+  it("returns base instructions when discovered is null", () => {
+    expect(buildInstructions({ discovered: null })).toBe(baseInstructions);
+  });
+
+  it("returns base instructions when isWorktree is false", () => {
+    const discovered = makeDiscovered({ isWorktree: false, kind: "unsupported" });
+    expect(buildInstructions({ discovered })).toBe(baseInstructions);
+  });
+
+  it("appends connect-time context when inside a managed worktree", () => {
+    const discovered = makeDiscovered();
+    const result = buildInstructions({ discovered });
+
+    expect(result.startsWith(baseInstructions)).toBe(true);
+    expect(result).toContain("Connect-time context");
+    expect(result).toContain("kind: managed");
+    expect(result).toContain("currentWorktreePath: /repos/my-repo/worktrees/feature-x");
+    expect(result).toContain("currentBranch: feature-x");
+    expect(result).toContain("configPath: /repos/sync-worktrees.config.js");
+  });
+
+  it("omits null fields from connect-time block", () => {
+    const discovered = makeDiscovered({ currentBranch: null, configPath: null });
+    const result = buildInstructions({ discovered });
+
+    expect(result).toContain("Connect-time context");
+    expect(result).toContain("kind: managed");
+    expect(result).toContain("currentWorktreePath:");
+    expect(result).not.toContain("currentBranch:");
+    expect(result).not.toContain("configPath:");
+  });
+
+  it("does not include sibling worktree, sibling repo, or capability lists", () => {
+    const discovered = makeDiscovered({
+      allWorktrees: [
+        { path: "/repos/my-repo/worktrees/main", branch: "main", isCurrent: false },
+        { path: "/repos/my-repo/worktrees/feature-x", branch: "feature-x", isCurrent: true },
+      ],
+      siblingRepositories: [{ name: "other-repo", bareRepoPath: "/repos/other-repo/.bare", configMatched: true }],
+    });
+    const result = buildInstructions({ discovered });
+
+    expect(result).not.toContain("main");
+    expect(result).not.toContain("other-repo");
+    expect(result).not.toContain("Sibling");
+    expect(result).not.toContain("Disabled");
+  });
+
+  it("stays within size budget even with all fields populated", () => {
+    const discovered = makeDiscovered();
+    const result = buildInstructions({ discovered });
+    expect(result.length).toBeLessThanOrEqual(baseInstructions.length + 500);
   });
 });

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -175,6 +175,11 @@ describe("buildInstructions", () => {
     expect(buildInstructions({ discovered })).toBe(baseInstructions);
   });
 
+  it("returns base instructions for unmanaged worktrees", () => {
+    const discovered = makeDiscovered({ kind: "unmanaged" });
+    expect(buildInstructions({ discovered })).toBe(baseInstructions);
+  });
+
   it("appends connect-time context when inside a managed worktree", () => {
     const discovered = makeDiscovered();
     const result = buildInstructions({ discovered });

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,6 +3,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { RepositoryContext } from "./context";
 import { createServer } from "./server";
 
+import type { DiscoveredRepoContext } from "./context";
+
 async function main(): Promise<void> {
   const context = new RepositoryContext();
 
@@ -16,8 +18,9 @@ async function main(): Promise<void> {
     }
   }
 
+  let discovered: DiscoveredRepoContext | null = null;
   try {
-    const discovered = await context.detectFromPath(process.cwd());
+    discovered = await context.detectFromPath(process.cwd());
     if (discovered.isWorktree) {
       process.stderr.write(
         `[sync-worktrees-mcp] Auto-detected ${discovered.kind} worktree at ${discovered.currentWorktreePath} (branch: ${discovered.currentBranch})\n`,
@@ -27,7 +30,7 @@ async function main(): Promise<void> {
     process.stderr.write(`[sync-worktrees-mcp] Auto-detect failed: ${(err as Error).message}\n`);
   }
 
-  const server = createServer(context);
+  const server = createServer(context, { discovered });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -33,7 +33,7 @@ export interface ServerSnapshot {
 
 export function buildInstructions(snapshot?: ServerSnapshot): string {
   const d = snapshot?.discovered;
-  if (!d || !d.isWorktree) return SERVER_INSTRUCTIONS;
+  if (!d || !d.isWorktree || d.kind !== "managed") return SERVER_INSTRUCTIONS;
 
   const lines: string[] = ["Connect-time context (call `detect_context` for live state):"];
   if (d.kind) lines.push(`- kind: ${d.kind}`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,7 +16,7 @@ import {
 } from "./handlers";
 import { wrapHandler } from "./utils";
 
-import type { RepositoryContext } from "./context";
+import type { DiscoveredRepoContext, RepositoryContext } from "./context";
 
 const REPO_NAME_DESCRIBE =
   "Repository name from loaded config. If omitted, uses the current repository set via set_current_repository or the only loaded repo.";
@@ -27,14 +27,31 @@ const SERVER_INSTRUCTIONS =
   "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, sibling repositories under the workspace root, and which capabilities are available. " +
   "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, lists sibling worktrees, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
 
-export function createServer(context: RepositoryContext): McpServer {
+export interface ServerSnapshot {
+  discovered: DiscoveredRepoContext | null;
+}
+
+export function buildInstructions(snapshot?: ServerSnapshot): string {
+  const d = snapshot?.discovered;
+  if (!d || !d.isWorktree) return SERVER_INSTRUCTIONS;
+
+  const lines: string[] = ["Connect-time context (call `detect_context` for live state):"];
+  if (d.kind) lines.push(`- kind: ${d.kind}`);
+  if (d.currentWorktreePath) lines.push(`- currentWorktreePath: ${d.currentWorktreePath}`);
+  if (d.currentBranch) lines.push(`- currentBranch: ${d.currentBranch}`);
+  if (d.configPath) lines.push(`- configPath: ${d.configPath}`);
+
+  return `${SERVER_INSTRUCTIONS}\n\n${lines.join("\n")}`;
+}
+
+export function createServer(context: RepositoryContext, snapshot?: ServerSnapshot): McpServer {
   const server = new McpServer(
     {
       name: "sync-worktrees",
       version: "1.0.0",
     },
     {
-      instructions: SERVER_INSTRUCTIONS,
+      instructions: buildInstructions(snapshot),
     },
   );
 

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -783,6 +783,100 @@ describe("GitService", () => {
         expect(worktreeAddCalls).toHaveLength(0);
       });
 
+      it("should rollback worktree add when --set-upstream-to fails", async () => {
+        const worktreeGitMock = {
+          branch: vi.fn<any>().mockRejectedValue(new Error("fatal: branch 'feature-1' does not point to a commit")),
+          raw: vi.fn<any>().mockResolvedValue(""),
+          revparse: vi.fn<any>().mockResolvedValue("abc123"),
+        };
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: true });
+        mockGit.raw.mockClear();
+
+        await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow(
+          /Failed to set upstream for 'feature-1'.*does not point to a commit/,
+        );
+
+        expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "add", "/test/worktrees/feature-1", "feature-1"]);
+        expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "remove", "--force", "/test/worktrees/feature-1"]);
+      });
+
+      it("should still throw wrapped upstream error if rollback also fails", async () => {
+        const worktreeGitMock = {
+          branch: vi.fn<any>().mockRejectedValue(new Error("upstream-set-failure")),
+          raw: vi.fn<any>().mockResolvedValue(""),
+          revparse: vi.fn<any>().mockResolvedValue("abc123"),
+        };
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: true });
+        mockGit.raw.mockClear();
+        (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+          if (Array.isArray(args)) {
+            if (args[0] === "show-ref" && args[1] === "--verify") {
+              return Promise.resolve("");
+            }
+            if (args[0] === "worktree" && args[1] === "remove") {
+              return Promise.reject(new Error("rollback-failure"));
+            }
+          }
+          return Promise.resolve("");
+        });
+
+        await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow(
+          /Failed to set upstream.*upstream-set-failure.*rollback failed/,
+        );
+        expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Rollback failed"));
+      });
+
+      it("should not enter tracking-error fallback when upstream-set fails with tracking-classified message", async () => {
+        // Fresh add: no existing dir.
+        (fs.access as Mock<any>).mockRejectedValue(new Error("Not found"));
+
+        const worktreeGitMock = {
+          branch: vi.fn<any>().mockRejectedValue(new Error("fatal: no such remote ref refs/remotes/origin/feature-1")),
+          raw: vi.fn<any>().mockResolvedValue(""),
+          revparse: vi.fn<any>().mockResolvedValue("abc123"),
+        };
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: true });
+        mockGit.raw.mockClear();
+        (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+          if (Array.isArray(args)) {
+            if (args[0] === "show-ref" && args[1] === "--verify") {
+              return Promise.resolve("");
+            }
+            if (args[0] === "worktree" && args[1] === "remove") {
+              return Promise.reject(new Error("rollback-failure"));
+            }
+            if (args[0] === "worktree" && args[1] === "list") {
+              return Promise.resolve("");
+            }
+          }
+          return Promise.resolve("");
+        });
+
+        await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow(
+          /Failed to set upstream/,
+        );
+
+        // Only the initial `worktree add <path> <branch>` should fire.
+        // The fallback non-tracking add at addWorktree's L498 must NOT fire.
+        const plainWorktreeAdds = (mockGit.raw as Mock).mock.calls.filter(
+          (call) =>
+            Array.isArray(call[0]) && call[0][0] === "worktree" && call[0][1] === "add" && !call[0].includes("--track"),
+        );
+        expect(plainWorktreeAdds).toHaveLength(1);
+      });
+
       it("should not special-case slash branch names (feat/foo with both refs behaves like normal)", async () => {
         const worktreeGitMock = makeWorktreeGitMock();
         (simpleGit as unknown as Mock).mockImplementation((p?: any) =>

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -57,6 +57,21 @@ describe("GitService", () => {
   let mockMetadataService: any;
   let mockLogger: Logger;
 
+  const mockShowRef = (opts: { local: boolean; remote: boolean }): void => {
+    (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+      if (Array.isArray(args) && args[0] === "show-ref" && args[1] === "--verify") {
+        const ref = args[3];
+        if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
+          return opts.local ? Promise.resolve("") : Promise.reject(new Error("show-ref: not found"));
+        }
+        if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
+          return opts.remote ? Promise.resolve("") : Promise.reject(new Error("show-ref: not found"));
+        }
+      }
+      return Promise.resolve("");
+    });
+  };
+
   beforeEach(() => {
     // Reset all mocks
     vi.clearAllMocks();
@@ -446,14 +461,10 @@ describe("GitService", () => {
     });
 
     it("should add worktree with tracking when branch doesn't exist locally", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
 
-      expect(mockGit.branch).toHaveBeenCalled();
       expect(mockGit.raw).toHaveBeenCalledWith([
         "worktree",
         "add",
@@ -466,10 +477,7 @@ describe("GitService", () => {
     });
 
     it("should add worktree and set upstream when branch exists locally", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: ["feature-1", "main"],
-        current: "main",
-      } as any);
+      mockShowRef({ local: true, remote: true });
 
       const worktreeGitMock = {
         branch: vi.fn<any>().mockResolvedValue(undefined),
@@ -489,7 +497,6 @@ describe("GitService", () => {
 
       await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
 
-      expect(mockGit.branch).toHaveBeenCalled();
       expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "add", "/test/worktrees/feature-1", "feature-1"]);
       expect(worktreeGitMock.branch).toHaveBeenCalledWith(["--set-upstream-to", "origin/feature-1", "feature-1"]);
 
@@ -500,10 +507,7 @@ describe("GitService", () => {
     });
 
     it("should resolve relative paths to absolute paths when adding worktrees", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       await gitService.addWorktree("feature-1", "./test/worktrees/feature-1");
 
@@ -520,17 +524,50 @@ describe("GitService", () => {
     });
 
     it("should fallback to simple add when tracking setup fails with tracking error", async () => {
-      mockGit.branch.mockRejectedValueOnce(new Error("cannot set up tracking"));
+      let trackingAddCalled = false;
+      (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+        if (Array.isArray(args)) {
+          if (args[0] === "show-ref" && args[1] === "--verify") {
+            const ref = args[3];
+            if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
+              return Promise.reject(new Error("show-ref: not found"));
+            }
+            if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
+              return Promise.resolve("");
+            }
+          }
+          if (args[0] === "worktree" && args[1] === "add" && args.includes("--track") && !trackingAddCalled) {
+            trackingAddCalled = true;
+            return Promise.reject(new Error("cannot set up tracking"));
+          }
+        }
+        return Promise.resolve("");
+      });
 
       await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
 
-      // Should have two calls to raw - first failed attempt, then fallback
-      const rawCalls = mockGit.raw.mock.calls.filter((call) => call[0][1] === "add");
+      const rawCalls = mockGit.raw.mock.calls.filter((call) => Array.isArray(call[0]) && call[0][1] === "add");
       expect(rawCalls[rawCalls.length - 1]).toEqual([["worktree", "add", "/test/worktrees/feature-1", "feature-1"]]);
     });
 
     it("should NOT fallback to simple add when a non-tracking error occurs", async () => {
-      mockGit.branch.mockRejectedValueOnce(new Error("Permission denied"));
+      (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+        if (Array.isArray(args)) {
+          if (args[0] === "show-ref" && args[1] === "--verify") {
+            const ref = args[3];
+            if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
+              return Promise.reject(new Error("show-ref: not found"));
+            }
+            if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
+              return Promise.resolve("");
+            }
+          }
+          if (args[0] === "worktree" && args[1] === "add") {
+            return Promise.reject(new Error("Permission denied"));
+          }
+        }
+        return Promise.resolve("");
+      });
 
       await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow(
         "Permission denied",
@@ -538,19 +575,14 @@ describe("GitService", () => {
     });
 
     it("should clean up orphaned directory before creating worktree", async () => {
-      // Mock - directory exists when checking in addWorktree
       (fs.access as Mock<any>).mockResolvedValueOnce(undefined);
 
-      // Reset mockGit.raw and set up responses
       mockGit.raw.mockReset();
       mockGit.raw
         .mockResolvedValueOnce("") // worktree list - empty (directory is not a valid worktree)
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads/feature-1 missing
+        .mockResolvedValueOnce("") // refs/remotes/origin/feature-1 exists
         .mockResolvedValueOnce(""); // worktree add command
-
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
 
       await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
 
@@ -587,34 +619,27 @@ describe("GitService", () => {
     });
 
     it("should clean up orphaned directory in fallback path when tracking fails", async () => {
-      // Mock - directory exists when checking in addWorktree fallback
       (fs.access as Mock<any>)
         .mockRejectedValueOnce(new Error("Not found")) // First check - directory doesn't exist
         .mockResolvedValueOnce(undefined); // Second check in fallback - directory exists
 
-      // Reset mockGit.raw and set up responses
       mockGit.raw.mockReset();
       mockGit.raw
-        .mockRejectedValueOnce(new Error("no such remote ref")) // Initial add with tracking fails (tracking-specific error)
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("no such remote ref")) // tracking add fails
         .mockResolvedValueOnce("") // worktree list - empty (directory is not a valid worktree)
         .mockResolvedValueOnce(""); // fallback worktree add succeeds
-
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
 
       await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
 
       expect(fs.rm).toHaveBeenCalledWith("/test/worktrees/feature-1", { recursive: true, force: true });
-      expect(mockGit.raw).toHaveBeenCalledTimes(4); // Failed tracking add, worktree list, successful fallback add, LFS ls-files
+      // Calls: show-ref heads, show-ref remotes, tracking add (fail), worktree list, fallback add, LFS ls-files
+      expect(mockGit.raw).toHaveBeenCalledTimes(6);
     });
 
     it("should throw error when metadata creation fails", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const metadataError = new Error("Failed to write metadata file");
       mockMetadataService.createInitialMetadataFromPath.mockRejectedValueOnce(metadataError);
@@ -642,16 +667,15 @@ describe("GitService", () => {
 
       mockGit.raw.mockReset();
       mockGit.raw
-        .mockRejectedValueOnce(new Error("fatal: 'feature-1' is already registered worktree")) // Initial add fails - already registered
-        .mockResolvedValueOnce(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feature-1\nprunable\n\n`) // Worktree list shows it's registered but prunable
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("fatal: 'feature-1' is already registered worktree")) // Initial add fails
+        .mockResolvedValueOnce(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feature-1\nprunable\n\n`) // Worktree list shows registered but prunable
         .mockResolvedValueOnce("") // Prune succeeds
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing on retry
+        .mockResolvedValueOnce("") // refs/remotes/origin exists on retry
         .mockResolvedValueOnce("") // Retry add succeeds
         .mockResolvedValueOnce(""); // LFS ls-files
-
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
 
       await gitService.addWorktree("feature-1", worktreePath);
 
@@ -676,19 +700,145 @@ describe("GitService", () => {
 
       mockGit.raw.mockReset();
       mockGit.raw
-        .mockRejectedValueOnce(new Error("fatal: 'feature-1' is already registered worktree")) // Initial add fails - already registered
-        .mockResolvedValueOnce(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feature-1\n\n`); // Worktree list shows it's registered and NOT prunable
-
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("fatal: 'feature-1' is already registered worktree")) // Initial add fails
+        .mockResolvedValueOnce(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feature-1\n\n`); // Registered, NOT prunable
 
       await gitService.addWorktree("feature-1", worktreePath);
 
       expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "list", "--porcelain"]);
       expect(mockGit.raw).not.toHaveBeenCalledWith(["worktree", "prune"]);
       expect(fs.rm).not.toHaveBeenCalled();
+    });
+
+    describe("addWorktree - ref existence matrix", () => {
+      const makeWorktreeGitMock = () => ({
+        branch: vi.fn<any>().mockResolvedValue(undefined),
+        raw: vi.fn<any>().mockResolvedValue(""),
+        revparse: vi.fn<any>().mockResolvedValue("abc123"),
+      });
+
+      it("should add worktree without upstream when local exists but remote does not (push:false flow)", async () => {
+        const worktreeGitMock = makeWorktreeGitMock();
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feat-new") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: false });
+        mockGit.raw.mockClear();
+
+        await gitService.addWorktree("feat-new", "/test/worktrees/feat-new");
+
+        expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "add", "/test/worktrees/feat-new", "feat-new"]);
+        expect(worktreeGitMock.branch).not.toHaveBeenCalled();
+        expect(mockGit.raw).not.toHaveBeenCalledWith(
+          expect.arrayContaining(["worktree", "add", "--track", "-b", "feat-new"]),
+        );
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining("Failed to create worktree with tracking"),
+        );
+      });
+
+      it("should add worktree with upstream when both local and remote exist", async () => {
+        const worktreeGitMock = makeWorktreeGitMock();
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: true });
+
+        await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+        expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "add", "/test/worktrees/feature-1", "feature-1"]);
+        expect(worktreeGitMock.branch).toHaveBeenCalledWith(["--set-upstream-to", "origin/feature-1", "feature-1"]);
+      });
+
+      it("should use --track when local missing but remote exists", async () => {
+        mockShowRef({ local: false, remote: true });
+
+        await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+        expect(mockGit.raw).toHaveBeenCalledWith([
+          "worktree",
+          "add",
+          "--track",
+          "-b",
+          "feature-1",
+          "/test/worktrees/feature-1",
+          "origin/feature-1",
+        ]);
+      });
+
+      it("should throw clear WorktreeError when neither local nor remote ref exists", async () => {
+        mockShowRef({ local: false, remote: false });
+        mockGit.raw.mockClear();
+
+        await expect(gitService.addWorktree("nope", "/test/worktrees/nope")).rejects.toThrow(
+          /does not exist locally or on origin/,
+        );
+        const worktreeAddCalls = mockGit.raw.mock.calls.filter(
+          (call) => Array.isArray(call[0]) && call[0][0] === "worktree" && call[0][1] === "add",
+        );
+        expect(worktreeAddCalls).toHaveLength(0);
+      });
+
+      it("should not special-case slash branch names (feat/foo with both refs behaves like normal)", async () => {
+        const worktreeGitMock = makeWorktreeGitMock();
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feat-foo") ? worktreeGitMock : mockGit,
+        );
+
+        mockShowRef({ local: true, remote: true });
+
+        await gitService.addWorktree("feat/foo", "/test/worktrees/feat-foo");
+
+        expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "add", "/test/worktrees/feat-foo", "feat/foo"]);
+        expect(worktreeGitMock.branch).toHaveBeenCalledWith(["--set-upstream-to", "origin/feat/foo", "feat/foo"]);
+      });
+
+      it("should reuse ref matrix in retry path after pruning (no remote → non-tracking add)", async () => {
+        const worktreePath = "/test/worktrees/feat-new";
+        (fs.access as Mock<any>).mockRejectedValueOnce(new Error("Not found"));
+
+        const worktreeGitMock = makeWorktreeGitMock();
+        (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+          p && p.includes("feat-new") ? worktreeGitMock : mockGit,
+        );
+
+        mockGit.raw.mockClear();
+
+        let initialAddAttempted = false;
+        (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+          if (Array.isArray(args)) {
+            if (args[0] === "show-ref" && args[1] === "--verify") {
+              const ref = args[3];
+              if (typeof ref === "string" && ref.startsWith("refs/heads/")) return Promise.resolve("");
+              if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
+                return Promise.reject(new Error("show-ref: not found"));
+              }
+            }
+            if (args[0] === "worktree" && args[1] === "add" && !initialAddAttempted) {
+              initialAddAttempted = true;
+              return Promise.reject(new Error("fatal: 'feat-new' is already registered worktree"));
+            }
+            if (args[0] === "worktree" && args[1] === "list") {
+              return Promise.resolve(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feat-new\nprunable\n\n`);
+            }
+          }
+          return Promise.resolve("");
+        });
+
+        await gitService.addWorktree("feat-new", worktreePath);
+
+        const trackingAdds = mockGit.raw.mock.calls.filter(
+          (call) => Array.isArray(call[0]) && call[0].includes("--track"),
+        );
+        expect(trackingAdds).toHaveLength(0);
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining("Failed to create worktree with tracking"),
+        );
+      });
     });
   });
 
@@ -699,10 +849,7 @@ describe("GitService", () => {
     });
 
     it("should verify LFS files are downloaded when LFS is not skipped", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const lfsFiles = "file1.png\nfile2.png\nfile3.png\n";
       const worktreeGitMock = {
@@ -747,10 +894,7 @@ describe("GitService", () => {
 
       await gitServiceWithSkipLfs.initialize();
 
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const worktreeGitMock = {
         raw: vi.fn<any>().mockResolvedValue("file1.png\n"),
@@ -771,10 +915,7 @@ describe("GitService", () => {
     });
 
     it("should wait for LFS files to be downloaded if they are pointers", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const lfsFiles = "file1.png\n";
       const worktreeGitMock = {
@@ -812,10 +953,7 @@ describe("GitService", () => {
     });
 
     it("should warn if LFS files are not downloaded after timeout", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const lfsFiles = "file1.png\n";
       const worktreeGitMock = {
@@ -848,10 +986,7 @@ describe("GitService", () => {
     }, 40000);
 
     it("should skip verification if no LFS files exist", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       const worktreeGitMock = {
         raw: vi.fn<any>().mockResolvedValue(""),
@@ -915,10 +1050,7 @@ describe("GitService", () => {
     });
 
     it("should remove worktree when metadata creation fails", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
+      mockShowRef({ local: false, remote: true });
 
       mockMetadataService.createInitialMetadataFromPath.mockRejectedValueOnce(
         new Error("Failed to write metadata file"),
@@ -928,7 +1060,6 @@ describe("GitService", () => {
         "Metadata creation failed for feature-1",
       );
 
-      // Should have attempted to clean up the worktree
       expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "remove", "--force", "/test/worktrees/feature-1"]);
     });
   });
@@ -1270,20 +1401,15 @@ prunable
     });
 
     it("should throw when both tracking and fallback add fail", async () => {
-      // Initial directory check: doesn't exist
       (fs.access as Mock<any>).mockRejectedValueOnce(new Error("Not found"));
-      // Fallback directory check: doesn't exist
       (fs.access as Mock<any>).mockRejectedValueOnce(new Error("Not found"));
-
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
 
       mockGit.raw.mockReset();
       mockGit.raw
-        .mockRejectedValueOnce(new Error("no such remote ref")) // Initial tracking add fails (tracking-specific)
-        .mockRejectedValueOnce(new Error("simple add also failed")); // Fallback add also fails
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("no such remote ref")) // tracking add fails
+        .mockRejectedValueOnce(new Error("simple add also failed")); // fallback add fails
 
       await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow(
         "simple add also failed",
@@ -1293,29 +1419,22 @@ prunable
     it("should throw non-tracking errors immediately without fallback", async () => {
       (fs.access as Mock<any>).mockRejectedValueOnce(new Error("Not found"));
 
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
-
       mockGit.raw.mockReset();
-      mockGit.raw.mockRejectedValueOnce(new Error("disk full"));
+      mockGit.raw
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("disk full")); // tracking add fails non-recoverably
 
       await expect(gitService.addWorktree("feature-1", "/test/worktrees/feature-1")).rejects.toThrow("disk full");
     });
 
     it("should throw metadata error even when worktree cleanup also fails", async () => {
-      mockGit.branch.mockResolvedValueOnce({
-        all: [],
-        current: "main",
-      } as any);
-
-      // Worktree add succeeds, but metadata creation fails
       mockMetadataService.createInitialMetadataFromPath.mockRejectedValueOnce(new Error("Failed to write metadata"));
 
-      // Worktree removal during cleanup also fails
       mockGit.raw.mockReset();
       mockGit.raw
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
         .mockResolvedValueOnce("") // tracking add succeeds
         .mockResolvedValueOnce("") // LFS ls-files verification (no LFS files)
         .mockRejectedValueOnce(new Error("remove also failed")); // cleanup removal fails

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -401,6 +401,12 @@ export class GitService {
     } catch (error) {
       const errorMessage = getErrorMessage(error);
 
+      // Upstream setup failures are already rolled back inside runWorktreeAddByMatrix.
+      // Don't enter the tracking-error fallback (which would silently accept a partial worktree).
+      if ((error as { isUpstreamSetupFailure?: boolean })?.isUpstreamSetupFailure) {
+        throw error;
+      }
+
       // Re-throw metadata creation errors - these are fatal and should not fall back
       if (errorMessage.includes("Metadata creation failed")) {
         throw error;
@@ -543,8 +549,28 @@ export class GitService {
   ): Promise<void> {
     if (localExists && remoteExists) {
       await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
-      const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
-      await worktreeGit.branch(["--set-upstream-to", `origin/${branchName}`, branchName]);
+      try {
+        const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
+        await worktreeGit.branch(["--set-upstream-to", `origin/${branchName}`, branchName]);
+      } catch (error) {
+        let rollbackFailed = false;
+        try {
+          await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
+        } catch (rollbackError) {
+          rollbackFailed = true;
+          this.logger.warn(
+            `  - Rollback failed for '${branchName}' at '${absoluteWorktreePath}' after upstream setup error: ${getErrorMessage(rollbackError)}`,
+          );
+        }
+        // Mark the error so the outer addWorktree catch won't reclassify it as a tracking
+        // error and fall back to a non-tracking add (which would silently accept the partial
+        // worktree without upstream).
+        const detail = getErrorMessage(error);
+        const suffix = rollbackFailed ? " (rollback failed; partial worktree may remain)" : "";
+        const wrapped = new Error(`Failed to set upstream for '${branchName}': ${detail}${suffix}`);
+        (wrapped as Error & { isUpstreamSetupFailure?: boolean }).isUpstreamSetupFailure = true;
+        throw wrapped;
+      }
       return;
     }
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import simpleGit from "simple-git";
 
 import { ENV_CONSTANTS, GIT_CONSTANTS } from "../constants";
+import { WorktreeError } from "../errors";
 import { getDefaultBareRepoDir } from "../utils/git-url";
 import { getErrorMessage } from "../utils/lfs-error";
 import { parseWorktreeListPorcelain } from "../utils/worktree-list-parser";
@@ -365,29 +366,21 @@ export class GitService {
     }
 
     try {
-      // Check if local branch already exists
-      const branches = await bareGit.branch();
-      const localBranchExists = branches.all.includes(branchName);
+      const { local: localBranchExists, remote: remoteBranchExists } = await this.branchExists(branchName);
 
-      if (localBranchExists || branchName.includes("/")) {
-        await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
+      await this.runWorktreeAddByMatrix(
+        bareGit,
+        branchName,
+        absoluteWorktreePath,
+        localBranchExists,
+        remoteBranchExists,
+      );
 
-        const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
-        await worktreeGit.branch(["--set-upstream-to", `origin/${branchName}`, branchName]);
+      if (localBranchExists && !remoteBranchExists) {
+        this.logger.info(`  - Created worktree for '${branchName}' (no remote yet — push to set upstream)`);
       } else {
-        // Create new branch tracking the remote branch
-        await bareGit.raw([
-          "worktree",
-          "add",
-          "--track",
-          "-b",
-          branchName,
-          absoluteWorktreePath,
-          `origin/${branchName}`,
-        ]);
+        this.logger.info(`  - Created worktree for '${branchName}' with tracking to origin/${branchName}`);
       }
-
-      this.logger.info(`  - Created worktree for '${branchName}' with tracking to origin/${branchName}`);
 
       // Verify LFS files are properly downloaded (if not skipping LFS)
       if (!this.isLfsSkipEnabled()) {
@@ -432,17 +425,15 @@ export class GitService {
         } catch {
           // Directory might not exist, ignore
         }
-        // Retry once after pruning
         try {
-          await bareGit.raw([
-            "worktree",
-            "add",
-            "--track",
-            "-b",
+          const { local: localBranchExists, remote: remoteBranchExists } = await this.branchExists(branchName);
+          await this.runWorktreeAddByMatrix(
+            bareGit,
             branchName,
             absoluteWorktreePath,
-            `origin/${branchName}`,
-          ]);
+            localBranchExists,
+            remoteBranchExists,
+          );
           this.logger.info(`  - Created worktree for '${branchName}' after pruning`);
 
           // Verify LFS files are properly downloaded (if not skipping LFS)
@@ -541,6 +532,36 @@ export class GitService {
         throw fallbackError;
       }
     }
+  }
+
+  private async runWorktreeAddByMatrix(
+    bareGit: SimpleGit,
+    branchName: string,
+    absoluteWorktreePath: string,
+    localExists: boolean,
+    remoteExists: boolean,
+  ): Promise<void> {
+    if (localExists && remoteExists) {
+      await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
+      const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
+      await worktreeGit.branch(["--set-upstream-to", `origin/${branchName}`, branchName]);
+      return;
+    }
+
+    if (localExists) {
+      await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
+      return;
+    }
+
+    if (remoteExists) {
+      await bareGit.raw(["worktree", "add", "--track", "-b", branchName, absoluteWorktreePath, `origin/${branchName}`]);
+      return;
+    }
+
+    throw new WorktreeError(
+      `Branch '${branchName}' does not exist locally or on origin; create it first`,
+      "BRANCH_NOT_FOUND",
+    );
   }
 
   async removeWorktree(worktreePath: string): Promise<void> {
@@ -801,12 +822,19 @@ export class GitService {
 
   async branchExists(branchName: string): Promise<{ local: boolean; remote: boolean }> {
     const bareGit = this.getCachedGit(this.bareRepoPath);
+    const checkRef = async (ref: string): Promise<boolean> => {
+      try {
+        await bareGit.raw(["show-ref", "--verify", "--quiet", ref]);
+        return true;
+      } catch {
+        return false;
+      }
+    };
 
-    const localBranches = await bareGit.branch();
-    const local = localBranches.all.includes(branchName);
-
-    const remoteBranches = await bareGit.branch(["-r"]);
-    const remote = remoteBranches.all.includes(`origin/${branchName}`);
+    const [local, remote] = await Promise.all([
+      checkRef(`${GIT_CONSTANTS.REFS.HEADS}${branchName}`),
+      checkRef(`${GIT_CONSTANTS.REFS.REMOTES}/${branchName}`),
+    ]);
 
     return { local, remote };
   }


### PR DESCRIPTION
## Summary

- **MCP `instructions` enrichment**: when the server starts inside a managed sync-worktrees worktree, the `instructions` field now appends a `Connect-time context` block with `kind`, `currentWorktreePath`, `currentBranch`, `configPath`. Lets agents orient without an initial `detect_context` round-trip. Sibling lists and capability state intentionally not inlined — they stay behind tool calls to avoid prompt staleness.
- **`GitService.addWorktree` ref-existence matrix**: probes `refs/heads/<branch>` and `refs/remotes/origin/<branch>` via `git show-ref --verify --quiet` (parallelized with `Promise.all`). Decision matrix on `(local, remote)`:
  - both → `worktree add` + `--set-upstream-to`
  - local-only → `worktree add` (no upstream — push later via `pushBranch -u`)
  - remote-only → `worktree add --track -b`
  - neither → throws `WorktreeError("BRANCH_NOT_FOUND")`
  Fixes noisy fallback warning when MCP `create_worktree` runs with `push:false` against a brand-new branch.
- **Unified ref probing**: `branchExists` rewritten on top of `show-ref` (cheaper than parsing `git branch` output, and parallelized). MCP handler and `GitService.addWorktree` share one implementation now.
- **Logging cleanup**: collapsed three-branch logger cascade after the matrix call (two cases emitted identical strings).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 51 files, 997 tests pass
- [x] New tests added: `buildInstructions` (6 cases), ref-existence matrix (6 cases), `push:false` flow in `handleCreateWorktree`
- [ ] Manual: MCP `create_worktree` against a managed worktree with `push:false` on a brand-new branch — confirm no fallback warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP server now includes connect-time context in instructions when running in a managed worktree, providing worktree path, current branch, and config information for faster agent orientation.

* **Improvements**
  * Enhanced worktree creation with improved local and remote branch reference detection, enabling smarter upstream tracking decisions.

* **Tests**
  * Added comprehensive test coverage for worktree creation and MCP server instructions handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->