### PR TITLE
feat(sparse): skip ff updates when upstream diff is outside sparse cone

### DIFF
--- a/.changeset/sparse-skip-update-when-outside.md
+++ b/.changeset/sparse-skip-update-when-outside.md
@@ -1,0 +1,17 @@
+---
+"sync-worktrees": minor
+---
+
+feat(sparse): skip fast-forward updates when upstream diff is outside sparse cone
+
+Sparse-checkout users in cone mode now avoid pointless `git merge --ff-only` work when the incoming commits only touch files outside the materialized include set — the working tree wouldn't have changed anyway. Saves LFS smudge, post-checkout hooks, and disk churn in monorepos that fan out one upstream into multiple sparse slices.
+
+Changes:
+- `SparseCheckoutConfig` gains `skipUpdateWhenOutsideSparse?: boolean` (default `true`). Set to `false` to keep HEAD strictly tracking remote even when no sparse files change.
+- New `SparseCheckoutService.pathsTouchSparse()` mirrors git's cone-mode materialization rules, including direct files in every ancestor of an included directory (e.g. include `tools/build` keeps `tools/foo.txt` checked out, so a change to that file still triggers an update).
+- New `GitService.getChangedPathsInRange()` runs `git -c core.quotePath=false diff --name-only --no-renames` between two refs. Returns `null` on git failure so the caller forces a safe update rather than silently skipping a behind worktree.
+- Wired into Phase 4a of `WorktreeSyncService.updateExistingWorktrees()` after the existing `isWorktreeBehind` check.
+
+No-cone mode falls through to the existing update path; gitignore-style pattern matching with negation is intentionally out of scope here.
+
+Trade-off: when an update is skipped, the worktree's local HEAD lags the remote tip. `git status` inside that worktree will show "behind by N commits" until upstream advances into the sparse area or `skipUpdateWhenOutsideSparse: false` is set.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,31 +14,13 @@ import { WorktreeSyncService } from "./services/worktree-sync.service";
 import { isInteractiveMode, parseArguments, reconstructCliCommand } from "./utils/cli";
 import { findConfigInCwd } from "./utils/config-generator";
 import { promptForConfig } from "./utils/interactive";
+import { setupSignalHandlers } from "./utils/signal-handlers";
 
 import type { ReloadOptions } from "./services/InteractiveUIService";
 import type { Config, RepositoryConfig } from "./types";
 import type { CliOptions } from "./utils/cli";
 
