### PR TITLE
feat(sparse): sparse-checkout + multi-entry same-repo support

### DIFF
--- a/.changeset/sparse-checkout-multi-entry.md
+++ b/.changeset/sparse-checkout-multi-entry.md
@@ -1,0 +1,9 @@
+---
+"sync-worktrees": minor
+---
+
+Add `sparseCheckout` config option for monorepos. Each repo entry can declare `{ include, exclude?, mode? }` to clone only a subset of folders/files. Cone mode is the default; explicit excludes or `!`-negation patterns auto-promote to `no-cone`.
+
+Same `repoUrl` may now appear under multiple repository entries with different `name`s, sparse patterns, and `worktreeDir`s. The first entry per `repoUrl` keeps the URL-derived bare path (`.bare/<repo-slug>`); subsequent duplicates auto-derive `.bare/<sanitized-name>` so they do not collide. Pin `bareRepoDir` explicitly to make config order irrelevant.
+
+Sync-time reapply reconciles existing worktrees with the latest sparse config in parallel. Narrowing (removing previously included paths) is skipped with a warning when the worktree has uncommitted changes. Worktree creation now uses `git worktree add --no-checkout` followed by sparse setup and `git checkout HEAD`, with transactional rollback (worktree remove + branch delete for newly created branches) on any post-add failure. LFS verification picks up `GIT_ATTR_SOURCE=HEAD` so `.gitattributes` is honored under sparse on Git ≥ 2.42.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,45 @@ rm -rf .diverged/2024-01-15-feature-x
 
 This ensures you never lose work due to force pushes while keeping your worktrees in sync with upstream.
 
