### PR TITLE
feat(progress): emit clone/fetch progress to logger

### DIFF
--- a/.changeset/clone-fetch-progress.md
+++ b/.changeset/clone-fetch-progress.md
@@ -1,0 +1,12 @@
+---
+"sync-worktrees": minor
+---
+
+feat(progress): emit clone/fetch progress to logger
+
+Long bitbucket clones and fetches felt like a hang because the TUI showed `Cloning from "..."` and then went silent for minutes while git negotiated the pack and resolved deltas. Output was being captured by simple-git but never surfaced.
+
+Changes:
+- `GitService` now wires simple-git's `progress` plugin and passes `--progress` to `git clone` and `git fetch`. Per-stage events (`receiving`, `resolving`, `compressing`, `writing`) are throttled to one log line every 25% so the TUI keeps a live "↳ clone receiving: 50% (12345/24690)" trail without flooding the log.
+- Applies to bare clone (`initialize`), the post-init `--all` refresh, `fetchAll`, and `fetchBranch`.
+- Per-call `progressState` reset between fetches so the same stage reports fresh buckets each run.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const GIT_CONSTANTS = {
     REMOTES_ORIGIN: "refs/remotes/origin/*",
   },
   FETCH_CONFIG: "+refs/heads/*:refs/remotes/origin/*",
