### PR TITLE
fix(lfs): strip EDITOR env vars before forwarding to simple-git

### DIFF
--- a/.changeset/fix-lfs-verify-editor-env.md
+++ b/.changeset/fix-lfs-verify-editor-env.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Fix LFS verify failing on sparse-checkout worktrees when shell `EDITOR` is set. simple-git's argv-parser blocks `EDITOR`/`GIT_EDITOR`/`GIT_SEQUENCE_EDITOR` env vars unless `allowUnsafeEditor` is enabled, causing `git lfs ls-files` to error out and skip verification. The forwarded env now strips these vars before passing to simple-git.

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -24,6 +24,16 @@ export type GitServiceOptions = Pick<
   "repoUrl" | "worktreeDir" | "bareRepoDir" | "skipLfs" | "debug" | "sparseCheckout"
 >;
 
+// simple-git blocks EDITOR / GIT_EDITOR / GIT_SEQUENCE_EDITOR unless allowUnsafeEditor is set;
+// strip them when forwarding process.env so a user's shell EDITOR doesn't break read-only commands.
+function sanitizeGitEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const sanitized = { ...env };
+  delete sanitized.EDITOR;
+  delete sanitized.GIT_EDITOR;
+  delete sanitized.GIT_SEQUENCE_EDITOR;
+  return sanitized;
+}
+
 export class GitService {
   private git: SimpleGit | null = null;
   private bareRepoPath: string;
@@ -260,7 +270,7 @@ export class GitService {
 
   private async verifyLfsFilesDownloaded(worktreePath: string, branchName: string): Promise<void> {
     const worktreeGit = this.config.sparseCheckout
-      ? simpleGit(worktreePath).env({ ...process.env, [ENV_CONSTANTS.GIT_ATTR_SOURCE]: "HEAD" })
+      ? simpleGit(worktreePath).env({ ...sanitizeGitEnv(process.env), [ENV_CONSTANTS.GIT_ATTR_SOURCE]: "HEAD" })
       : this.getCachedGit(worktreePath);
 
     try {


### PR DESCRIPTION
## Summary
- LFS verify on sparse-checkout worktrees emitted `Use of "EDITOR" is not permitted without enabling allowUnsafeEditor` whenever the user's shell had `EDITOR` set, skipping the verification entirely.
- Root cause: `verifyLfsFilesDownloaded` spread `process.env` into simple-git's `.env()`. simple-git@3's argv-parser (`@simple-git/argv-parser`) blocks `EDITOR` / `GIT_EDITOR` / `GIT_SEQUENCE_EDITOR` unless `unsafe.allowUnsafeEditor` is enabled.
- Fix: added a small `sanitizeGitEnv()` helper that strips the three editor vars before forwarding. `git lfs ls-files` doesn't need them.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test src/services/__tests__/git.service.test.ts` (72/72 pass)
- [ ] Manual: run sync on a sparse-checkout repo with `EDITOR` set in the shell; LFS verify completes without the warning