+### Sparse Checkout
+
+For monorepos where you only need a subset of folders, set `sparseCheckout` per repository entry. The tool runs `git worktree add --no-checkout`, configures sparse-checkout, then materializes only the included paths. The same repository can be listed multiple times under different `name`s with different sparse patterns to build domain-grouped layouts.
+
+```js
+export default {
+  repositories: [
+    {
+      name: "roulette-game-client",
+      repoUrl: "https://github.com/acme/casino-monorepo.git",
+      worktreeDir: "/Users/me/game-clients/roulette",
+      sparseCheckout: { include: ["game-client"] },
+    },
+    {
+      name: "roulette-autocue",
+      repoUrl: "https://github.com/acme/casino-monorepo.git",
+      worktreeDir: "/Users/me/autocues/roulette",
+      sparseCheckout: { include: ["autocue"] },
+      // bareRepoDir: ".bare/roulette-autocue", // pin to make config reorder-proof
+    },
+  ],
+};
+```
+
+**Modes:**
+
+- `cone` (default): pass folder names in `include`. Fast and recommended.
+- `no-cone`: pass gitignore-style patterns including `!negation`. Required for `exclude` and any `!`-prefixed include.
+
+If you set `exclude` or use `!`-prefixed patterns while `mode: "cone"` is explicit, the tool auto-promotes to `no-cone` and logs a warning.
+
+**Duplicate `repoUrl` handling:**
+
+The first entry per `repoUrl` keeps the URL-derived bare path (`.bare/<repo-slug>`). Subsequent duplicate entries auto-derive `bareRepoDir` from `name` (`.bare/<name>`) so they do not collide. Pin `bareRepoDir` explicitly on duplicate entries if you want config order to be irrelevant.
+
+**Narrowing safety:**
+
+When a sync would narrow an existing worktree's sparse patterns (remove a previously included path), it first checks the worktree is clean. If there are uncommitted changes, unpushed commits, or in-progress operations, the sparse update is skipped with a warning. Clean or stash local changes to apply the narrower patterns.
+
 ## Requirements
 
 - Node.js >= 22.0.0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,6 +77,7 @@ export const TEST_TIMEOUT = {
 
 export const ENV_CONSTANTS = {
   GIT_LFS_SKIP_SMUDGE: "GIT_LFS_SKIP_SMUDGE",
+  GIT_ATTR_SOURCE: "GIT_ATTR_SOURCE",
   NODE_ENV_TEST: "test",
 } as const;
 

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -130,13 +130,6 @@ export class RepositoryContext {
     const absolutePath = path.resolve(configPath);
     const configFile = await this.configLoader.loadConfigFile(absolutePath);
 
-    for (const [name, entry] of this.repos) {
-      if (entry.source === "config") {
-        this.repos.delete(name);
-      }
-    }
-
-    this.configPath = absolutePath;
     const configDir = path.dirname(absolutePath);
     const globalDefaults = configFile.defaults;
 
@@ -150,13 +143,23 @@ export class RepositoryContext {
         configFile.repositories,
       );
       resolvedAll.push(resolved);
+    }
+    this.configLoader.detectBareRepoDirCollisions(resolvedAll);
+
+    for (const [name, entry] of this.repos) {
+      if (entry.source === "config") {
+        this.repos.delete(name);
+      }
+    }
+
+    this.configPath = absolutePath;
+    for (const resolved of resolvedAll) {
       this.repos.set(resolved.name, {
         name: resolved.name,
         config: resolved,
         source: "config",
       });
     }
-    this.configLoader.detectBareRepoDirCollisions(resolvedAll);
 
     if (this.currentRepo && !this.repos.has(this.currentRepo)) {
       this.currentRepo = null;

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -140,14 +140,23 @@ export class RepositoryContext {
     const configDir = path.dirname(absolutePath);
     const globalDefaults = configFile.defaults;
 
+    const resolvedAll: RepositoryConfig[] = [];
     for (const repo of configFile.repositories) {
-      const resolved = this.configLoader.resolveRepositoryConfig(repo, globalDefaults, configDir, configFile.retry);
+      const resolved = this.configLoader.resolveRepositoryConfig(
+        repo,
+        globalDefaults,
+        configDir,
+        configFile.retry,
+        configFile.repositories,
+      );
+      resolvedAll.push(resolved);
       this.repos.set(resolved.name, {
         name: resolved.name,
         config: resolved,
         source: "config",
       });
     }
+    this.configLoader.detectBareRepoDirCollisions(resolvedAll);
 
     if (this.currentRepo && !this.repos.has(this.currentRepo)) {
       this.currentRepo = null;

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -1483,4 +1483,207 @@ describe("ConfigLoaderService", () => {
       }
     });
   });
+
+  describe("sparseCheckout validation", () => {
+    async function loadInline(content: string): Promise<unknown> {
+      const configPath = path.join(tempDir, "test.config.js");
+      await fs.writeFile(configPath, content, "utf-8");
+      return configLoader.loadConfigFile(configPath);
+    }
+
+    it("rejects sparseCheckout missing include", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { exclude: ["docs"] } }] };`;
+      await expect(loadInline(c)).rejects.toThrow(/'sparseCheckout.include'.*must be an array/);
+    });
+
+    it("rejects empty include array", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { include: [] } }] };`;
+      await expect(loadInline(c)).rejects.toThrow(/at least one pattern/);
+    });
+
+    it("rejects bad mode", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { include: ["a"], mode: "weird" } }] };`;
+      await expect(loadInline(c)).rejects.toThrow(/must be 'cone' or 'no-cone'/);
+    });
+
+    it("rejects empty include strings", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { include: ["a", ""] } }] };`;
+      await expect(loadInline(c)).rejects.toThrow(/non-empty strings/);
+    });
+
+    it("accepts valid cone config", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { include: ["apps", "packages"] } }] };`;
+      await expect(loadInline(c)).resolves.toBeDefined();
+    });
+
+    it("accepts valid no-cone config with excludes", async () => {
+      const c = `export default { repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w", sparseCheckout: { include: ["/*"], exclude: ["docs"], mode: "no-cone" } }] };`;
+      await expect(loadInline(c)).resolves.toBeDefined();
+    });
+
+    it("validates sparseCheckout in defaults", async () => {
+      const c = `export default { defaults: { sparseCheckout: { include: [] } }, repositories: [{ name: "r", repoUrl: "${TEST_URLS.github}", worktreeDir: "/w" }] };`;
+      await expect(loadInline(c)).rejects.toThrow(/at least one pattern/);
+    });
+  });
+
+  describe("resolveRepositoryConfig - sparseCheckout merge", () => {
+    it("uses repo sparseCheckout over defaults", () => {
+      const repo = {
+        name: "r",
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "/w",
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+        sparseCheckout: { include: ["apps"] },
+      };
+      const defaults = { sparseCheckout: { include: ["packages"] } };
+      const resolved = configLoader.resolveRepositoryConfig(repo, defaults);
+      expect(resolved.sparseCheckout).toEqual({ include: ["apps"] });
+    });
+
+    it("falls back to defaults sparseCheckout", () => {
+      const repo = {
+        name: "r",
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "/w",
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+      };
+      const defaults = { sparseCheckout: { include: ["packages"] } };
+      const resolved = configLoader.resolveRepositoryConfig(repo, defaults);
+      expect(resolved.sparseCheckout).toEqual({ include: ["packages"] });
+    });
+
+    it("leaves sparseCheckout undefined when neither set", () => {
+      const repo = {
+        name: "r",
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "/w",
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+      };
+      const resolved = configLoader.resolveRepositoryConfig(repo);
+      expect(resolved.sparseCheckout).toBeUndefined();
+    });
+  });
+
+  describe("resolveRepositoryConfig - asymmetric bareRepoDir for duplicate repoUrl", () => {
+    const monorepoUrl = "https://github.com/acme/monorepo.git";
+
+    function makeRepo(name: string, overrides: Record<string, unknown> = {}) {
+      return {
+        name,
+        repoUrl: monorepoUrl,
+        worktreeDir: `/wt/${name}`,
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+        ...overrides,
+      };
+    }
+
+    it("first entry uses URL-derived bareRepoDir", () => {
+      const all = [makeRepo("first"), makeRepo("second")];
+      const resolved = configLoader.resolveRepositoryConfig(all[0], undefined, "/cfg", undefined, all);
+      expect(resolved.bareRepoDir).toBe("/cfg/.bare/monorepo");
+    });
+
+    it("second duplicate entry uses name-derived bareRepoDir", () => {
+      const all = [makeRepo("first"), makeRepo("second-name")];
+      const resolved = configLoader.resolveRepositoryConfig(all[1], undefined, "/cfg", undefined, all);
+      expect(resolved.bareRepoDir).toBe("/cfg/.bare/second-name");
+    });
+
+    it("explicit bareRepoDir always wins", () => {
+      const all = [
+        makeRepo("first", { bareRepoDir: "/explicit/first" }),
+        makeRepo("second", { bareRepoDir: "/explicit/second" }),
+      ];
+      const r1 = configLoader.resolveRepositoryConfig(all[0], undefined, "/cfg", undefined, all);
+      const r2 = configLoader.resolveRepositoryConfig(all[1], undefined, "/cfg", undefined, all);
+      expect(r1.bareRepoDir).toBe("/explicit/first");
+      expect(r2.bareRepoDir).toBe("/explicit/second");
+    });
+
+    it("non-duplicate entry keeps URL-derived default", () => {
+      const repos = [
+        makeRepo("a"),
+        {
+          name: "b",
+          repoUrl: "https://github.com/other/repo.git",
+          worktreeDir: "/wt/b",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+        },
+      ];
+      const r2 = configLoader.resolveRepositoryConfig(repos[1], undefined, "/cfg", undefined, repos);
+      expect(r2.bareRepoDir).toBe("/cfg/.bare/repo");
+    });
+
+    it("sanitizes name with slashes for path", () => {
+      const all = [makeRepo("first"), makeRepo("group/sub-name")];
+      const resolved = configLoader.resolveRepositoryConfig(all[1], undefined, "/cfg", undefined, all);
+      expect(resolved.bareRepoDir).toBe("/cfg/.bare/group-sub-name");
+    });
+
+    it("rejects name that sanitizes to empty", () => {
+      const all = [makeRepo("first"), makeRepo("...")];
+      expect(() => configLoader.resolveRepositoryConfig(all[1], undefined, "/cfg", undefined, all)).toThrow(
+        /empty path segment/,
+      );
+    });
+
+    it("rejects Windows-reserved name", () => {
+      const all = [makeRepo("first"), makeRepo("CON")];
+      expect(() => configLoader.resolveRepositoryConfig(all[1], undefined, "/cfg", undefined, all)).toThrow(
+        /reserved name/,
+      );
+    });
+  });
+
+  describe("detectBareRepoDirCollisions", () => {
+    it("throws when two repos resolve to same bareRepoDir", () => {
+      const repos = [
+        {
+          name: "a",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/a",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/shared/.bare/x",
+        },
+        {
+          name: "b",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/b",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/shared/.bare/x",
+        },
+      ];
+      expect(() => configLoader.detectBareRepoDirCollisions(repos)).toThrow(/same bareRepoDir/);
+    });
+
+    it("does not throw when bareRepoDirs differ", () => {
+      const repos = [
+        {
+          name: "a",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/a",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/a/.bare",
+        },
+        {
+          name: "b",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/b",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/b/.bare",
+        },
+      ];
+      expect(() => configLoader.detectBareRepoDirCollisions(repos)).not.toThrow();
+    });
+  });
 });

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -1685,5 +1685,28 @@ describe("ConfigLoaderService", () => {
       ];
       expect(() => configLoader.detectBareRepoDirCollisions(repos)).not.toThrow();
     });
+
+    it("detects collision across case-only differences on case-insensitive filesystems", () => {
+      if (process.platform !== "darwin") return;
+      const repos = [
+        {
+          name: "a",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/a",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/Users/Me/.bare/x",
+        },
+        {
+          name: "b",
+          repoUrl: "https://github.com/x/y.git",
+          worktreeDir: "/w/b",
+          cronSchedule: "0 * * * *",
+          runOnce: false,
+          bareRepoDir: "/users/me/.bare/x",
+        },
+      ];
+      expect(() => configLoader.detectBareRepoDirCollisions(repos)).toThrow(/same bareRepoDir/);
+    });
   });
 });

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -1573,4 +1573,134 @@ prunable
       expect(git).toBe(mockGit);
     });
   });
+
+  describe("addWorktree with sparseCheckout", () => {
+    it("adds --no-checkout, runs sparse init/set, then checkout HEAD", async () => {
+      const sparseConfig: Config = {
+        ...createMockConfig(),
+        sparseCheckout: { include: ["apps", "packages"] },
+      };
+
+      const worktreeRawCalls: string[][] = [];
+      const worktreeGitMock: any = {
+        branch: vi.fn<any>().mockResolvedValue(undefined),
+        raw: vi.fn<any>().mockImplementation((...args: unknown[]) => {
+          worktreeRawCalls.push(args[0] as string[]);
+          return Promise.resolve("");
+        }),
+        revparse: vi.fn<any>().mockResolvedValue("abc123"),
+      };
+      worktreeGitMock.env = vi.fn(() => worktreeGitMock);
+
+      (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+        p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+      );
+
+      mockShowRef({ local: false, remote: true });
+
+      const sparseGitService = new GitService(sparseConfig, mockLogger);
+      mockGit.raw.mockClear();
+
+      await sparseGitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+      expect(mockGit.raw).toHaveBeenCalledWith([
+        "worktree",
+        "add",
+        "--no-checkout",
+        "--track",
+        "-b",
+        "feature-1",
+        "/test/worktrees/feature-1",
+        "origin/feature-1",
+      ]);
+      expect(worktreeRawCalls).toEqual(
+        expect.arrayContaining([
+          ["sparse-checkout", "init", "--cone"],
+          ["sparse-checkout", "set", "--cone", "apps", "packages"],
+          ["checkout", "HEAD"],
+        ]),
+      );
+    });
+
+    it("uses --no-cone for excludes config", async () => {
+      const sparseConfig: Config = {
+        ...createMockConfig(),
+        sparseCheckout: { include: ["/*"], exclude: ["docs"] },
+      };
+
+      const worktreeRawCalls: string[][] = [];
+      const worktreeGitMock: any = {
+        branch: vi.fn<any>().mockResolvedValue(undefined),
+        raw: vi.fn<any>().mockImplementation((...args: unknown[]) => {
+          worktreeRawCalls.push(args[0] as string[]);
+          return Promise.resolve("");
+        }),
+        revparse: vi.fn<any>().mockResolvedValue("abc123"),
+      };
+      worktreeGitMock.env = vi.fn(() => worktreeGitMock);
+
+      (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+        p && p.includes("feature-1") ? worktreeGitMock : mockGit,
+      );
+
+      mockShowRef({ local: true, remote: false });
+
+      const sparseGitService = new GitService(sparseConfig, mockLogger);
+
+      await sparseGitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+      expect(worktreeRawCalls).toEqual(
+        expect.arrayContaining([
+          ["sparse-checkout", "init", "--no-cone"],
+          ["sparse-checkout", "set", "--no-cone", "/*", "!docs"],
+          ["checkout", "HEAD"],
+        ]),
+      );
+    });
+
+    it("does not pass --no-checkout when sparseCheckout is unset", async () => {
+      mockShowRef({ local: true, remote: false });
+      mockGit.raw.mockClear();
+
+      await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+      const calls = (mockGit.raw as Mock).mock.calls.map((c) => (Array.isArray(c[0]) ? c[0] : []));
+      const hasNoCheckout = calls.some(
+        (args: any[]) => args[0] === "worktree" && args[1] === "add" && args.includes("--no-checkout"),
+      );
+      expect(hasNoCheckout).toBe(false);
+    });
+
+    it("rolls back worktree and deletes new branch when sparse apply fails (track-new variant)", async () => {
+      const sparseConfig: Config = {
+        ...createMockConfig(),
+        sparseCheckout: { include: ["apps"] },
+      };
+
+      const worktreeGitMock = {
+        branch: vi.fn<any>().mockResolvedValue(undefined),
+        raw: vi
+          .fn<any>()
+          .mockImplementationOnce(() => Promise.reject(new Error("sparse-checkout init blew up")))
+          .mockResolvedValue(""),
+        revparse: vi.fn<any>().mockResolvedValue("abc123"),
+      };
+
+      (simpleGit as unknown as Mock).mockImplementation((p?: any) =>
+        p && p.includes("feat-new") ? worktreeGitMock : mockGit,
+      );
+
+      mockShowRef({ local: false, remote: true });
+
+      const sparseGitService = new GitService(sparseConfig, mockLogger);
+      mockGit.raw.mockClear();
+
+      await expect(sparseGitService.addWorktree("feat-new", "/test/worktrees/feat-new")).rejects.toThrow(
+        /Sparse-checkout setup failed/,
+      );
+
+      expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "remove", "--force", "/test/worktrees/feat-new"]);
+      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "-D", "feat-new"]);
+    });
+  });
 });

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -47,6 +47,10 @@ describe("SparseCheckoutService", () => {
       expect(service.resolveMode({ include: ["/*", "!docs"] })).toBe("no-cone");
     });
 
+    it("auto-promotes cone to no-cone when negation pattern has surrounding whitespace", () => {
+      expect(service.resolveMode({ include: ["/*", "  !docs"] })).toBe("no-cone");
+    });
+
     it("warns when explicit cone is auto-promoted", () => {
       service.resolveMode({ include: ["/*"], exclude: ["docs"], mode: "cone" });
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("auto-promoting"));

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SparseCheckoutService } from "../sparse-checkout.service";
+
+import type { SparseCheckoutConfig } from "../../types";
+import type { Logger } from "../logger.service";
+import type { SimpleGit } from "simple-git";
+
+function createMockGit() {
+  return {
+    raw: vi.fn(),
+  } as unknown as SimpleGit & { raw: ReturnType<typeof vi.fn> };
+}
+
+describe("SparseCheckoutService", () => {
+  let service: SparseCheckoutService;
+  let logger: Logger;
+  let warnSpy: ReturnType<typeof vi.fn>;
+  let mockGit: ReturnType<typeof createMockGit>;
+
+  beforeEach(() => {
+    warnSpy = vi.fn();
+    logger = {
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+    mockGit = createMockGit();
+    service = new SparseCheckoutService(logger, () => mockGit);
+  });
+
+  describe("resolveMode", () => {
+    it("defaults to cone when mode unset, no exclude, no negation", () => {
+      expect(service.resolveMode({ include: ["apps", "packages"] })).toBe("cone");
+    });
+
+    it("returns no-cone when explicit", () => {
+      expect(service.resolveMode({ include: ["apps"], mode: "no-cone" })).toBe("no-cone");
+    });
+
+    it("auto-promotes cone to no-cone when exclude present", () => {
+      expect(service.resolveMode({ include: ["/*"], exclude: ["docs"] })).toBe("no-cone");
+    });
+
+    it("auto-promotes cone to no-cone when include has negation", () => {
+      expect(service.resolveMode({ include: ["/*", "!docs"] })).toBe("no-cone");
+    });
+
+    it("warns when explicit cone is auto-promoted", () => {
+      service.resolveMode({ include: ["/*"], exclude: ["docs"], mode: "cone" });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("auto-promoting"));
+    });
+
+    it("does not warn when mode is unset and auto-promoted", () => {
+      service.resolveMode({ include: ["/*"], exclude: ["docs"] });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("buildPatterns", () => {
+    it("returns include list as-is for cone", () => {
+      expect(service.buildPatterns({ include: ["apps", "packages"] })).toEqual(["apps", "packages"]);
+    });
+
+    it("appends excludes as !-prefixed lines for no-cone", () => {
+      expect(service.buildPatterns({ include: ["/*"], exclude: ["docs", "vendor"] })).toEqual([
+        "/*",
+        "!docs",
+        "!vendor",
+      ]);
+    });
+
+    it("preserves existing !-prefix on excludes", () => {
+      expect(service.buildPatterns({ include: ["/*"], exclude: ["!docs"] })).toEqual(["/*", "!docs"]);
+    });
+
+    it("trims whitespace and drops empty entries", () => {
+      expect(service.buildPatterns({ include: ["  apps  ", "", "packages"] })).toEqual(["apps", "packages"]);
+    });
+  });
+
+  describe("applyToWorktree", () => {
+    it("runs init --cone then set --cone <patterns> for cone mode", async () => {
+      mockGit.raw.mockResolvedValue("");
+      await service.applyToWorktree("/wt", { include: ["apps", "packages"] });
+      expect(mockGit.raw).toHaveBeenNthCalledWith(1, ["sparse-checkout", "init", "--cone"]);
+      expect(mockGit.raw).toHaveBeenNthCalledWith(2, ["sparse-checkout", "set", "--cone", "apps", "packages"]);
+    });
+
+    it("runs init --no-cone then set --no-cone <patterns> for no-cone mode", async () => {
+      mockGit.raw.mockResolvedValue("");
+      await service.applyToWorktree("/wt", { include: ["/*"], exclude: ["docs"] });
+      expect(mockGit.raw).toHaveBeenNthCalledWith(1, ["sparse-checkout", "init", "--no-cone"]);
+      expect(mockGit.raw).toHaveBeenNthCalledWith(2, ["sparse-checkout", "set", "--no-cone", "/*", "!docs"]);
+    });
+
+    it("throws if patterns are empty", async () => {
+      await expect(service.applyToWorktree("/wt", { include: ["", "  "] })).rejects.toThrow(/no patterns/);
+    });
+  });
+
+  describe("readCurrent", () => {
+    it("parses sparse-checkout list output to non-empty array", async () => {
+      mockGit.raw.mockResolvedValue("apps\npackages\n");
+      const out = await service.readCurrent("/wt");
+      expect(out).toEqual(["apps", "packages"]);
+    });
+
+    it("returns null on empty output", async () => {
+      mockGit.raw.mockResolvedValue("");
+      expect(await service.readCurrent("/wt")).toBeNull();
+    });
+
+    it("returns null when git command fails", async () => {
+      mockGit.raw.mockRejectedValue(new Error("not configured"));
+      expect(await service.readCurrent("/wt")).toBeNull();
+    });
+
+    it("filters comment and blank lines", async () => {
+      mockGit.raw.mockResolvedValue("# heading\n\napps\n");
+      expect(await service.readCurrent("/wt")).toEqual(["apps"]);
+    });
+  });
+
+  describe("needsUpdate", () => {
+    const cfg: SparseCheckoutConfig = { include: ["apps"] };
+
+    it("returns true when not configured", async () => {
+      mockGit.raw.mockResolvedValue("");
+      expect(await service.needsUpdate("/wt", cfg)).toBe(true);
+    });
+
+    it("returns false when current matches desired (order-insensitive)", async () => {
+      mockGit.raw.mockResolvedValue("apps\n");
+      expect(await service.needsUpdate("/wt", cfg)).toBe(false);
+    });
+
+    it("returns true when patterns differ", async () => {
+      mockGit.raw.mockResolvedValue("apps\npackages\n");
+      expect(await service.needsUpdate("/wt", cfg)).toBe(true);
+    });
+  });
+
+  describe("isNarrowing", () => {
+    it("returns false when current is null or empty", () => {
+      expect(service.isNarrowing(null, ["apps"])).toBe(false);
+      expect(service.isNarrowing([], ["apps"])).toBe(false);
+    });
+
+    it("returns true when next omits a current pattern", () => {
+      expect(service.isNarrowing(["apps", "packages"], ["apps"])).toBe(true);
+    });
+
+    it("returns false when next is a superset", () => {
+      expect(service.isNarrowing(["apps"], ["apps", "packages"])).toBe(false);
+    });
+
+    it("returns false when sets are identical", () => {
+      expect(service.isNarrowing(["apps"], ["apps"])).toBe(false);
+    });
+  });
+});

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -58,7 +58,7 @@ describe("SparseCheckoutService", () => {
     });
 
     it("warns only once per config instance even across many calls", () => {
-      const cfg = { include: ["/*"], exclude: ["docs"], mode: "cone" } as const;
+      const cfg: SparseCheckoutConfig = { include: ["/*"], exclude: ["docs"], mode: "cone" };
       service.resolveMode(cfg);
       service.resolveMode(cfg);
       service.buildPatterns(cfg);

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -56,6 +56,26 @@ describe("SparseCheckoutService", () => {
       service.resolveMode({ include: ["/*"], exclude: ["docs"] });
       expect(warnSpy).not.toHaveBeenCalled();
     });
+
+    it("warns only once per config instance even across many calls", () => {
+      const cfg = { include: ["/*"], exclude: ["docs"], mode: "cone" } as const;
+      service.resolveMode(cfg);
+      service.resolveMode(cfg);
+      service.buildPatterns(cfg);
+      service.buildPatterns(cfg);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("updateLogger", () => {
+    it("redirects subsequent warnings to the new logger", () => {
+      const newWarn = vi.fn();
+      const newLogger = { info: vi.fn(), warn: newWarn, error: vi.fn(), debug: vi.fn() } as unknown as Logger;
+      service.updateLogger(newLogger);
+      service.resolveMode({ include: ["/*"], exclude: ["docs"], mode: "cone" });
+      expect(newWarn).toHaveBeenCalledWith(expect.stringContaining("auto-promoting"));
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("buildPatterns", () => {
@@ -158,6 +178,32 @@ describe("SparseCheckoutService", () => {
 
     it("returns false when sets are identical", () => {
       expect(service.isNarrowing(["apps"], ["apps"])).toBe(false);
+    });
+
+    it("returns true when an exclude is added (no-cone narrowing)", () => {
+      expect(service.isNarrowing(["/*", "!docs"], ["/*", "!docs", "!vendor"])).toBe(true);
+    });
+
+    it("returns false when an exclude is removed (no-cone widening)", () => {
+      expect(service.isNarrowing(["/*", "!docs", "!vendor"], ["/*", "!docs"])).toBe(false);
+    });
+
+    it("returns true when a positive include is removed but negatives are unchanged", () => {
+      expect(service.isNarrowing(["/*", "apps", "!docs"], ["/*", "!docs"])).toBe(true);
+    });
+  });
+
+  describe("patternsEqual", () => {
+    it("returns true for identical lists in same order", () => {
+      expect(service.patternsEqual(["/*", "!docs"], ["/*", "!docs"])).toBe(true);
+    });
+
+    it("returns false when order differs (no-cone semantics depend on order)", () => {
+      expect(service.patternsEqual(["/*", "!docs"], ["!docs", "/*"])).toBe(false);
+    });
+
+    it("returns false when lengths differ", () => {
+      expect(service.patternsEqual(["a"], ["a", "b"])).toBe(false);
     });
   });
 });

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -1280,5 +1280,17 @@ describe("WorktreeSyncService", () => {
       expect(applyToWorktree).not.toHaveBeenCalled();
       expect(mockGitService.getSparseCheckoutService).not.toHaveBeenCalled();
     });
+
+    it("continues sync and warns when readCurrent throws", async () => {
+      readCurrent.mockRejectedValue(new Error("boom"));
+      isNarrowing.mockReturnValue(false);
+
+      const svc = makeSparseService();
+      await expect(svc.sync()).resolves.not.toThrow();
+
+      expect(applyToWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Failed to update sparse-checkout"));
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("boom"));
+    });
   });
 });

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -58,6 +58,8 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
       getCurrentCommit: vi.fn<any>().mockResolvedValue("abc123"),
       getRemoteCommit: vi.fn<any>().mockResolvedValue("def456"),
       getRemoteBranchesWithActivity: vi.fn<any>().mockResolvedValue([]),
+      checkoutHead: vi.fn<any>().mockResolvedValue(undefined),
+      getSparseCheckoutService: vi.fn(),
     } as any,
   };
 });
@@ -1128,6 +1130,95 @@ describe("WorktreeSyncService", () => {
       expect(mockGitService.fetchAll).toHaveBeenCalled();
       expect(mockGitService.getRemoteBranches).toHaveBeenCalled();
       expect(mockGitService.pruneWorktrees).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("sparseCheckout reapply on existing worktrees", () => {
+    function makeSparseService(): WorktreeSyncService {
+      const cfg: Config = {
+        ...mockConfig,
+        runOnce: true,
+        sparseCheckout: { include: ["apps"] },
+      };
+      const sparseSvc = new WorktreeSyncService(cfg);
+      return sparseSvc;
+    }
+
+    let applyToWorktree: Mock<any>;
+    let readCurrent: Mock<any>;
+    let isNarrowing: Mock<any>;
+
+    beforeEach(() => {
+      applyToWorktree = vi.fn().mockResolvedValue(undefined);
+      readCurrent = vi.fn();
+      isNarrowing = vi.fn();
+      mockGitService.getSparseCheckoutService.mockReturnValue({
+        applyToWorktree,
+        readCurrent,
+        isNarrowing,
+        buildPatterns: vi.fn().mockReturnValue(["apps"]),
+        needsUpdate: vi.fn().mockResolvedValue(true),
+        resolveMode: vi.fn(),
+        patternsEqual: vi.fn((a: string[], b: string[]) => a.length === b.length && a.every((v, i) => v === b[i])),
+      } as any);
+      (fs.access as Mock).mockResolvedValue(undefined);
+      (fs.mkdir as Mock).mockResolvedValue(undefined);
+      mockGitService.getRemoteBranches.mockResolvedValue(["main"]);
+      mockGitService.getWorktrees.mockResolvedValue([{ path: wtPath("/test/worktrees", "main"), branch: "main" }]);
+    });
+
+    it("skips when current matches desired", async () => {
+      readCurrent.mockResolvedValue(["apps"]);
+      isNarrowing.mockReturnValue(false);
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).not.toHaveBeenCalled();
+    });
+
+    it("applies and checks out when widening (current is subset of desired)", async () => {
+      readCurrent.mockResolvedValue(null);
+      isNarrowing.mockReturnValue(false);
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).toHaveBeenCalled();
+      expect(mockGitService.checkoutHead).toHaveBeenCalled();
+    });
+
+    it("skips narrowing when worktree is dirty", async () => {
+      readCurrent.mockResolvedValue(["apps", "packages"]);
+      isNarrowing.mockReturnValue(true);
+      mockGitService.checkWorktreeStatus.mockResolvedValue(false);
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Skipping sparse-checkout narrowing"));
+    });
+
+    it("applies narrowing when worktree is clean", async () => {
+      readCurrent.mockResolvedValue(["apps", "packages"]);
+      isNarrowing.mockReturnValue(true);
+      mockGitService.checkWorktreeStatus.mockResolvedValue(true);
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).toHaveBeenCalled();
+      expect(mockGitService.checkoutHead).toHaveBeenCalled();
+    });
+
+    it("does nothing when sparseCheckout is unset", async () => {
+      readCurrent.mockResolvedValue(["apps"]);
+      isNarrowing.mockReturnValue(false);
+      // service WITHOUT sparseCheckout
+      await service.sync();
+      expect(applyToWorktree).not.toHaveBeenCalled();
+      expect(mockGitService.getSparseCheckoutService).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -1191,7 +1191,16 @@ describe("WorktreeSyncService", () => {
     it("skips narrowing when worktree is dirty", async () => {
       readCurrent.mockResolvedValue(["apps", "packages"]);
       isNarrowing.mockReturnValue(true);
-      mockGitService.checkWorktreeStatus.mockResolvedValue(false);
+      mockGitService.getFullWorktreeStatus.mockResolvedValue({
+        isClean: false,
+        hasUnpushedCommits: false,
+        hasStashedChanges: false,
+        hasOperationInProgress: false,
+        hasModifiedSubmodules: false,
+        upstreamGone: false,
+        canRemove: false,
+        reasons: ["uncommitted changes"],
+      });
 
       const svc = makeSparseService();
       await svc.sync();
@@ -1200,10 +1209,61 @@ describe("WorktreeSyncService", () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Skipping sparse-checkout narrowing"));
     });
 
+    it("skips narrowing when worktree has unpushed commits", async () => {
+      readCurrent.mockResolvedValue(["apps", "packages"]);
+      isNarrowing.mockReturnValue(true);
+      mockGitService.getFullWorktreeStatus.mockResolvedValue({
+        isClean: true,
+        hasUnpushedCommits: true,
+        hasStashedChanges: false,
+        hasOperationInProgress: false,
+        hasModifiedSubmodules: false,
+        upstreamGone: false,
+        canRemove: false,
+        reasons: ["unpushed commits"],
+      });
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("unpushed commits"));
+    });
+
+    it("skips narrowing when worktree has operation in progress", async () => {
+      readCurrent.mockResolvedValue(["apps", "packages"]);
+      isNarrowing.mockReturnValue(true);
+      mockGitService.getFullWorktreeStatus.mockResolvedValue({
+        isClean: true,
+        hasUnpushedCommits: false,
+        hasStashedChanges: false,
+        hasOperationInProgress: true,
+        hasModifiedSubmodules: false,
+        upstreamGone: false,
+        canRemove: false,
+        reasons: ["rebase in progress"],
+      });
+
+      const svc = makeSparseService();
+      await svc.sync();
+
+      expect(applyToWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("rebase in progress"));
+    });
+
     it("applies narrowing when worktree is clean", async () => {
       readCurrent.mockResolvedValue(["apps", "packages"]);
       isNarrowing.mockReturnValue(true);
-      mockGitService.checkWorktreeStatus.mockResolvedValue(true);
+      mockGitService.getFullWorktreeStatus.mockResolvedValue({
+        isClean: true,
+        hasUnpushedCommits: false,
+        hasStashedChanges: false,
+        hasOperationInProgress: false,
+        hasModifiedSubmodules: false,
+        upstreamGone: false,
+        canRemove: true,
+        reasons: [],
+      });
 
       const svc = makeSparseService();
       await svc.sync();

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -7,6 +7,7 @@ import * as cron from "node-cron";
 import { CONFIG_FILE_NAMES, DEFAULT_CONFIG } from "../constants";
 import { matchesPattern } from "../utils/branch-filter";
 import { getDefaultBareRepoDir } from "../utils/git-url";
+import { normalizePathForCompare } from "../utils/path-compare";
 import { sanitizeNameForPath } from "../utils/sanitize-name";
 
 import type { Config, ConfigFile, RepositoryConfig } from "../types";
@@ -457,18 +458,19 @@ export class ConfigLoaderService {
   }
 
   detectBareRepoDirCollisions(repositories: RepositoryConfig[]): void {
-    const seen = new Map<string, string>();
+    const seen = new Map<string, { name: string; displayPath: string }>();
     for (const repo of repositories) {
       if (!repo.bareRepoDir) continue;
-      const key = path.resolve(repo.bareRepoDir);
+      const key = normalizePathForCompare(repo.bareRepoDir);
+      const displayPath = path.resolve(repo.bareRepoDir);
       const existing = seen.get(key);
-      if (existing && existing !== repo.name) {
+      if (existing && existing.name !== repo.name) {
         throw new Error(
-          `Repositories '${existing}' and '${repo.name}' resolve to the same bareRepoDir '${key}'. ` +
+          `Repositories '${existing.name}' and '${repo.name}' resolve to the same bareRepoDir '${displayPath}'. ` +
             `Set distinct 'bareRepoDir' values for duplicate repoUrl entries.`,
         );
       }
-      seen.set(key, repo.name);
+      seen.set(key, { name: repo.name, displayPath });
     }
   }
 

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -6,6 +6,8 @@ import * as cron from "node-cron";
 
 import { CONFIG_FILE_NAMES, DEFAULT_CONFIG } from "../constants";
 import { matchesPattern } from "../utils/branch-filter";
+import { getDefaultBareRepoDir } from "../utils/git-url";
+import { sanitizeNameForPath } from "../utils/sanitize-name";
 
 import type { Config, ConfigFile, RepositoryConfig } from "../types";
 
@@ -132,7 +134,13 @@ export class ConfigLoaderService {
       if (repoObj.hooks !== undefined) {
         this.validateHooksConfig(repoObj.hooks, `Repository '${repoObj.name}'`);
       }
+
+      if (repoObj.sparseCheckout !== undefined) {
+        this.validateSparseCheckoutConfig(repoObj.sparseCheckout, `Repository '${repoObj.name}'`);
+      }
     });
+
+    this.warnOnDuplicateRepoUrls(configObj.repositories as Array<Record<string, unknown>>);
 
     if (configObj.defaults) {
       if (typeof configObj.defaults !== "object") {
@@ -159,6 +167,10 @@ export class ConfigLoaderService {
 
       if (defaults.hooks !== undefined) {
         this.validateHooksConfig(defaults.hooks, "defaults");
+      }
+
+      if (defaults.sparseCheckout !== undefined) {
+        this.validateSparseCheckoutConfig(defaults.sparseCheckout, "defaults");
       }
     }
 
@@ -275,6 +287,67 @@ export class ConfigLoaderService {
     }
   }
 
+  private validateSparseCheckoutConfig(value: unknown, context: string): void {
+    if (typeof value !== "object" || value === null) {
+      throw new Error(`'sparseCheckout' in ${context} must be an object`);
+    }
+
+    const cfg = value as Record<string, unknown>;
+
+    if (!Array.isArray(cfg.include)) {
+      throw new Error(`'sparseCheckout.include' in ${context} must be an array`);
+    }
+    if (cfg.include.length === 0) {
+      throw new Error(`'sparseCheckout.include' in ${context} must contain at least one pattern`);
+    }
+    for (let i = 0; i < cfg.include.length; i++) {
+      const p = cfg.include[i];
+      if (typeof p !== "string" || p.trim() === "") {
+        throw new Error(
+          `'sparseCheckout.include' in ${context} must contain only non-empty strings (invalid at index ${i})`,
+        );
+      }
+    }
+
+    if (cfg.exclude !== undefined) {
+      if (!Array.isArray(cfg.exclude)) {
+        throw new Error(`'sparseCheckout.exclude' in ${context} must be an array`);
+      }
+      for (let i = 0; i < cfg.exclude.length; i++) {
+        const p = cfg.exclude[i];
+        if (typeof p !== "string" || p.trim() === "") {
+          throw new Error(
+            `'sparseCheckout.exclude' in ${context} must contain only non-empty strings (invalid at index ${i})`,
+          );
+        }
+      }
+    }
+
+    if (cfg.mode !== undefined && cfg.mode !== "cone" && cfg.mode !== "no-cone") {
+      throw new Error(`'sparseCheckout.mode' in ${context} must be 'cone' or 'no-cone'`);
+    }
+  }
+
+  private warnOnDuplicateRepoUrls(repositories: Array<Record<string, unknown>>): void {
+    const seen = new Map<string, string[]>();
+    for (const repo of repositories) {
+      const url = typeof repo.repoUrl === "string" ? repo.repoUrl : null;
+      const name = typeof repo.name === "string" ? repo.name : null;
+      if (!url || !name) continue;
+      const list = seen.get(url) ?? [];
+      list.push(name);
+      seen.set(url, list);
+    }
+    for (const [url, names] of seen) {
+      if (names.length > 1) {
+        console.warn(
+          `[sync-worktrees] repoUrl '${url}' appears in multiple entries (${names.join(", ")}). ` +
+            `Pin 'bareRepoDir' on duplicate entries to make config reorder-proof.`,
+        );
+      }
+    }
+  }
+
   private validateHooksConfig(hooks: unknown, context: string): void {
     if (typeof hooks !== "object" || hooks === null) {
       throw new Error(`'hooks' in ${context} must be an object`);
@@ -303,6 +376,7 @@ export class ConfigLoaderService {
     defaults?: Partial<Config>,
     configDir?: string,
     globalRetry?: Config["retry"],
+    allRepositories?: RepositoryConfig[],
   ): RepositoryConfig {
     const resolved: RepositoryConfig = {
       name: repo.name,
@@ -314,6 +388,11 @@ export class ConfigLoaderService {
 
     if (repo.bareRepoDir) {
       resolved.bareRepoDir = this.resolvePath(repo.bareRepoDir, configDir);
+    } else if (allRepositories && this.isDuplicateRepoUrl(repo, allRepositories)) {
+      const sanitized = sanitizeNameForPath(repo.name, `Repository '${repo.name}' name`);
+      resolved.bareRepoDir = this.resolvePath(`.bare/${sanitized}`, configDir);
+    } else {
+      resolved.bareRepoDir = this.resolvePath(getDefaultBareRepoDir(repo.repoUrl), configDir);
     }
 
     if (repo.branchMaxAge || defaults?.branchMaxAge) {
@@ -363,7 +442,34 @@ export class ConfigLoaderService {
       };
     }
 
+    const sparse = repo.sparseCheckout ?? defaults?.sparseCheckout;
+    if (sparse) {
+      resolved.sparseCheckout = sparse;
+    }
+
     return resolved;
+  }
+
+  private isDuplicateRepoUrl(repo: RepositoryConfig, all: RepositoryConfig[]): boolean {
+    const firstIndex = all.findIndex((r) => r.repoUrl === repo.repoUrl);
+    const myIndex = all.indexOf(repo);
+    return firstIndex !== -1 && myIndex !== -1 && myIndex !== firstIndex;
+  }
+
+  detectBareRepoDirCollisions(repositories: RepositoryConfig[]): void {
+    const seen = new Map<string, string>();
+    for (const repo of repositories) {
+      if (!repo.bareRepoDir) continue;
+      const key = path.resolve(repo.bareRepoDir);
+      const existing = seen.get(key);
+      if (existing && existing !== repo.name) {
+        throw new Error(
+          `Repositories '${existing}' and '${repo.name}' resolve to the same bareRepoDir '${key}'. ` +
+            `Set distinct 'bareRepoDir' values for duplicate repoUrl entries.`,
+        );
+      }
+      seen.set(key, repo.name);
+    }
   }
 
   private isValidGitUrl(url: string): boolean {
@@ -406,8 +512,10 @@ export class ConfigLoaderService {
     const configDir = path.dirname(path.resolve(configPath));
 
     let repositories = configFile.repositories.map((repo) =>
-      this.resolveRepositoryConfig(repo, configFile.defaults, configDir, configFile.retry),
+      this.resolveRepositoryConfig(repo, configFile.defaults, configDir, configFile.retry, configFile.repositories),
     );
+
+    this.detectBareRepoDirCollisions(repositories);
 
     if (overrides?.filter) {
       repositories = this.filterRepositories(repositories, overrides.filter);

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -10,6 +10,7 @@ import { getErrorMessage } from "../utils/lfs-error";
 import { parseWorktreeListPorcelain } from "../utils/worktree-list-parser";
 
 import { Logger } from "./logger.service";
+import { SparseCheckoutService } from "./sparse-checkout.service";
 import { WorktreeMetadataService } from "./worktree-metadata.service";
 import { WorktreeStatusService } from "./worktree-status.service";
 
@@ -18,7 +19,10 @@ import type { Config } from "../types";
 import type { SyncMetadata } from "../types/sync-metadata";
 import type { SimpleGit } from "simple-git";
 
-export type GitServiceOptions = Pick<Config, "repoUrl" | "worktreeDir" | "bareRepoDir" | "skipLfs" | "debug">;
+export type GitServiceOptions = Pick<
+  Config,
+  "repoUrl" | "worktreeDir" | "bareRepoDir" | "skipLfs" | "debug" | "sparseCheckout"
+>;
 
 export class GitService {
   private git: SimpleGit | null = null;
@@ -27,6 +31,7 @@ export class GitService {
   private defaultBranch: string = GIT_CONSTANTS.DEFAULT_BRANCH; // Will be updated after detection
   private metadataService: WorktreeMetadataService;
   private statusService: WorktreeStatusService;
+  private sparseCheckoutService: SparseCheckoutService;
   private logger: Logger;
   private lfsSkipOverride = false;
   private gitInstances = new Map<string, SimpleGit>();
@@ -40,6 +45,11 @@ export class GitService {
     this.mainWorktreePath = path.join(this.config.worktreeDir, GIT_CONSTANTS.DEFAULT_BRANCH); // Temporary, will be updated
     this.metadataService = new WorktreeMetadataService(this.logger);
     this.statusService = new WorktreeStatusService({ skipLfs: this.config.skipLfs }, this.logger);
+    this.sparseCheckoutService = new SparseCheckoutService(this.logger);
+  }
+
+  getSparseCheckoutService(): SparseCheckoutService {
+    return this.sparseCheckoutService;
   }
 
   private getCachedGit(dirPath: string, useLfsSkip = false): SimpleGit {
@@ -118,23 +128,27 @@ export class GitService {
       const branches = await bareGit.branch();
       const defaultBranchExists = branches.all.includes(this.defaultBranch);
 
+      const useNoCheckoutMain = !!this.config.sparseCheckout;
+      const noCheckoutFlagMain = useNoCheckoutMain ? ["--no-checkout"] : [];
+
       try {
         if (defaultBranchExists) {
-          await bareGit.raw(["worktree", "add", absoluteWorktreePath, this.defaultBranch]);
-          // Set upstream tracking after creating worktree
+          await bareGit.raw(["worktree", "add", ...noCheckoutFlagMain, absoluteWorktreePath, this.defaultBranch]);
           const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
           await worktreeGit.branch(["--set-upstream-to", `origin/${this.defaultBranch}`, this.defaultBranch]);
+          await this.applySparseAndCheckout(absoluteWorktreePath);
         } else {
-          // Create new branch tracking the remote branch
           await bareGit.raw([
             "worktree",
             "add",
+            ...noCheckoutFlagMain,
             "--track",
             "-b",
             this.defaultBranch,
             absoluteWorktreePath,
             `origin/${this.defaultBranch}`,
           ]);
+          await this.applySparseAndCheckout(absoluteWorktreePath);
         }
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -244,7 +258,9 @@ export class GitService {
   }
 
   private async verifyLfsFilesDownloaded(worktreePath: string, branchName: string): Promise<void> {
-    const worktreeGit = this.getCachedGit(worktreePath);
+    const worktreeGit = this.config.sparseCheckout
+      ? simpleGit(worktreePath).env({ ...process.env, [ENV_CONSTANTS.GIT_ATTR_SOURCE]: "HEAD" })
+      : this.getCachedGit(worktreePath);
 
     try {
       const lfsFiles = await worktreeGit.raw(["lfs", "ls-files", "--name-only"]);
@@ -319,6 +335,47 @@ export class GitService {
     }
   }
 
+  async checkoutHead(worktreePath: string): Promise<void> {
+    const git = this.getCachedGit(worktreePath, this.isLfsSkipEnabled());
+    await git.raw(["checkout", "HEAD"]);
+  }
+
+  private async applySparseAndCheckout(absoluteWorktreePath: string): Promise<void> {
+    if (!this.config.sparseCheckout) return;
+    await this.sparseCheckoutService.applyToWorktree(absoluteWorktreePath, this.config.sparseCheckout);
+    const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
+    await worktreeGit.raw(["checkout", "HEAD"]);
+  }
+
+  private async rollbackPartialWorktree(
+    bareGit: SimpleGit,
+    absoluteWorktreePath: string,
+    branchName: string,
+    createdNewBranch: boolean,
+    failureContext?: string,
+  ): Promise<{ worktreeRemoved: boolean }> {
+    let worktreeRemoved = true;
+    try {
+      await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
+    } catch (rollbackError) {
+      worktreeRemoved = false;
+      const ctx = failureContext ? ` after ${failureContext}` : "";
+      this.logger.warn(
+        `  - Rollback failed for '${branchName}' at '${absoluteWorktreePath}'${ctx}: ${getErrorMessage(rollbackError)}`,
+      );
+    }
+    if (createdNewBranch) {
+      try {
+        await bareGit.raw(["branch", "-D", branchName]);
+      } catch (branchRollbackError) {
+        this.logger.warn(
+          `  - Rollback (branch delete) failed for '${branchName}': ${getErrorMessage(branchRollbackError)}`,
+        );
+      }
+    }
+    return { worktreeRemoved };
+  }
+
   private async createWorktreeMetadata(bareGit: SimpleGit, worktreePath: string, branchName: string): Promise<void> {
     try {
       const worktreeGit = this.getCachedGit(worktreePath, this.isLfsSkipEnabled());
@@ -365,10 +422,11 @@ export class GitService {
       // Directory doesn't exist, which is expected - continue with creation
     }
 
+    let createdNewBranch = false;
     try {
       const { local: localBranchExists, remote: remoteBranchExists } = await this.branchExists(branchName);
 
-      await this.runWorktreeAddByMatrix(
+      createdNewBranch = await this.runWorktreeAddByMatrix(
         bareGit,
         branchName,
         absoluteWorktreePath,
@@ -382,7 +440,6 @@ export class GitService {
         this.logger.info(`  - Created worktree for '${branchName}' with tracking to origin/${branchName}`);
       }
 
-      // Verify LFS files are properly downloaded (if not skipping LFS)
       if (!this.isLfsSkipEnabled()) {
         await this.verifyLfsFilesDownloaded(absoluteWorktreePath, branchName);
       }
@@ -391,11 +448,7 @@ export class GitService {
         await this.createWorktreeMetadata(bareGit, absoluteWorktreePath, branchName);
       } catch (metadataError) {
         this.logger.warn(`  - Metadata creation failed for '${branchName}', removing worktree to prevent orphan`);
-        try {
-          await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
-        } catch {
-          // Best effort cleanup
-        }
+        await this.rollbackPartialWorktree(bareGit, absoluteWorktreePath, branchName, createdNewBranch);
         throw new Error(`Metadata creation failed for '${branchName}': ${getErrorMessage(metadataError)}`);
       }
     } catch (error) {
@@ -431,9 +484,10 @@ export class GitService {
         } catch {
           // Directory might not exist, ignore
         }
+        let retryCreatedNewBranch = false;
         try {
           const { local: localBranchExists, remote: remoteBranchExists } = await this.branchExists(branchName);
-          await this.runWorktreeAddByMatrix(
+          retryCreatedNewBranch = await this.runWorktreeAddByMatrix(
             bareGit,
             branchName,
             absoluteWorktreePath,
@@ -442,7 +496,6 @@ export class GitService {
           );
           this.logger.info(`  - Created worktree for '${branchName}' after pruning`);
 
-          // Verify LFS files are properly downloaded (if not skipping LFS)
           if (!this.isLfsSkipEnabled()) {
             await this.verifyLfsFilesDownloaded(absoluteWorktreePath, branchName);
           }
@@ -451,11 +504,7 @@ export class GitService {
             await this.createWorktreeMetadata(bareGit, absoluteWorktreePath, branchName);
           } catch (metadataError) {
             this.logger.warn(`  - Metadata creation failed for '${branchName}', removing worktree to prevent orphan`);
-            try {
-              await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
-            } catch {
-              // Best effort cleanup
-            }
+            await this.rollbackPartialWorktree(bareGit, absoluteWorktreePath, branchName, retryCreatedNewBranch);
             throw new Error(`Metadata creation failed for '${branchName}': ${getErrorMessage(metadataError)}`);
           }
           return;
@@ -501,10 +550,14 @@ export class GitService {
       }
 
       try {
-        await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
+        const useNoCheckout = !!this.config.sparseCheckout;
+        const fallbackArgs = useNoCheckout
+          ? ["worktree", "add", "--no-checkout", absoluteWorktreePath, branchName]
+          : ["worktree", "add", absoluteWorktreePath, branchName];
+        await bareGit.raw(fallbackArgs);
+        await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, branchName, false);
         this.logger.info(`  - Created worktree for '${branchName}' (without tracking)`);
 
-        // Verify LFS files are properly downloaded (if not skipping LFS)
         if (!this.isLfsSkipEnabled()) {
           await this.verifyLfsFilesDownloaded(absoluteWorktreePath, branchName);
         }
@@ -513,11 +566,7 @@ export class GitService {
           await this.createWorktreeMetadata(bareGit, absoluteWorktreePath, branchName);
         } catch (metadataError) {
           this.logger.warn(`  - Metadata creation failed for '${branchName}', removing worktree to prevent orphan`);
-          try {
-            await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
-          } catch {
-            // Best effort cleanup
-          }
+          await this.rollbackPartialWorktree(bareGit, absoluteWorktreePath, branchName, false);
           throw new Error(`Metadata creation failed for '${branchName}': ${getErrorMessage(metadataError)}`);
         }
       } catch (fallbackError) {
@@ -546,48 +595,85 @@ export class GitService {
     absoluteWorktreePath: string,
     localExists: boolean,
     remoteExists: boolean,
-  ): Promise<void> {
+  ): Promise<boolean> {
+    const useNoCheckout = !!this.config.sparseCheckout;
+    const noCheckoutFlag = useNoCheckout ? ["--no-checkout"] : [];
+
     if (localExists && remoteExists) {
-      await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
+      await bareGit.raw(["worktree", "add", ...noCheckoutFlag, absoluteWorktreePath, branchName]);
+
+      // branch --set-upstream-to is a config-only operation and works on a --no-checkout
+      // worktree, so we run it before sparse setup and materialization.
       try {
         const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
         await worktreeGit.branch(["--set-upstream-to", `origin/${branchName}`, branchName]);
       } catch (error) {
-        let rollbackFailed = false;
-        try {
-          await bareGit.raw(["worktree", "remove", "--force", absoluteWorktreePath]);
-        } catch (rollbackError) {
-          rollbackFailed = true;
-          this.logger.warn(
-            `  - Rollback failed for '${branchName}' at '${absoluteWorktreePath}' after upstream setup error: ${getErrorMessage(rollbackError)}`,
-          );
-        }
-        // Mark the error so the outer addWorktree catch won't reclassify it as a tracking
-        // error and fall back to a non-tracking add (which would silently accept the partial
-        // worktree without upstream).
-        const detail = getErrorMessage(error);
-        const suffix = rollbackFailed ? " (rollback failed; partial worktree may remain)" : "";
-        const wrapped = new Error(`Failed to set upstream for '${branchName}': ${detail}${suffix}`);
-        (wrapped as Error & { isUpstreamSetupFailure?: boolean }).isUpstreamSetupFailure = true;
-        throw wrapped;
+        throw await this.wrapUpstreamFailure(bareGit, absoluteWorktreePath, branchName, false, error);
       }
-      return;
+
+      await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, branchName, false);
+      return false;
     }
 
     if (localExists) {
-      await bareGit.raw(["worktree", "add", absoluteWorktreePath, branchName]);
-      return;
+      await bareGit.raw(["worktree", "add", ...noCheckoutFlag, absoluteWorktreePath, branchName]);
+      await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, branchName, false);
+      return false;
     }
 
     if (remoteExists) {
-      await bareGit.raw(["worktree", "add", "--track", "-b", branchName, absoluteWorktreePath, `origin/${branchName}`]);
-      return;
+      await bareGit.raw([
+        "worktree",
+        "add",
+        ...noCheckoutFlag,
+        "--track",
+        "-b",
+        branchName,
+        absoluteWorktreePath,
+        `origin/${branchName}`,
+      ]);
+      await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, branchName, true);
+      return true;
     }
 
     throw new WorktreeError(
       `Branch '${branchName}' does not exist locally or on origin; create it first`,
       "BRANCH_NOT_FOUND",
     );
+  }
+
+  private async runSparseStepWithRollback(
+    bareGit: SimpleGit,
+    absoluteWorktreePath: string,
+    branchName: string,
+    createdNewBranch: boolean,
+  ): Promise<void> {
+    try {
+      await this.applySparseAndCheckout(absoluteWorktreePath);
+    } catch (sparseError) {
+      await this.rollbackPartialWorktree(bareGit, absoluteWorktreePath, branchName, createdNewBranch);
+      throw new Error(`Sparse-checkout setup failed for '${branchName}': ${getErrorMessage(sparseError)}`);
+    }
+  }
+
+  private async wrapUpstreamFailure(
+    bareGit: SimpleGit,
+    absoluteWorktreePath: string,
+    branchName: string,
+    createdNewBranch: boolean,
+    error: unknown,
+  ): Promise<Error> {
+    const { worktreeRemoved } = await this.rollbackPartialWorktree(
+      bareGit,
+      absoluteWorktreePath,
+      branchName,
+      createdNewBranch,
+      "upstream setup error",
+    );
+    const suffix = worktreeRemoved ? "" : " (rollback failed; partial worktree may remain)";
+    const wrapped = new Error(`Failed to set upstream for '${branchName}': ${getErrorMessage(error)}${suffix}`);
+    (wrapped as Error & { isUpstreamSetupFailure?: boolean }).isUpstreamSetupFailure = true;
+    return wrapped;
   }
 
   async removeWorktree(worktreePath: string): Promise<void> {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -64,6 +64,7 @@ export class GitService {
 
   updateLogger(logger: Logger): void {
     this.logger = logger;
+    this.sparseCheckoutService.updateLogger(logger);
   }
 
   async initialize(): Promise<SimpleGit> {
@@ -136,7 +137,7 @@ export class GitService {
           await bareGit.raw(["worktree", "add", ...noCheckoutFlagMain, absoluteWorktreePath, this.defaultBranch]);
           const worktreeGit = this.getCachedGit(absoluteWorktreePath, this.isLfsSkipEnabled());
           await worktreeGit.branch(["--set-upstream-to", `origin/${this.defaultBranch}`, this.defaultBranch]);
-          await this.applySparseAndCheckout(absoluteWorktreePath);
+          await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, this.defaultBranch, false);
         } else {
           await bareGit.raw([
             "worktree",
@@ -148,7 +149,7 @@ export class GitService {
             absoluteWorktreePath,
             `origin/${this.defaultBranch}`,
           ]);
-          await this.applySparseAndCheckout(absoluteWorktreePath);
+          await this.runSparseStepWithRollback(bareGit, absoluteWorktreePath, this.defaultBranch, true);
         }
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -264,13 +265,33 @@ export class GitService {
 
     try {
       const lfsFiles = await worktreeGit.raw(["lfs", "ls-files", "--name-only"]);
-      const lfsFileList = lfsFiles
+      let lfsFileList = lfsFiles
         .trim()
         .split("\n")
         .filter((f) => f.length > 0);
 
       if (lfsFileList.length === 0) {
         return;
+      }
+
+      // GIT_ATTR_SOURCE=HEAD lists every LFS file declared in HEAD's .gitattributes,
+      // including ones outside the sparse-checkout cone that aren't on disk. Sampling
+      // those would burn the 30s retry loop on guaranteed-missing files.
+      if (this.config.sparseCheckout) {
+        const existence = await Promise.all(
+          lfsFileList.map(async (f) => {
+            try {
+              await fs.access(path.join(worktreePath, f));
+              return f;
+            } catch {
+              return null;
+            }
+          }),
+        );
+        lfsFileList = existence.filter((f): f is string => f !== null);
+        if (lfsFileList.length === 0) {
+          return;
+        }
       }
 
       if (this.config.debug) {

--- a/src/services/sparse-checkout.service.ts
+++ b/src/services/sparse-checkout.service.ts
@@ -23,7 +23,7 @@ export class SparseCheckoutService {
 
   resolveMode(cfg: SparseCheckoutConfig): SparseCheckoutMode {
     const hasExclude = !!cfg.exclude && cfg.exclude.length > 0;
-    const hasNegation = cfg.include.some((p) => p.startsWith("!"));
+    const hasNegation = cfg.include.some((p) => p.trim().startsWith("!"));
 
     if (cfg.mode === "no-cone") return "no-cone";
     if (hasExclude || hasNegation) {

--- a/src/services/sparse-checkout.service.ts
+++ b/src/services/sparse-checkout.service.ts
@@ -1,0 +1,98 @@
+import simpleGit from "simple-git";
+
+import { Logger } from "./logger.service";
+
+import type { SparseCheckoutConfig, SparseCheckoutMode } from "../types";
+import type { SimpleGit } from "simple-git";
+
+export type GitFactory = (worktreePath: string) => SimpleGit;
+
+export class SparseCheckoutService {
+  private logger: Logger;
+  private gitFactory: GitFactory;
+
+  constructor(logger?: Logger, gitFactory?: GitFactory) {
+    this.logger = logger ?? Logger.createDefault();
+    this.gitFactory = gitFactory ?? ((p: string): SimpleGit => simpleGit(p));
+  }
+
+  resolveMode(cfg: SparseCheckoutConfig): SparseCheckoutMode {
+    const hasExclude = !!cfg.exclude && cfg.exclude.length > 0;
+    const hasNegation = cfg.include.some((p) => p.startsWith("!"));
+
+    if (cfg.mode === "no-cone") return "no-cone";
+    if (hasExclude || hasNegation) {
+      if (cfg.mode === "cone") {
+        this.logger.warn(
+          "sparseCheckout: mode 'cone' is incompatible with excludes or negation patterns; auto-promoting to 'no-cone'",
+        );
+      }
+      return "no-cone";
+    }
+    return cfg.mode ?? "cone";
+  }
+
+  buildPatterns(cfg: SparseCheckoutConfig): string[] {
+    const mode = this.resolveMode(cfg);
+    const includes = cfg.include.map((p) => p.trim()).filter((p) => p.length > 0);
+
+    if (mode === "cone") {
+      return includes;
+    }
+
+    const excludes = (cfg.exclude ?? [])
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+      .map((p) => (p.startsWith("!") ? p : `!${p}`));
+
+    return [...includes, ...excludes];
+  }
+
+  async applyToWorktree(worktreePath: string, cfg: SparseCheckoutConfig): Promise<void> {
+    const mode = this.resolveMode(cfg);
+    const patterns = this.buildPatterns(cfg);
+
+    if (patterns.length === 0) {
+      throw new Error("sparseCheckout produced no patterns; refusing to apply empty config");
+    }
+
+    const git = this.gitFactory(worktreePath);
+    await git.raw(["sparse-checkout", "init", mode === "cone" ? "--cone" : "--no-cone"]);
+    await git.raw(["sparse-checkout", "set", mode === "cone" ? "--cone" : "--no-cone", ...patterns]);
+  }
+
+  async readCurrent(worktreePath: string): Promise<string[] | null> {
+    const git = this.gitFactory(worktreePath);
+    try {
+      const out = await git.raw(["sparse-checkout", "list"]);
+      const lines = out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0 && !l.startsWith("#"));
+      return lines.length === 0 ? null : lines;
+    } catch {
+      return null;
+    }
+  }
+
+  async needsUpdate(worktreePath: string, cfg: SparseCheckoutConfig): Promise<boolean> {
+    const current = await this.readCurrent(worktreePath);
+    const desired = this.buildPatterns(cfg);
+    if (current === null) return true;
+    return !this.patternsEqual(current, desired);
+  }
+
+  isNarrowing(currentPatterns: string[] | null, nextPatterns: string[]): boolean {
+    if (!currentPatterns || currentPatterns.length === 0) return false;
+    const nextSet = new Set(nextPatterns.map((p) => p.trim()));
+    return currentPatterns.some((p) => !nextSet.has(p.trim()));
+  }
+
+  patternsEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) return false;
+    const norm = (xs: string[]): string[] => xs.map((x) => x.trim()).sort();
+    const an = norm(a);
+    const bn = norm(b);
+    return an.every((v, i) => v === bn[i]);
+  }
+}

--- a/src/services/sparse-checkout.service.ts
+++ b/src/services/sparse-checkout.service.ts
@@ -10,10 +10,15 @@ export type GitFactory = (worktreePath: string) => SimpleGit;
 export class SparseCheckoutService {
   private logger: Logger;
   private gitFactory: GitFactory;
+  private warnedConfigs = new WeakSet<SparseCheckoutConfig>();
 
   constructor(logger?: Logger, gitFactory?: GitFactory) {
     this.logger = logger ?? Logger.createDefault();
     this.gitFactory = gitFactory ?? ((p: string): SimpleGit => simpleGit(p));
+  }
+
+  updateLogger(logger: Logger): void {
+    this.logger = logger;
   }
 
   resolveMode(cfg: SparseCheckoutConfig): SparseCheckoutMode {
@@ -22,10 +27,11 @@ export class SparseCheckoutService {
 
     if (cfg.mode === "no-cone") return "no-cone";
     if (hasExclude || hasNegation) {
-      if (cfg.mode === "cone") {
+      if (cfg.mode === "cone" && !this.warnedConfigs.has(cfg)) {
         this.logger.warn(
           "sparseCheckout: mode 'cone' is incompatible with excludes or negation patterns; auto-promoting to 'no-cone'",
         );
+        this.warnedConfigs.add(cfg);
       }
       return "no-cone";
     }
@@ -33,7 +39,10 @@ export class SparseCheckoutService {
   }
 
   buildPatterns(cfg: SparseCheckoutConfig): string[] {
-    const mode = this.resolveMode(cfg);
+    return this.buildPatternsForMode(cfg, this.resolveMode(cfg));
+  }
+
+  private buildPatternsForMode(cfg: SparseCheckoutConfig, mode: SparseCheckoutMode): string[] {
     const includes = cfg.include.map((p) => p.trim()).filter((p) => p.length > 0);
 
     if (mode === "cone") {
@@ -50,7 +59,7 @@ export class SparseCheckoutService {
 
   async applyToWorktree(worktreePath: string, cfg: SparseCheckoutConfig): Promise<void> {
     const mode = this.resolveMode(cfg);
-    const patterns = this.buildPatterns(cfg);
+    const patterns = this.buildPatternsForMode(cfg, mode);
 
     if (patterns.length === 0) {
       throw new Error("sparseCheckout produced no patterns; refusing to apply empty config");
@@ -84,15 +93,31 @@ export class SparseCheckoutService {
 
   isNarrowing(currentPatterns: string[] | null, nextPatterns: string[]): boolean {
     if (!currentPatterns || currentPatterns.length === 0) return false;
-    const nextSet = new Set(nextPatterns.map((p) => p.trim()));
-    return currentPatterns.some((p) => !nextSet.has(p.trim()));
+
+    const isNeg = (p: string): boolean => p.startsWith("!");
+    const trim = (xs: string[]): string[] => xs.map((p) => p.trim()).filter((p) => p.length > 0);
+
+    const cur = trim(currentPatterns);
+    const next = trim(nextPatterns);
+
+    const positiveCurrent = new Set(cur.filter((p) => !isNeg(p)));
+    const negativeCurrent = new Set(cur.filter(isNeg));
+    const positiveNext = new Set(next.filter((p) => !isNeg(p)));
+    const negativeNext = new Set(next.filter(isNeg));
+
+    for (const p of positiveCurrent) {
+      if (!positiveNext.has(p)) return true;
+    }
+    for (const p of negativeNext) {
+      if (!negativeCurrent.has(p)) return true;
+    }
+    return false;
   }
 
   patternsEqual(a: string[], b: string[]): boolean {
     if (a.length !== b.length) return false;
-    const norm = (xs: string[]): string[] => xs.map((x) => x.trim()).sort();
-    const an = norm(a);
-    const bn = norm(b);
-    return an.every((v, i) => v === bn[i]);
+    const at = a.map((x) => x.trim());
+    const bt = b.map((x) => x.trim());
+    return at.every((v, i) => v === bt[i]);
   }
 }

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -159,7 +159,57 @@ export class WorktreeSyncService {
       await this.updateExistingWorktreesWithTiming(worktrees, remoteBranches, phaseTimer);
     }
 
+    if (this.config.sparseCheckout) {
+      await this.reapplySparseCheckout(worktrees);
+    }
+
     await this.finalizeSyncAttempt(phaseTimer);
+  }
+
+  private async reapplySparseCheckout(worktrees: { path: string; branch: string }[]): Promise<void> {
+    const sparseConfig = this.config.sparseCheckout;
+    if (!sparseConfig) return;
+
+    this.logger.info("Step 5: Reconciling sparse-checkout patterns on existing worktrees...");
+    const sparseService = this.gitService.getSparseCheckoutService();
+    const desired = sparseService.buildPatterns(sparseConfig);
+
+    const limit = pLimit(this.config.parallelism?.maxStatusChecks ?? DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
+
+    await Promise.all(
+      worktrees.map((worktree) =>
+        limit(async () => {
+          try {
+            await fs.access(worktree.path);
+          } catch {
+            return;
+          }
+
+          const current = await sparseService.readCurrent(worktree.path);
+          if (current !== null && sparseService.patternsEqual(current, desired)) return;
+
+          if (sparseService.isNarrowing(current, desired)) {
+            const isClean = await this.gitService.checkWorktreeStatus(worktree.path);
+            if (!isClean) {
+              this.logger.warn(
+                `  - Skipping sparse-checkout narrowing for '${worktree.branch}': clean or stash local changes first.`,
+              );
+              return;
+            }
+          }
+
+          try {
+            await sparseService.applyToWorktree(worktree.path, sparseConfig);
+            await this.gitService.checkoutHead(worktree.path);
+            this.logger.info(`  - ✅ Sparse-checkout updated for '${worktree.branch}'`);
+          } catch (error) {
+            this.logger.warn(
+              `  - ⚠️ Failed to update sparse-checkout for '${worktree.branch}': ${getErrorMessage(error)}`,
+            );
+          }
+        }),
+      ),
+    );
   }
 
   private async fetchLatestRemoteData(phaseTimer: PhaseTimer, syncContext: { lfsSkipEnabled: boolean }): Promise<void> {

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -189,10 +189,10 @@ export class WorktreeSyncService {
           if (current !== null && sparseService.patternsEqual(current, desired)) return;
 
           if (sparseService.isNarrowing(current, desired)) {
-            const isClean = await this.gitService.checkWorktreeStatus(worktree.path);
-            if (!isClean) {
+            const status = await this.gitService.getFullWorktreeStatus(worktree.path, false);
+            if (!status.canRemove) {
               this.logger.warn(
-                `  - Skipping sparse-checkout narrowing for '${worktree.branch}': clean or stash local changes first.`,
+                `  - Skipping sparse-checkout narrowing for '${worktree.branch}': ${status.reasons.join(", ")}.`,
               );
               return;
             }

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -180,25 +180,25 @@ export class WorktreeSyncService {
       worktrees.map((worktree) =>
         limit(async () => {
           try {
-            await fs.access(worktree.path);
-          } catch {
-            return;
-          }
-
-          const current = await sparseService.readCurrent(worktree.path);
-          if (current !== null && sparseService.patternsEqual(current, desired)) return;
-
-          if (sparseService.isNarrowing(current, desired)) {
-            const status = await this.gitService.getFullWorktreeStatus(worktree.path, false);
-            if (!status.canRemove) {
-              this.logger.warn(
-                `  - Skipping sparse-checkout narrowing for '${worktree.branch}': ${status.reasons.join(", ")}.`,
-              );
+            try {
+              await fs.access(worktree.path);
+            } catch {
               return;
             }
-          }
 
-          try {
+            const current = await sparseService.readCurrent(worktree.path);
+            if (current !== null && sparseService.patternsEqual(current, desired)) return;
+
+            if (sparseService.isNarrowing(current, desired)) {
+              const status = await this.gitService.getFullWorktreeStatus(worktree.path, false);
+              if (!status.canRemove) {
+                this.logger.warn(
+                  `  - Skipping sparse-checkout narrowing for '${worktree.branch}': ${status.reasons.join(", ")}.`,
+                );
+                return;
+              }
+            }
+
             await sparseService.applyToWorktree(worktree.path, sparseConfig);
             await this.gitService.checkoutHead(worktree.path);
             this.logger.info(`  - ✅ Sparse-checkout updated for '${worktree.branch}'`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,14 @@ export interface HooksConfig {
   onBranchCreated?: string[];
 }
 
+export type SparseCheckoutMode = "cone" | "no-cone";
+
+export interface SparseCheckoutConfig {
+  include: string[];
+  exclude?: string[];
+  mode?: SparseCheckoutMode;
+}
+
 /**
  * Controls concurrency limits for parallel operations.
  * Lower values reduce resource usage but increase total sync time.
@@ -65,6 +73,7 @@ export interface Config {
   logger?: Logger;
   filesToCopyOnBranchCreate?: string[];
   hooks?: HooksConfig;
+  sparseCheckout?: SparseCheckoutConfig;
 }
 
 export interface RepositoryConfig extends Config {

--- a/src/utils/sanitize-name.ts
+++ b/src/utils/sanitize-name.ts
@@ -1,0 +1,27 @@
+import { ConfigValidationError } from "../errors";
+
+const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+// eslint-disable-next-line no-control-regex -- Windows reserves \x00–\x1f for path validation; intentional
+const ILLEGAL_CHARS = /[<>:"|?*\x00-\x1f]/g;
+
+export function sanitizeNameForPath(name: string, fieldContext = "name"): string {
+  if (!name || typeof name !== "string") {
+    throw new ConfigValidationError(fieldContext, "must be a non-empty string");
+  }
+
+  let cleaned = name.trim();
+  cleaned = cleaned.replace(/[/\\]/g, "-");
+  cleaned = cleaned.replace(/^\.+/, "");
+  cleaned = cleaned.replace(ILLEGAL_CHARS, "_");
+  cleaned = cleaned.replace(/[. ]+$/, "");
+
+  if (cleaned.length === 0) {
+    throw new ConfigValidationError(fieldContext, `'${name}' produces an empty path segment after sanitization`);
+  }
+
+  if (WINDOWS_RESERVED.test(cleaned)) {
+    throw new ConfigValidationError(fieldContext, `'${cleaned}' is a reserved name on Windows`);
+  }
+
+  return cleaned;
+}

--- a/sync-worktrees.config.example.js
+++ b/sync-worktrees.config.example.js
@@ -167,15 +167,49 @@ export default {
 
     {
       name: "large-media-project",
-      
+
       repoUrl: "https://github.com/user/large-media.git",
       worktreeDir: "./worktrees/large-media",
-      
+
       // Skip downloading LFS files to save bandwidth and disk space
       skipLfs: true,
-      
+
       // Still check regularly for code changes
       cronSchedule: "0 * * * *"
+    },
+
+    // Sparse-checkout: clone only a subset of folders from a monorepo.
+    // The same repoUrl can be listed multiple times under different `name`s
+    // with different sparse patterns and worktreeDirs to build domain-grouped layouts.
+    {
+      name: "monorepo-game-client",
+      repoUrl: "https://github.com/acme/casino-monorepo.git",
+      worktreeDir: "/Users/me/game-clients/roulette",
+      sparseCheckout: {
+        // Cone mode (default): pass folder names; fast and recommended
+        include: ["game-client"]
+      }
+    },
+    {
+      name: "monorepo-autocue",
+      repoUrl: "https://github.com/acme/casino-monorepo.git",
+      worktreeDir: "/Users/me/autocues/roulette",
+      sparseCheckout: { include: ["autocue"] },
+      // Optional: pin bareRepoDir to make config order irrelevant.
+      // Without this pin, the FIRST entry per repoUrl gets .bare/<repo-slug>
+      // and subsequent duplicates auto-derive .bare/<sanitized-name>.
+      // bareRepoDir: ".bare/monorepo-autocue"
+    },
+    {
+      name: "monorepo-with-excludes",
+      repoUrl: "https://github.com/acme/casino-monorepo.git",
+      worktreeDir: "/Users/me/casino/all-but-docs",
+      sparseCheckout: {
+        // No-cone mode: gitignore-style patterns, supports !-negation.
+        // Setting `exclude` auto-promotes mode to "no-cone".
+        include: ["/*"],
+        exclude: ["docs", "vendor"]
+      }
     },
     
     {


### PR DESCRIPTION
## Summary
- Add `sparseCheckout` config (`include`, `exclude?`, `mode?`) so monorepo entries clone only a subset of folders. Cone default; excludes / `!`-negation auto-promote to `no-cone`.
- Allow same `repoUrl` across multiple entries with distinct `name` and `worktreeDir`. First occurrence keeps URL-derived bare path; duplicates auto-derive `.bare/<sanitized-name>`. Sanitizer rejects path traversal + Windows-reserved names.
- Worktree add uses `--no-checkout` + sparse + `checkout HEAD`. Upstream set before materialization. Transactional rollback (worktree remove + `branch -D` for new branches) on any post-add failure. LFS verify carries `GIT_ATTR_SOURCE=HEAD` for Git ≥ 2.42 sparse `.gitattributes` caveat.
- Sync reapplies sparse patterns to existing worktrees in parallel. Narrowing skipped with warning when worktree is dirty.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1045 passed (+52 new)
- [ ] Manual e2e against a real public monorepo (e.g. `vercel/turborepo`): two entries same `repoUrl`, different `sparseCheckout.include`, verify only included folders materialize and two independent `.bare/` dirs exist
- [ ] Manual narrowing safety: dirty worktree narrowing is skipped with warning; clean worktree narrows successfully
- [ ] Manual exclude path: `include: ["/*"], exclude: ["docs"]` auto-promotes to `no-cone` with warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sparse-checkout config for monorepos (include/exclude, cone/no-cone) with auto-promotion when needed.
  * Allow multiple worktrees from the same repo URL with distinct names, sparse patterns, and worktree dirs.
  * Safer worktree creation with transactional rollback on setup failures; LFS checks now respect repository attributes under sparse checkouts.

* **Documentation**
  * Added detailed sparse-checkout guide and example configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->