-const cleanupFns: Array<() => void | Promise<void>> = [];
-
-function setupSignalHandlers(): void {
-  let shuttingDown = false;
-  const handler = async (signal: string): Promise<void> => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log(`\nReceived ${signal}, shutting down gracefully...`);
-    for (const fn of cleanupFns) {
-      try {
-        await fn();
-      } catch {
-        // best effort
-      }
-    }
-    process.exit(0);
-  };
-  process.on("SIGINT", () => void handler("SIGINT"));
-  process.on("SIGTERM", () => void handler("SIGTERM"));
-}
+const signalHandle = setupSignalHandlers();
 
 async function runSingleRepository(config: Config): Promise<void> {
   const logger = Logger.createDefault(undefined, config.debug);
@@ -61,13 +43,13 @@ async function runSingleRepository(config: Config): Promise<void> {
       await syncService.sync();
     } else {
       const uiService = new InteractiveUIService([syncService], undefined, config.cronSchedule);
-      cleanupFns.push(() => uiService.destroy());
+      signalHandle.register((fast) => uiService.destroy(fast));
 
       await syncService.sync();
       uiService.updateLastSyncTime();
       void uiService.calculateAndUpdateDiskSpace();
 
-      cron.schedule(config.cronSchedule, async () => {
+      const job = cron.schedule(config.cronSchedule, async () => {
         try {
           uiService.setStatus("syncing");
           await syncService.sync();
@@ -78,6 +60,7 @@ async function runSingleRepository(config: Config): Promise<void> {
           uiService.setStatus("idle");
         }
       });
+      uiService.registerCronJob(job);
     }
   } catch (error) {
     logger.error("❌ Fatal Error during initialization:", error as Error);
@@ -166,7 +149,7 @@ async function runMultipleRepositories(
     const displaySchedule = uniqueSchedules.length === 1 ? uniqueSchedules[0] : undefined;
     const allServices = Array.from(services.values());
     const uiService = new InteractiveUIService(allServices, configPath, displaySchedule, maxParallel, reloadOptions);
-    cleanupFns.push(() => uiService.destroy());
+    signalHandle.register((fast) => uiService.destroy(fast));
 
     void uiService.calculateAndUpdateDiskSpace();
 
@@ -296,7 +279,6 @@ async function runInteractive(partial: Partial<Config>, options: CliOptions): Pr
 }
 
 async function main(): Promise<void> {
-  setupSignalHandlers();
   const options = parseArguments();
 
   if (!options.config && !options.repoUrl && !options.worktreeDir) {

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -19,8 +19,12 @@ import { AppEventEmitter } from "../utils/app-events";
 import { shellEscape } from "../utils/shell-escape";
 import * as fs from "fs/promises";
 import { calculateDirectorySize, formatBytes } from "../utils/disk-space";
+import { formatDuration } from "../utils/timing";
 import { GIT_CONSTANTS, METADATA_CONSTANTS, TERMINAL_CONSTANTS } from "../constants";
 import type { RepositoryConfig, HookContext, WorktreeStatusEntry, DivergedDirectoryInfo } from "../types";
+
+const WAIT_SYNC_FAST_TIMEOUT_MS = 2000;
+const WAIT_SYNC_DEFAULT_TIMEOUT_MS = 30000;
 
 export interface ReloadOptions {
   filter?: string;
@@ -157,6 +161,10 @@ export class InteractiveUIService {
       job.stop();
     }
     this.cronJobs = [];
+  }
+
+  public registerCronJob(job: cron.ScheduledTask): void {
+    this.cronJobs.push(job);
   }
 
   private renderUI(): void {
@@ -304,7 +312,7 @@ export class InteractiveUIService {
     process.exit(0);
   }
 
-  private async waitForInProgressSyncs(): Promise<void> {
+  private async waitForInProgressSyncs(timeoutMs: number = WAIT_SYNC_DEFAULT_TIMEOUT_MS): Promise<void> {
     const inProgressServices = this.syncServices.filter((s) => s.isSyncInProgress());
 
     if (inProgressServices.length === 0) {
@@ -314,12 +322,11 @@ export class InteractiveUIService {
     this.addLog(`Waiting for ${inProgressServices.length} in-progress sync(s) to finish...`, "info");
 
     const syncChecks = inProgressServices.map(async (service) => {
-      const timeout = 30000;
       const checkInterval = 500;
       const startTime = Date.now();
 
       while (service.isSyncInProgress()) {
-        if (Date.now() - startTime > timeout) {
+        if (Date.now() - startTime > timeoutMs) {
           throw new Error("Timeout waiting for sync operations to complete");
         }
         await new Promise((resolve) => setTimeout(resolve, checkInterval));
@@ -330,7 +337,7 @@ export class InteractiveUIService {
       await Promise.all(syncChecks);
     } catch {
       this.addLog(
-        "Warning: Timeout waiting for sync operations to complete after 30s. Proceeding with potential data loss risk.",
+        `Warning: Timeout waiting for sync operations to complete after ${formatDuration(timeoutMs)}. Proceeding with potential data loss risk.`,
         "warn",
       );
     }
@@ -863,13 +870,12 @@ export class InteractiveUIService {
     }
   }
 
-  public async destroy(): Promise<void> {
+  public async destroy(fast = false): Promise<void> {
     this.isDestroyed = true;
     this.cancelCronJobs();
 
-    // Wait for in-flight sync operations before tearing down
     try {
-      await this.waitForInProgressSyncs();
+      await this.waitForInProgressSyncs(fast ? WAIT_SYNC_FAST_TIMEOUT_MS : WAIT_SYNC_DEFAULT_TIMEOUT_MS);
     } catch {
       // Best effort - proceed with teardown even if syncs don't finish
     }

--- a/src/services/__tests__/git-update.test.ts
+++ b/src/services/__tests__/git-update.test.ts
@@ -167,19 +167,7 @@ describe("GitService - Update Methods", () => {
         "--no-renames",
         "HEAD..origin/feature",
       ]);
-      expect(result).not.toBeNull();
-      expect(result!.paths).toEqual(["src/foo.ts", "lib/bar.ts"]);
-      expect(result!.rootFilesTouched).toBe(false);
-    });
-
-    it("flags rootFilesTouched when a path has no slash", async () => {
-      mockGit.raw.mockResolvedValue("README.md\nsrc/foo.ts\n");
-
-      const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/main");
-
-      expect(result).not.toBeNull();
-      expect(result!.paths).toEqual(["README.md", "src/foo.ts"]);
-      expect(result!.rootFilesTouched).toBe(true);
+      expect(result).toEqual(["src/foo.ts", "lib/bar.ts"]);
     });
 
     it("returns null on git error so caller can force a safe update", async () => {
@@ -195,8 +183,7 @@ describe("GitService - Update Methods", () => {
 
       const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/main");
 
-      expect(result).not.toBeNull();
-      expect(result!.paths).toEqual(["src/foo.ts", "lib/bar.ts"]);
+      expect(result).toEqual(["src/foo.ts", "lib/bar.ts"]);
     });
   });
 });

--- a/src/services/__tests__/git-update.test.ts
+++ b/src/services/__tests__/git-update.test.ts
@@ -152,4 +152,51 @@ describe("GitService - Update Methods", () => {
       await expect(service.updateWorktree("/test/worktrees/diverged")).rejects.toThrow("Not possible to fast-forward");
     });
   });
+
+  describe("getChangedPathsInRange", () => {
+    it("invokes git diff with core.quotePath=false and the requested range", async () => {
+      mockGit.raw.mockResolvedValue("src/foo.ts\nlib/bar.ts\n");
+
+      const result = await service.getChangedPathsInRange("/test/worktrees/feature", "HEAD", "origin/feature");
+
+      expect(mockGit.raw).toHaveBeenCalledWith([
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "HEAD..origin/feature",
+      ]);
+      expect(result).not.toBeNull();
+      expect(result!.paths).toEqual(["src/foo.ts", "lib/bar.ts"]);
+      expect(result!.rootFilesTouched).toBe(false);
+    });
+
+    it("flags rootFilesTouched when a path has no slash", async () => {
+      mockGit.raw.mockResolvedValue("README.md\nsrc/foo.ts\n");
+
+      const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/main");
+
+      expect(result).not.toBeNull();
+      expect(result!.paths).toEqual(["README.md", "src/foo.ts"]);
+      expect(result!.rootFilesTouched).toBe(true);
+    });
+
+    it("returns null on git error so caller can force a safe update", async () => {
+      mockGit.raw.mockRejectedValue(new Error("bad ref"));
+
+      const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/missing");
+
+      expect(result).toBeNull();
+    });
+
+    it("trims and drops blank lines", async () => {
+      mockGit.raw.mockResolvedValue("\n  src/foo.ts  \n\n  lib/bar.ts\n");
+
+      const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/main");
+
+      expect(result).not.toBeNull();
+      expect(result!.paths).toEqual(["src/foo.ts", "lib/bar.ts"]);
+    });
+  });
 });

--- a/src/services/__tests__/git-update.test.ts
+++ b/src/services/__tests__/git-update.test.ts
@@ -178,12 +178,12 @@ describe("GitService - Update Methods", () => {
       expect(result).toBeNull();
     });
 
-    it("trims and drops blank lines", async () => {
-      mockGit.raw.mockResolvedValue("\n  src/foo.ts  \n\n  lib/bar.ts\n");
+    it("preserves leading/trailing whitespace, strips CRLF, drops blanks", async () => {
+      mockGit.raw.mockResolvedValue("\n  src/foo.ts  \r\n\nlib/bar.ts\r\n");
 
       const result = await service.getChangedPathsInRange("/wt", "HEAD", "origin/main");
 
-      expect(result).toEqual(["src/foo.ts", "lib/bar.ts"]);
+      expect(result).toEqual(["  src/foo.ts  ", "lib/bar.ts"]);
     });
   });
 });

--- a/src/services/__tests__/interactive-ui.service.test.ts
+++ b/src/services/__tests__/interactive-ui.service.test.ts
@@ -10,6 +10,7 @@ import type { Config } from "../../types";
 import type { WorktreeSyncService } from "../worktree-sync.service";
 import type * as ChildProcessModule from "child_process";
 import type * as FsModule from "fs";
+import type * as cron from "node-cron";
 import type { Mock, Mocked } from "vitest";
 
 const { mockConfigLoaderInstance, mockWorktreeSyncServiceInstance, mockSpawn, mockSpawnSync, mockExistsSync } =
@@ -304,6 +305,42 @@ describe("InteractiveUIService", () => {
 
       expect(statusSpy).not.toHaveBeenCalled();
       expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("should resolve quickly when called with fast option even if sync stays in progress", async () => {
+      mockSyncService.isSyncInProgress.mockReturnValue(true);
+      const service = new InteractiveUIService([mockSyncService]);
+
+      vi.useFakeTimers();
+      try {
+        const destroyPromise = service.destroy(true);
+        await vi.advanceTimersByTimeAsync(2500);
+        await expect(destroyPromise).resolves.toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockUnmount).toHaveBeenCalled();
+    });
+
+    it("should use slow timeout by default when sync is not in progress", async () => {
+      mockSyncService.isSyncInProgress.mockReturnValue(false);
+      const service = new InteractiveUIService([mockSyncService]);
+
+      await expect(service.destroy()).resolves.toBeUndefined();
+      expect(mockUnmount).toHaveBeenCalled();
+    });
+  });
+
+  describe("registerCronJob", () => {
+    it("should stop registered cron jobs on destroy", async () => {
+      const service = new InteractiveUIService([mockSyncService]);
+      const stopSpy = vi.fn();
+      service.registerCronJob({ stop: stopSpy } as unknown as cron.ScheduledTask);
+
+      await service.destroy();
+
+      expect(stopSpy).toHaveBeenCalled();
     });
   });
 

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -210,4 +210,80 @@ describe("SparseCheckoutService", () => {
       expect(service.patternsEqual(["a"], ["a", "b"])).toBe(false);
     });
   });
+
+  describe("pathsTouchSparse (cone mode)", () => {
+    it("returns false when changed paths list is empty", () => {
+      expect(service.pathsTouchSparse([], false, { include: ["src"] })).toBe(false);
+    });
+
+    it("returns true when a changed path lies inside an include directory", () => {
+      expect(service.pathsTouchSparse(["src/foo.ts"], false, { include: ["src"] })).toBe(true);
+    });
+
+    it("returns false when changed paths are all outside the include directories", () => {
+      expect(service.pathsTouchSparse(["lib/foo.ts", "tools/x.ts"], false, { include: ["src"] })).toBe(false);
+    });
+
+    it("treats trailing slash on patterns as equivalent", () => {
+      expect(service.pathsTouchSparse(["src/foo.ts"], false, { include: ["src/"] })).toBe(true);
+    });
+
+    it("matches nested include paths exactly", () => {
+      expect(service.pathsTouchSparse(["tools/build/x.ts"], false, { include: ["tools/build"] })).toBe(true);
+      expect(service.pathsTouchSparse(["tools/other/x.ts"], false, { include: ["tools/build"] })).toBe(false);
+    });
+
+    it("matches files directly inside ancestors of a nested include (cone keeps parent files)", () => {
+      // For include "tools/build", git's cone mode also checks out files directly in "tools/"
+      expect(service.pathsTouchSparse(["tools/file.txt"], false, { include: ["tools/build"] })).toBe(true);
+    });
+
+    it("does not match files in sibling directories of an ancestor", () => {
+      expect(service.pathsTouchSparse(["other/file.txt"], false, { include: ["tools/build"] })).toBe(false);
+    });
+
+    it("matches direct files of every ancestor for deeply nested includes", () => {
+      const cfg = { include: ["a/b/c/d"] };
+      expect(service.pathsTouchSparse(["a/x"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/x"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/c/x"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/c/d/x"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/d/x"], false, cfg)).toBe(false);
+      expect(service.pathsTouchSparse(["a/b/c/sibling/x"], false, cfg)).toBe(false);
+    });
+
+    it("returns true when a root file is touched (cone always materializes root files)", () => {
+      expect(service.pathsTouchSparse(["README.md"], true, { include: ["src"] })).toBe(true);
+    });
+
+    it("does not match a sibling directory whose name shares a prefix", () => {
+      expect(service.pathsTouchSparse(["sources/foo.ts"], false, { include: ["src"] })).toBe(false);
+    });
+
+    it("matches when include itself is the exact path", () => {
+      expect(service.pathsTouchSparse(["src"], false, { include: ["src"] })).toBe(true);
+    });
+
+    it("returns true (force update) when include list is effectively empty", () => {
+      expect(service.pathsTouchSparse(["lib/foo.ts"], false, { include: ["", "  "] })).toBe(true);
+    });
+
+    it("supports multiple include patterns", () => {
+      const cfg = { include: ["react-game-client", "jenkins"] };
+      expect(service.pathsTouchSparse(["jenkins/Jenkinsfile"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["autocue/main.ts"], false, cfg)).toBe(false);
+    });
+  });
+
+  describe("pathsTouchSparse (no-cone mode)", () => {
+    it("returns true conservatively for any non-empty diff (no-cone matching not implemented)", () => {
+      const cfg: SparseCheckoutConfig = { include: ["/*"], exclude: ["docs"] };
+      expect(service.pathsTouchSparse(["lib/foo.ts"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["docs/x.md"], false, cfg)).toBe(true);
+    });
+
+    it("still returns false for empty diff in no-cone", () => {
+      expect(service.pathsTouchSparse([], false, { include: ["/*"], exclude: ["docs"] })).toBe(false);
+    });
+  });
 });

--- a/src/services/__tests__/sparse-checkout.service.test.ts
+++ b/src/services/__tests__/sparse-checkout.service.test.ts
@@ -213,77 +213,77 @@ describe("SparseCheckoutService", () => {
 
   describe("pathsTouchSparse (cone mode)", () => {
     it("returns false when changed paths list is empty", () => {
-      expect(service.pathsTouchSparse([], false, { include: ["src"] })).toBe(false);
+      expect(service.pathsTouchSparse([], { include: ["src"] })).toBe(false);
     });
 
     it("returns true when a changed path lies inside an include directory", () => {
-      expect(service.pathsTouchSparse(["src/foo.ts"], false, { include: ["src"] })).toBe(true);
+      expect(service.pathsTouchSparse(["src/foo.ts"], { include: ["src"] })).toBe(true);
     });
 
     it("returns false when changed paths are all outside the include directories", () => {
-      expect(service.pathsTouchSparse(["lib/foo.ts", "tools/x.ts"], false, { include: ["src"] })).toBe(false);
+      expect(service.pathsTouchSparse(["lib/foo.ts", "tools/x.ts"], { include: ["src"] })).toBe(false);
     });
 
     it("treats trailing slash on patterns as equivalent", () => {
-      expect(service.pathsTouchSparse(["src/foo.ts"], false, { include: ["src/"] })).toBe(true);
+      expect(service.pathsTouchSparse(["src/foo.ts"], { include: ["src/"] })).toBe(true);
     });
 
     it("matches nested include paths exactly", () => {
-      expect(service.pathsTouchSparse(["tools/build/x.ts"], false, { include: ["tools/build"] })).toBe(true);
-      expect(service.pathsTouchSparse(["tools/other/x.ts"], false, { include: ["tools/build"] })).toBe(false);
+      expect(service.pathsTouchSparse(["tools/build/x.ts"], { include: ["tools/build"] })).toBe(true);
+      expect(service.pathsTouchSparse(["tools/other/x.ts"], { include: ["tools/build"] })).toBe(false);
     });
 
     it("matches files directly inside ancestors of a nested include (cone keeps parent files)", () => {
       // For include "tools/build", git's cone mode also checks out files directly in "tools/"
-      expect(service.pathsTouchSparse(["tools/file.txt"], false, { include: ["tools/build"] })).toBe(true);
+      expect(service.pathsTouchSparse(["tools/file.txt"], { include: ["tools/build"] })).toBe(true);
     });
 
     it("does not match files in sibling directories of an ancestor", () => {
-      expect(service.pathsTouchSparse(["other/file.txt"], false, { include: ["tools/build"] })).toBe(false);
+      expect(service.pathsTouchSparse(["other/file.txt"], { include: ["tools/build"] })).toBe(false);
     });
 
     it("matches direct files of every ancestor for deeply nested includes", () => {
       const cfg = { include: ["a/b/c/d"] };
-      expect(service.pathsTouchSparse(["a/x"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["a/b/x"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["a/b/c/x"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["a/b/c/d/x"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["a/b/d/x"], false, cfg)).toBe(false);
-      expect(service.pathsTouchSparse(["a/b/c/sibling/x"], false, cfg)).toBe(false);
+      expect(service.pathsTouchSparse(["a/x"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/x"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/c/x"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/c/d/x"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["a/b/d/x"], cfg)).toBe(false);
+      expect(service.pathsTouchSparse(["a/b/c/sibling/x"], cfg)).toBe(false);
     });
 
     it("returns true when a root file is touched (cone always materializes root files)", () => {
-      expect(service.pathsTouchSparse(["README.md"], true, { include: ["src"] })).toBe(true);
+      expect(service.pathsTouchSparse(["README.md"], { include: ["src"] })).toBe(true);
     });
 
     it("does not match a sibling directory whose name shares a prefix", () => {
-      expect(service.pathsTouchSparse(["sources/foo.ts"], false, { include: ["src"] })).toBe(false);
+      expect(service.pathsTouchSparse(["sources/foo.ts"], { include: ["src"] })).toBe(false);
     });
 
     it("matches when include itself is the exact path", () => {
-      expect(service.pathsTouchSparse(["src"], false, { include: ["src"] })).toBe(true);
+      expect(service.pathsTouchSparse(["src"], { include: ["src"] })).toBe(true);
     });
 
     it("returns true (force update) when include list is effectively empty", () => {
-      expect(service.pathsTouchSparse(["lib/foo.ts"], false, { include: ["", "  "] })).toBe(true);
+      expect(service.pathsTouchSparse(["lib/foo.ts"], { include: ["", "  "] })).toBe(true);
     });
 
     it("supports multiple include patterns", () => {
       const cfg = { include: ["react-game-client", "jenkins"] };
-      expect(service.pathsTouchSparse(["jenkins/Jenkinsfile"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["autocue/main.ts"], false, cfg)).toBe(false);
+      expect(service.pathsTouchSparse(["jenkins/Jenkinsfile"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["autocue/main.ts"], cfg)).toBe(false);
     });
   });
 
   describe("pathsTouchSparse (no-cone mode)", () => {
     it("returns true conservatively for any non-empty diff (no-cone matching not implemented)", () => {
       const cfg: SparseCheckoutConfig = { include: ["/*"], exclude: ["docs"] };
-      expect(service.pathsTouchSparse(["lib/foo.ts"], false, cfg)).toBe(true);
-      expect(service.pathsTouchSparse(["docs/x.md"], false, cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["lib/foo.ts"], cfg)).toBe(true);
+      expect(service.pathsTouchSparse(["docs/x.md"], cfg)).toBe(true);
     });
 
     it("still returns false for empty diff in no-cone", () => {
-      expect(service.pathsTouchSparse([], false, { include: ["/*"], exclude: ["docs"] })).toBe(false);
+      expect(service.pathsTouchSparse([], { include: ["/*"], exclude: ["docs"] })).toBe(false);
     });
   });
 });

--- a/src/services/__tests__/worktree-update.test.ts
+++ b/src/services/__tests__/worktree-update.test.ts
@@ -322,7 +322,7 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
 
       service = new WorktreeSyncService(mockConfig);
 
-      getChangedPathsInRange = vi.fn().mockResolvedValue({ paths: [], rootFilesTouched: false });
+      getChangedPathsInRange = vi.fn().mockResolvedValue([]);
       sparseService = {
         resolveMode: vi.fn().mockReturnValue("cone"),
         pathsTouchSparse: vi.fn().mockReturnValue(true),
@@ -345,7 +345,7 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
     it("skips update when diff has no paths inside sparse include", async () => {
       setup(true);
       mockGitService.isWorktreeBehind.mockResolvedValue(true);
-      getChangedPathsInRange.mockResolvedValue({ paths: ["lib/x.ts"], rootFilesTouched: false });
+      getChangedPathsInRange.mockResolvedValue(["lib/x.ts"]);
       sparseService.pathsTouchSparse.mockReturnValue(false);
 
       await service.sync();
@@ -358,7 +358,7 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
     it("proceeds with update when diff includes a path inside sparse", async () => {
       setup(true);
       mockGitService.isWorktreeBehind.mockResolvedValue(true);
-      getChangedPathsInRange.mockResolvedValue({ paths: ["src/foo.ts"], rootFilesTouched: false });
+      getChangedPathsInRange.mockResolvedValue(["src/foo.ts"]);
       sparseService.pathsTouchSparse.mockReturnValue(true);
 
       await service.sync();
@@ -379,7 +379,7 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
     it("defaults to enabled when sparseCheckout is set without an explicit flag", async () => {
       setup(undefined);
       mockGitService.isWorktreeBehind.mockResolvedValue(true);
-      getChangedPathsInRange.mockResolvedValue({ paths: ["lib/x.ts"], rootFilesTouched: false });
+      getChangedPathsInRange.mockResolvedValue(["lib/x.ts"]);
       sparseService.pathsTouchSparse.mockReturnValue(false);
 
       await service.sync();

--- a/src/services/__tests__/worktree-update.test.ts
+++ b/src/services/__tests__/worktree-update.test.ts
@@ -303,4 +303,112 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
       expect(mockLogger.info).toHaveBeenCalledWith("  - All worktrees are up to date.");
     });
   });
+
+  describe("skipUpdateWhenOutsideSparse (cone mode)", () => {
+    let getChangedPathsInRange: Mock;
+    let sparseService: { resolveMode: Mock; pathsTouchSparse: Mock };
+
+    function setup(skipFlag: boolean | undefined) {
+      mockConfig = {
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "/test/worktrees",
+        cronSchedule: "0 * * * *",
+        runOnce: true,
+        updateExistingWorktrees: true,
+        sparseCheckout:
+          skipFlag === undefined ? { include: ["src"] } : { include: ["src"], skipUpdateWhenOutsideSparse: skipFlag },
+        logger: mockLogger,
+      };
+
+      service = new WorktreeSyncService(mockConfig);
+
+      getChangedPathsInRange = vi.fn().mockResolvedValue({ paths: [], rootFilesTouched: false });
+      sparseService = {
+        resolveMode: vi.fn().mockReturnValue("cone"),
+        pathsTouchSparse: vi.fn().mockReturnValue(true),
+        buildPatterns: vi.fn().mockReturnValue(["src"]),
+        readCurrent: vi.fn().mockResolvedValue(["src"]),
+        patternsEqual: vi.fn().mockReturnValue(true),
+        isNarrowing: vi.fn().mockReturnValue(false),
+        applyToWorktree: vi.fn().mockResolvedValue(undefined),
+      } as any;
+
+      mockGitService = {
+        ...mockGitService,
+        getSparseCheckoutService: vi.fn().mockReturnValue(sparseService),
+        getChangedPathsInRange,
+      } as any;
+
+      (service as any).gitService = mockGitService;
+    }
+
+    it("skips update when diff has no paths inside sparse include", async () => {
+      setup(true);
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+      getChangedPathsInRange.mockResolvedValue({ paths: ["lib/x.ts"], rootFilesTouched: false });
+      sparseService.pathsTouchSparse.mockReturnValue(false);
+
+      await service.sync();
+
+      expect(getChangedPathsInRange).toHaveBeenCalled();
+      expect(mockGitService.updateWorktree).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("upstream changes outside sparse paths"));
+    });
+
+    it("proceeds with update when diff includes a path inside sparse", async () => {
+      setup(true);
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+      getChangedPathsInRange.mockResolvedValue({ paths: ["src/foo.ts"], rootFilesTouched: false });
+      sparseService.pathsTouchSparse.mockReturnValue(true);
+
+      await service.sync();
+
+      expect(mockGitService.updateWorktree).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not consult diff when flag is explicitly disabled", async () => {
+      setup(false);
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+
+      await service.sync();
+
+      expect(getChangedPathsInRange).not.toHaveBeenCalled();
+      expect(mockGitService.updateWorktree).toHaveBeenCalledTimes(3);
+    });
+
+    it("defaults to enabled when sparseCheckout is set without an explicit flag", async () => {
+      setup(undefined);
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+      getChangedPathsInRange.mockResolvedValue({ paths: ["lib/x.ts"], rootFilesTouched: false });
+      sparseService.pathsTouchSparse.mockReturnValue(false);
+
+      await service.sync();
+
+      expect(getChangedPathsInRange).toHaveBeenCalled();
+      expect(mockGitService.updateWorktree).not.toHaveBeenCalled();
+    });
+
+    it("skips diff and updates normally in no-cone mode", async () => {
+      setup(true);
+      sparseService.resolveMode.mockReturnValue("no-cone");
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+
+      await service.sync();
+
+      expect(getChangedPathsInRange).not.toHaveBeenCalled();
+      expect(mockGitService.updateWorktree).toHaveBeenCalledTimes(3);
+    });
+
+    it("forces update when diff fails (returns null) so a behind worktree is never silently left stale", async () => {
+      setup(true);
+      mockGitService.isWorktreeBehind.mockResolvedValue(true);
+      getChangedPathsInRange.mockResolvedValue(null);
+
+      await service.sync();
+
+      expect(getChangedPathsInRange).toHaveBeenCalled();
+      expect(sparseService.pathsTouchSparse).not.toHaveBeenCalled();
+      expect(mockGitService.updateWorktree).toHaveBeenCalledTimes(3);
+    });
+  });
 });

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -940,11 +940,7 @@ export class GitService {
     }
   }
 
-  async getChangedPathsInRange(
-    worktreePath: string,
-    fromRef: string,
-    toRef: string,
-  ): Promise<{ paths: string[]; rootFilesTouched: boolean } | null> {
+  async getChangedPathsInRange(worktreePath: string, fromRef: string, toRef: string): Promise<string[] | null> {
     const worktreeGit = this.getCachedGit(worktreePath);
     try {
       const out = await worktreeGit.raw([
@@ -955,12 +951,10 @@ export class GitService {
         "--no-renames",
         `${fromRef}..${toRef}`,
       ]);
-      const paths = out
+      return out
         .split("\n")
         .map((l) => l.trim())
         .filter((l) => l.length > 0);
-      const rootFilesTouched = paths.some((p) => !p.includes("/"));
-      return { paths, rootFilesTouched };
     } catch (error) {
       this.logger.warn(`Failed to compute diff ${fromRef}..${toRef} in ${worktreePath}: ${getErrorMessage(error)}`);
       return null;

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -940,6 +940,33 @@ export class GitService {
     }
   }
 
+  async getChangedPathsInRange(
+    worktreePath: string,
+    fromRef: string,
+    toRef: string,
+  ): Promise<{ paths: string[]; rootFilesTouched: boolean } | null> {
+    const worktreeGit = this.getCachedGit(worktreePath);
+    try {
+      const out = await worktreeGit.raw([
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-only",
+        "--no-renames",
+        `${fromRef}..${toRef}`,
+      ]);
+      const paths = out
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      const rootFilesTouched = paths.some((p) => !p.includes("/"));
+      return { paths, rootFilesTouched };
+    } catch (error) {
+      this.logger.warn(`Failed to compute diff ${fromRef}..${toRef} in ${worktreePath}: ${getErrorMessage(error)}`);
+      return null;
+    }
+  }
+
   async compareTreeContent(worktreePath: string, branch: string): Promise<boolean> {
     const worktreeGit = this.getCachedGit(worktreePath);
     try {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -951,9 +951,12 @@ export class GitService {
         "--no-renames",
         `${fromRef}..${toRef}`,
       ]);
+      // Don't .trim() entries — leading/trailing whitespace is valid in POSIX
+      // paths and `core.quotePath=false` only affects high-byte quoting, not
+      // whitespace. Strip a trailing CR for Windows line endings only.
       return out
         .split("\n")
-        .map((l) => l.trim())
+        .map((l) => l.replace(/\r$/, ""))
         .filter((l) => l.length > 0);
     } catch (error) {
       this.logger.warn(`Failed to compute diff ${fromRef}..${toRef} in ${worktreePath}: ${getErrorMessage(error)}`);

--- a/src/services/sparse-checkout.service.ts
+++ b/src/services/sparse-checkout.service.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 import simpleGit from "simple-git";
 
 import { Logger } from "./logger.service";
@@ -7,10 +9,17 @@ import type { SimpleGit } from "simple-git";
 
 export type GitFactory = (worktreePath: string) => SimpleGit;
 
+interface SparseMatcher {
+  mode: SparseCheckoutMode;
+  patterns: string[];
+  ancestorDirs: Set<string>;
+}
+
 export class SparseCheckoutService {
   private logger: Logger;
   private gitFactory: GitFactory;
   private warnedConfigs = new WeakSet<SparseCheckoutConfig>();
+  private matcherCache = new WeakMap<SparseCheckoutConfig, SparseMatcher>();
 
   constructor(logger?: Logger, gitFactory?: GitFactory) {
     this.logger = logger ?? Logger.createDefault();
@@ -137,25 +146,44 @@ export class SparseCheckoutService {
    * No-cone mode: gitignore-style matching with negation is non-trivial and
    * not implemented here yet. We return `true` so the caller falls back to
    * the safe behavior of always running the update.
+   *
+   * The matcher derived from `cfg` is cached on the cfg object identity
+   * (WeakMap), so callers should reuse the same `cfg` reference across
+   * invocations to benefit from the cache.
    */
-  pathsTouchSparse(changedPaths: string[], rootFilesTouched: boolean, cfg: SparseCheckoutConfig): boolean {
+  pathsTouchSparse(changedPaths: string[], cfg: SparseCheckoutConfig): boolean {
     if (changedPaths.length === 0) return false;
+
+    const matcher = this.getMatcher(cfg);
+    if (matcher.mode === "no-cone") return true;
+    if (matcher.patterns.length === 0) return true;
+
+    return changedPaths.some((p) => {
+      if (!p.includes("/")) return true;
+      for (const pat of matcher.patterns) {
+        if (p === pat || p.startsWith(pat + "/")) return true;
+      }
+      return matcher.ancestorDirs.has(path.posix.dirname(p));
+    });
+  }
+
+  private getMatcher(cfg: SparseCheckoutConfig): SparseMatcher {
+    const cached = this.matcherCache.get(cfg);
+    if (cached) return cached;
 
     const mode = this.resolveMode(cfg);
     if (mode === "no-cone") {
-      return true;
+      const matcher: SparseMatcher = { mode, patterns: [], ancestorDirs: new Set() };
+      this.matcherCache.set(cfg, matcher);
+      return matcher;
     }
-
-    if (rootFilesTouched) return true;
 
     const patterns = cfg.include
       .map((p) => p.trim())
       .filter((p) => p.length > 0)
       .map((p) => (p.endsWith("/") ? p.slice(0, -1) : p));
 
-    if (patterns.length === 0) return true;
-
-    const ancestorDirs = new Set<string>([""]);
+    const ancestorDirs = new Set<string>();
     for (const pat of patterns) {
       const parts = pat.split("/");
       for (let i = 1; i < parts.length; i++) {
@@ -163,13 +191,8 @@ export class SparseCheckoutService {
       }
     }
 
-    return changedPaths.some((p) => {
-      for (const pat of patterns) {
-        if (p === pat || p.startsWith(pat + "/")) return true;
-      }
-      const lastSlash = p.lastIndexOf("/");
-      const parentDir = lastSlash === -1 ? "" : p.substring(0, lastSlash);
-      return ancestorDirs.has(parentDir);
-    });
+    const matcher: SparseMatcher = { mode, patterns, ancestorDirs };
+    this.matcherCache.set(cfg, matcher);
+    return matcher;
   }
 }

--- a/src/services/sparse-checkout.service.ts
+++ b/src/services/sparse-checkout.service.ts
@@ -120,4 +120,56 @@ export class SparseCheckoutService {
     const bt = b.map((x) => x.trim());
     return at.every((v, i) => v === bt[i]);
   }
+
+  /**
+   * Decide whether a list of changed file paths intersects the sparse-checkout
+   * set defined by `cfg`. Used to skip fast-forward updates when upstream
+   * commits only touch files outside the materialized worktree.
+   *
+   * Cone mode materializes:
+   *   - all files at the repository root,
+   *   - all files directly inside every ancestor of an included directory
+   *     (e.g. include `tools/build` keeps `tools/foo.txt` checked out too),
+   *   - everything inside an included directory.
+   * We mirror those rules here. Missing the ancestor-files case would let
+   * stale files linger when only those parent files change upstream.
+   *
+   * No-cone mode: gitignore-style matching with negation is non-trivial and
+   * not implemented here yet. We return `true` so the caller falls back to
+   * the safe behavior of always running the update.
+   */
+  pathsTouchSparse(changedPaths: string[], rootFilesTouched: boolean, cfg: SparseCheckoutConfig): boolean {
+    if (changedPaths.length === 0) return false;
+
+    const mode = this.resolveMode(cfg);
+    if (mode === "no-cone") {
+      return true;
+    }
+
+    if (rootFilesTouched) return true;
+
+    const patterns = cfg.include
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+      .map((p) => (p.endsWith("/") ? p.slice(0, -1) : p));
+
+    if (patterns.length === 0) return true;
+
+    const ancestorDirs = new Set<string>([""]);
+    for (const pat of patterns) {
+      const parts = pat.split("/");
+      for (let i = 1; i < parts.length; i++) {
+        ancestorDirs.add(parts.slice(0, i).join("/"));
+      }
+    }
+
+    return changedPaths.some((p) => {
+      for (const pat of patterns) {
+        if (p === pat || p.startsWith(pat + "/")) return true;
+      }
+      const lastSlash = p.lastIndexOf("/");
+      const parentDir = lastSlash === -1 ? "" : p.substring(0, lastSlash);
+      return ancestorDirs.has(parentDir);
+    });
+  }
 }

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -706,7 +706,27 @@ export class WorktreeSyncService {
           }
 
           const isBehind = await this.gitService.isWorktreeBehind(worktree.path);
-          return isBehind ? { action: "update", worktree } : null;
+          if (!isBehind) return null;
+
+          const sparseCfg = this.config.sparseCheckout;
+          if (sparseCfg && sparseCfg.skipUpdateWhenOutsideSparse !== false) {
+            const sparseService = this.gitService.getSparseCheckoutService();
+            if (sparseService.resolveMode(sparseCfg) === "cone") {
+              const diff = await this.gitService.getChangedPathsInRange(
+                worktree.path,
+                "HEAD",
+                `origin/${worktree.branch}`,
+              );
+              // null result means git diff failed — proceed with update for safety
+              // rather than treating the failure as "no sparse paths affected".
+              if (diff !== null && !sparseService.pathsTouchSparse(diff.paths, diff.rootFilesTouched, sparseCfg)) {
+                this.logger.info(`⏭️  Skipping '${worktree.branch}' - upstream changes outside sparse paths`);
+                return null;
+              }
+            }
+          }
+
+          return { action: "update", worktree };
         }),
       ),
     );

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -717,9 +717,8 @@ export class WorktreeSyncService {
                 "HEAD",
                 `origin/${worktree.branch}`,
               );
-              // null result means git diff failed — proceed with update for safety
-              // rather than treating the failure as "no sparse paths affected".
-              if (diff !== null && !sparseService.pathsTouchSparse(diff.paths, diff.rootFilesTouched, sparseCfg)) {
+              // null = git diff failed; force update rather than treat the failure as "no sparse paths affected".
+              if (diff !== null && !sparseService.pathsTouchSparse(diff, sparseCfg)) {
                 this.logger.info(`⏭️  Skipping '${worktree.branch}' - upstream changes outside sparse paths`);
                 return null;
               }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,17 @@ export interface SparseCheckoutConfig {
   include: string[];
   exclude?: string[];
   mode?: SparseCheckoutMode;
+  /**
+   * Skip fast-forward updates of existing worktrees when the upstream diff
+   * does not touch any path inside the sparse-checkout set. Local HEAD lags
+   * remote in those cases, but the working tree would have been a no-op
+   * anyway — set to false to always update HEAD even when no sparse files
+   * change.
+   * Only honored in cone mode; no-cone mode always proceeds with the update
+   * (gitignore-style pattern matching not implemented here).
+   * Default: true.
+   */
+  skipUpdateWhenOutsideSparse?: boolean;
 }
 
 /**

--- a/src/utils/__tests__/signal-handlers.test.ts
+++ b/src/utils/__tests__/signal-handlers.test.ts
@@ -1,0 +1,116 @@
+import { EventEmitter } from "events";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setupSignalHandlers } from "../signal-handlers";
+
+describe("setupSignalHandlers", () => {
+  let proc: NodeJS.EventEmitter;
+  let exit: (code: number) => void;
+  let log: (message: string) => void;
+  let exitMock: ReturnType<typeof vi.fn>;
+  let logMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    proc = new EventEmitter();
+    exitMock = vi.fn();
+    logMock = vi.fn();
+    exit = exitMock as unknown as (code: number) => void;
+    log = logMock as unknown as (message: string) => void;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs registered cleanups in parallel and exits 0 on completion", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log, forceExitMs: 3000 });
+    const order: string[] = [];
+    handle.register(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      order.push("a");
+    });
+    handle.register(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      order.push("b");
+    });
+
+    proc.emit("SIGINT");
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(order).toContain("a");
+    expect(order).toContain("b");
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("force-exits 130 if cleanup exceeds watchdog window", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log, forceExitMs: 3000 });
+    handle.register(() => new Promise(() => {}));
+
+    proc.emit("SIGINT");
+    await vi.advanceTimersByTimeAsync(3001);
+
+    expect(exitMock).toHaveBeenCalledWith(130);
+  });
+
+  it("force-exits 130 immediately on second signal", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log, forceExitMs: 5000 });
+    handle.register(() => new Promise(() => {}));
+
+    proc.emit("SIGINT");
+    proc.emit("SIGINT");
+
+    expect(exitMock).toHaveBeenLastCalledWith(130);
+    expect(logMock).toHaveBeenCalledWith(expect.stringContaining("second SIGINT"));
+  });
+
+  it("passes fast=true to cleanup functions", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log });
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    handle.register(cleanup);
+
+    proc.emit("SIGINT");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(cleanup).toHaveBeenCalledWith(true);
+  });
+
+  it("handles SIGTERM the same as SIGINT", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log });
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    handle.register(cleanup);
+
+    proc.emit("SIGTERM");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(cleanup).toHaveBeenCalledWith(true);
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("dispose removes signal listeners", () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log });
+    expect((proc as EventEmitter).listenerCount("SIGINT")).toBe(1);
+    expect((proc as EventEmitter).listenerCount("SIGTERM")).toBe(1);
+
+    handle.dispose();
+
+    expect((proc as EventEmitter).listenerCount("SIGINT")).toBe(0);
+    expect((proc as EventEmitter).listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("survives a cleanup that throws synchronously", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log });
+    handle.register(() => {
+      throw new Error("boom");
+    });
+    const after = vi.fn();
+    handle.register(after);
+
+    proc.emit("SIGINT");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(after).toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/utils/signal-handlers.ts
+++ b/src/utils/signal-handlers.ts
@@ -1,0 +1,64 @@
+export type CleanupFn = (fast: boolean) => void | Promise<void>;
+
+export interface SignalHandlerOptions {
+  forceExitMs?: number;
+  log?: (message: string) => void;
+  exit?: (code: number) => void;
+  process?: NodeJS.EventEmitter;
+}
+
+export interface SignalHandlerHandle {
+  register: (fn: CleanupFn) => void;
+  dispose: () => void;
+}
+
+export const DEFAULT_FORCE_EXIT_MS = 3000;
+
+export function setupSignalHandlers(options: SignalHandlerOptions = {}): SignalHandlerHandle {
+  const forceExitMs = options.forceExitMs ?? DEFAULT_FORCE_EXIT_MS;
+  const log = options.log ?? ((msg: string): void => console.log(msg));
+  const exit = options.exit ?? ((code: number): void => process.exit(code));
+  const target = options.process ?? process;
+
+  const cleanupFns: CleanupFn[] = [];
+  let signalCount = 0;
+
+  const handler = (signal: string): void => {
+    signalCount += 1;
+    if (signalCount >= 2) {
+      log(`\nReceived second ${signal}, forcing exit.`);
+      exit(130);
+      return;
+    }
+    log(`\nReceived ${signal}, shutting down (Ctrl+C again to force exit)...`);
+
+    const watchdog = setTimeout(() => {
+      log(`\nShutdown took longer than ${forceExitMs}ms, forcing exit.`);
+      exit(130);
+    }, forceExitMs);
+    if (typeof watchdog.unref === "function") {
+      watchdog.unref();
+    }
+
+    void Promise.allSettled(cleanupFns.map((fn) => Promise.resolve().then(() => fn(true)))).then(() => {
+      clearTimeout(watchdog);
+      exit(0);
+    });
+  };
+
+  const sigintListener = (): void => handler("SIGINT");
+  const sigtermListener = (): void => handler("SIGTERM");
+
+  target.on("SIGINT", sigintListener);
+  target.on("SIGTERM", sigtermListener);
+
+  return {
+    register: (fn: CleanupFn): void => {
+      cleanupFns.push(fn);
+    },
+    dispose: (): void => {
+      target.removeListener("SIGINT", sigintListener);
+      target.removeListener("SIGTERM", sigtermListener);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `sparseCheckout.skipUpdateWhenOutsideSparse` (default `true`). In cone mode, Phase 4a now consults `git diff --name-only HEAD..origin/<branch>` and skips the fast-forward when no path lies inside the sparse cone — the working tree would have been a no-op anyway.
- New `SparseCheckoutService.pathsTouchSparse()` mirrors git's cone-mode materialization, including direct files at every ancestor of a nested include (e.g. include `tools/build` keeps `tools/foo.txt` materialized, so a change there still triggers an update).
- New `GitService.getChangedPathsInRange()` runs `git -c core.quotePath=false diff --name-only --no-renames` and returns `null` on git failure so the caller forces a safe update rather than silently skipping a behind worktree.

## Why

Saves LFS smudge, post-checkout hooks, and disk churn for sparse worktrees — especially valuable when one upstream repo is cloned under multiple entries with different sparse slices (each slice independently decides whether the upstream commits affect its files).

## Trade-off

When skipped, the worktree's local HEAD lags the remote tip until upstream advances into the sparse area. `git status` inside the worktree will read "behind by N commits" in that window. Set `skipUpdateWhenOutsideSparse: false` to opt back into strict tracking.

No-cone mode falls through to the existing update path unchanged — gitignore-style pattern matching with negation is intentionally out of scope here.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1083 passed, 9 skipped, 0 failed (E2E suites need `pnpm build` populated `dist/`, unrelated)
- [x] New unit tests for `pathsTouchSparse` covering nested includes, ancestor-file matching, sibling rejection, root files, multi-include configs
- [x] New unit tests for `getChangedPathsInRange` covering args, parsing, null-on-error
- [x] New integration tests in `worktree-update.test.ts` covering: skip when outside sparse, update when inside, default-on behavior, explicit opt-out, no-cone fallback, diff-failure forces update
- [ ] Manual smoke against a sparse repo (e.g. set `skipUpdateWhenOutsideSparse: false` first run, then default true, and confirm the log line `⏭️ Skipping '<branch>' - upstream changes outside sparse paths` appears for unrelated commits)

## Codex review findings (addressed)

1. **Cone parent-dir files** — initial matcher missed direct files in ancestor dirs of nested includes. Fixed by building an ancestor-set per pattern.
2. **Diff failure handling** — earlier draft returned `{ paths: [], rootFilesTouched: false }` on git error, which the caller mistook for "no sparse impact" and silently skipped a behind worktree. Now returns `null`; caller forces update.
3. **Path quoting** (caught proactively) — `git diff --name-only` quotes non-ASCII paths by default. Added `-c core.quotePath=false` so e.g. `tëst.txt` isn't returned as `"t\303\253st.txt"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sparse checkouts (cone mode) can skip unnecessary worktree updates when upstream changes only touch files outside your sparse cone; toggle with a new config flag (enabled by default).
  * New process signal handling utility to manage graceful shutdown and registered cleanup tasks.
  * UI service supports a fast teardown mode and registration of cron jobs for proper lifecycle handling.

* **Tests**
  * Added comprehensive tests for sparse logic, change-path detection, signal handling, and UI lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->