+  PROGRESS_BUCKET_PERCENT: 25,
 } as const;
 
 export const GIT_OPERATIONS = {

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -121,11 +121,11 @@ describe("GitService", () => {
       const git = await gitService.initialize();
 
       expect(fs.access).toHaveBeenCalledWith(".bare/repo/HEAD");
-      expect(simpleGit).toHaveBeenCalledWith(".bare/repo");
+      expect(simpleGit).toHaveBeenCalledWith(".bare/repo", expect.objectContaining({ progress: expect.any(Function) }));
       expect(mockGit.raw).toHaveBeenCalledWith(["config", "--get-all", "remote.origin.fetch"]);
       expect(mockGit.addConfig).toHaveBeenCalledWith("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*");
       // Fetch is always called to ensure remote refs are up-to-date
-      expect(mockGit.fetch).toHaveBeenCalledWith(["--all"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["--all", "--progress"]);
       expect(git).toBe(mockGit);
     });
 
@@ -144,11 +144,11 @@ describe("GitService", () => {
 
       expect(fs.access).toHaveBeenCalledWith(".bare/repo/HEAD");
       expect(fs.mkdir).toHaveBeenCalled();
-      expect(simpleGit).toHaveBeenCalledWith(); // Called without args for cloning
-      expect(mockGit.clone).toHaveBeenCalledWith(TEST_URLS.github, ".bare/repo", ["--bare"]);
+      expect(simpleGit).toHaveBeenCalledWith(expect.objectContaining({ progress: expect.any(Function) }));
+      expect(mockGit.clone).toHaveBeenCalledWith(TEST_URLS.github, ".bare/repo", ["--bare", "--progress"]);
       expect(mockGit.raw).toHaveBeenCalledWith(["config", "--get-all", "remote.origin.fetch"]);
       expect(mockGit.addConfig).toHaveBeenCalledWith("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*");
-      expect(mockGit.fetch).toHaveBeenCalledWith(["--all"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["--all", "--progress"]);
     });
 
     it("should create main worktree if it doesn't exist", async () => {
@@ -169,7 +169,7 @@ describe("GitService", () => {
       await gitService.initialize();
 
       // Fetch is always called to ensure remote refs are up-to-date
-      expect(mockGit.fetch).toHaveBeenCalledWith(["--all"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["--all", "--progress"]);
       expect(fs.mkdir).toHaveBeenCalledWith(TEST_PATHS.worktree, { recursive: true });
       expect(mockGit.raw).toHaveBeenCalledWith([
         "worktree",
@@ -209,7 +209,7 @@ describe("GitService", () => {
       await relativeGitService.initialize();
 
       // Fetch is always called to ensure remote refs are up-to-date
-      expect(mockGit.fetch).toHaveBeenCalledWith(["--all"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["--all", "--progress"]);
       // Verify that the worktree add command received an absolute path
       const expectedAbsolutePath = path.resolve("./test/worktrees/main");
       expect(mockGit.raw).toHaveBeenCalledWith([
@@ -256,11 +256,11 @@ describe("GitService", () => {
       const git = await gitService.initialize();
 
       expect(fs.access).toHaveBeenCalledWith(".bare/repo/HEAD");
-      expect(simpleGit).toHaveBeenCalledWith(".bare/repo");
+      expect(simpleGit).toHaveBeenCalledWith(".bare/repo", expect.objectContaining({ progress: expect.any(Function) }));
       expect(mockGit.raw).toHaveBeenCalledWith(["config", "--get-all", "remote.origin.fetch"]);
       expect(mockGit.addConfig).not.toHaveBeenCalled(); // Should not add config if it already exists
       // Fetch is always called to ensure remote refs are up-to-date
-      expect(mockGit.fetch).toHaveBeenCalledWith(["--all"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["--all", "--progress"]);
       expect(git).toBe(mockGit);
     });
   });
@@ -297,7 +297,7 @@ describe("GitService", () => {
       await gitService.initialize();
 
       await gitService.fetchBranch("feature-1");
-      expect(mockGit.fetch).toHaveBeenCalledWith(["origin", "feature-1", "--prune"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["origin", "feature-1", "--prune", "--progress"]);
     });
 
     it("should respect LFS skip when fetching branch", async () => {
@@ -313,7 +313,7 @@ describe("GitService", () => {
       await svc.initialize();
       await svc.fetchBranch("feature-2");
       expect(mockGit.env).toHaveBeenCalledWith({ GIT_LFS_SKIP_SMUDGE: "1" });
-      expect(mockGit.fetch).toHaveBeenCalledWith(["origin", "feature-2", "--prune"]);
+      expect(mockGit.fetch).toHaveBeenCalledWith(["origin", "feature-2", "--prune", "--progress"]);
     });
   });
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -102,7 +102,12 @@ export class GitService {
       if (event.method !== "fetch" && event.method !== "clone" && event.method !== "pull") return;
       const key = `${event.method}:${event.stage}`;
       const bucket = Math.floor(event.progress / GIT_CONSTANTS.PROGRESS_BUCKET_PERCENT);
-      const last = lastBucket.get(key) ?? -1;
+      let last = lastBucket.get(key) ?? -1;
+      // Stage restart on a new operation (e.g. second fetch on the same cached SimpleGit
+      // instance): bucket regresses below `last`. Reset so the new run logs from scratch.
+      if (bucket < last) {
+        last = -1;
+      }
       if (bucket <= last && event.progress < 100) return;
       lastBucket.set(key, bucket);
       const total = event.total > 0 ? `${event.processed}/${event.total}` : `${event.processed}`;

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -17,7 +17,7 @@ import { WorktreeStatusService } from "./worktree-status.service";
 import type { WorktreeStatusResult } from "./worktree-status.service";
 import type { Config } from "../types";
 import type { SyncMetadata } from "../types/sync-metadata";
-import type { SimpleGit } from "simple-git";
+import type { SimpleGit, SimpleGitOptions, SimpleGitProgressEvent } from "simple-git";
 
 export type GitServiceOptions = Pick<
   Config,
@@ -83,12 +83,31 @@ export class GitService {
     const key = `${path.resolve(dirPath)}::${useLfsSkip ? "1" : "0"}`;
     let git = this.gitInstances.get(key);
     if (!git) {
-      const block = this.getFetchTimeoutMs();
-      const base = block > 0 ? simpleGit(dirPath, { timeout: { block } }) : simpleGit(dirPath);
+      const base = simpleGit(dirPath, this.buildSimpleGitOptions(this.getFetchTimeoutMs()));
       git = useLfsSkip ? base.env({ [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" }) : base;
       this.gitInstances.set(key, git);
     }
     return git;
+  }
+
+  private buildSimpleGitOptions(blockMs: number): Partial<SimpleGitOptions> {
+    const options: Partial<SimpleGitOptions> = { progress: this.makeProgressHandler() };
+    if (blockMs > 0) options.timeout = { block: blockMs };
+    return options;
+  }
+
+  private makeProgressHandler(): (event: SimpleGitProgressEvent) => void {
+    const lastBucket = new Map<string, number>();
+    return (event: SimpleGitProgressEvent): void => {
+      if (event.method !== "fetch" && event.method !== "clone" && event.method !== "pull") return;
+      const key = `${event.method}:${event.stage}`;
+      const bucket = Math.floor(event.progress / GIT_CONSTANTS.PROGRESS_BUCKET_PERCENT);
+      const last = lastBucket.get(key) ?? -1;
+      if (bucket <= last && event.progress < 100) return;
+      lastBucket.set(key, bucket);
+      const total = event.total > 0 ? `${event.processed}/${event.total}` : `${event.processed}`;
+      this.logger.info(`  ↳ ${event.method} ${event.stage}: ${event.progress}% (${total})`);
+    };
   }
 
   updateLogger(logger: Logger): void {
@@ -106,12 +125,11 @@ export class GitService {
       // Clone as bare repository
       this.logger.info(`Cloning from "${repoUrl}" as bare repository into "${this.bareRepoPath}"...`);
       await fs.mkdir(path.dirname(this.bareRepoPath), { recursive: true });
-      const cloneBlock = this.getCloneTimeoutMs();
-      const cloneBase = cloneBlock > 0 ? simpleGit({ timeout: { block: cloneBlock } }) : simpleGit();
+      const cloneBase = simpleGit(this.buildSimpleGitOptions(this.getCloneTimeoutMs()));
       const cloneGit = this.isLfsSkipEnabled()
         ? cloneBase.env({ [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" })
         : cloneBase;
-      await cloneGit.clone(repoUrl, this.bareRepoPath, ["--bare"]);
+      await cloneGit.clone(repoUrl, this.bareRepoPath, ["--bare", "--progress"]);
       this.logger.info("✅ Clone successful.");
     }
 
@@ -134,7 +152,7 @@ export class GitService {
     // Always fetch to ensure remote refs are up-to-date
     // This is needed for branch creation UI even when repo already exists
     this.logger.info("Fetching remote branches...");
-    await bareGit.fetch(["--all"]);
+    await bareGit.fetch(["--all", "--progress"]);
 
     // Detect the default branch (works from local refs even without fetch)
     this.defaultBranch = await this.detectDefaultBranch(bareGit);
@@ -235,13 +253,13 @@ export class GitService {
     this.assertInitialized();
     this.logger.info("Fetching latest data from remote...");
     const git = this.getCachedGit(this.mainWorktreePath, this.isLfsSkipEnabled());
-    await git.fetch(["--all", "--prune"]);
+    await git.fetch(["--all", "--prune", "--progress"]);
   }
 
   async fetchBranch(branchName: string): Promise<void> {
     this.assertInitialized();
     const git = this.getCachedGit(this.mainWorktreePath, this.isLfsSkipEnabled());
-    await git.fetch(["origin", branchName, "--prune"]);
+    await git.fetch(["origin", branchName, "--prune", "--progress"]);
   }
 
   private assertInitialized(): void {


### PR DESCRIPTION
## Summary
- Long bitbucket clones felt like a hang because the TUI showed `Cloning from "..."` then went silent for minutes during pack negotiation. simple-git captured the output but never surfaced it.
- Wire simple-git's `progress` plugin and pass `--progress` to clone + fetch. Per-stage events (`receiving`, `resolving`, `compressing`, `writing`) throttle to one log line every 25% — TUI gets a live `↳ clone receiving: 50% (12345/24690)` trail without flooding.
- Applies to bare clone (`initialize`), the post-init `--all` refresh, `fetchAll`, `fetchBranch`.
- Bucket state lives in a closure-local Map per handler — concurrent fetches on the same GitService can't stomp each other. simple-git options construction shared via `buildSimpleGitOptions(blockMs)`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (1058 pass, 9 skipped)
- [ ] Manual: run sync against a slow bitbucket repo, confirm `↳ clone receiving: N%` lines appear in TUI during clone
- [ ] Manual: verify no regression on small/fast repos (progress lines bounded to ~5 per stage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git operations (clone, fetch) now emit progress updates to the logger, displaying per-stage events while throttling output to prevent log flooding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->