### PR TITLE
[codex] fix create_worktree new branches

### DIFF
--- a/.changeset/hook-test-flake-fix.md
+++ b/.changeset/hook-test-flake-fix.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Stabilize the hook-execution test suite by awaiting actual child-process completion via the `onComplete` callback instead of a fixed 500 ms sleep, removing a flake that surfaced under the full parallel test run.

--- a/.changeset/mcp-operation-locks.md
+++ b/.changeset/mcp-operation-locks.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Serialize MCP repository mutations through the same repo operation lock used by sync and correct the `load_config` tool response description.

--- a/.changeset/quiet-refs-branch.md
+++ b/.changeset/quiet-refs-branch.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Fix MCP worktree creation for brand-new branches by making missing ref checks observable through simple-git and by accepting remote-qualified base branches.

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -261,7 +261,7 @@ branch refs/heads/dirty-branch
         mockRawCalls.push(argsArray);
 
         if (argsArray[0] === "show-ref" && argsArray[1] === "--verify") {
-          const ref = argsArray[3];
+          const ref = argsArray[argsArray.length - 1];
           if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
             throw new Error("show-ref: not found");
           }

--- a/src/__tests__/local-ahead-of-remote.test.ts
+++ b/src/__tests__/local-ahead-of-remote.test.ts
@@ -17,6 +17,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
   return {
     mockGitServiceInstance: {
       initialize: vi.fn<any>().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(true),
       fetchAll: vi.fn<any>().mockResolvedValue(undefined),
       getRemoteBranches: vi.fn<any>().mockResolvedValue(["main", "feature-ahead"]),
       addWorktree: vi.fn<any>().mockResolvedValue(undefined),

--- a/src/__tests__/rebased-branch-handling.test.ts
+++ b/src/__tests__/rebased-branch-handling.test.ts
@@ -17,6 +17,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
   return {
     mockGitServiceInstance: {
       initialize: vi.fn<any>().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(true),
       fetchAll: vi.fn<any>().mockResolvedValue(undefined),
       getRemoteBranches: vi.fn<any>().mockResolvedValue(["main", "feature-rebased", "feature-diverged"]),
       addWorktree: vi.fn<any>().mockResolvedValue(undefined),

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -139,6 +139,10 @@ function makeCtx(opts: {
     isInitialized: vi.fn<any>().mockReturnValue(true),
     isSyncInProgress: vi.fn<any>().mockReturnValue(opts.syncInProgress ?? false),
     initialize: vi.fn<any>().mockResolvedValue(undefined),
+    runExclusiveRepoOperation: vi.fn<any>().mockImplementation(async (operation: unknown) => ({
+      started: true,
+      value: await (operation as () => Promise<unknown>)(),
+    })),
     sync: vi.fn<any>().mockResolvedValue({ started: true }),
     getGitService: () => git,
   };
@@ -259,10 +263,30 @@ describe("handleCreateWorktree", () => {
   });
 
   it("fails with SYNC_IN_PROGRESS when sync running", async () => {
-    const { ctx } = makeCtx({ syncInProgress: true });
+    const { ctx, service } = makeCtx({ syncInProgress: true });
+    service.runExclusiveRepoOperation.mockResolvedValueOnce({ started: false, reason: "in_progress" });
     const result = await invoke(handleCreateWorktree, ctx, { branchName: "x", baseBranch: "main" });
     const body = parseResponse(result);
     expect(body.code).toBe("SYNC_IN_PROGRESS");
+  });
+
+  it("does not touch git when the repo operation lock is unavailable", async () => {
+    const { ctx, git, service } = makeCtx({
+      git: {
+        branchExists: vi.fn<any>(),
+        createBranch: vi.fn<any>(),
+        addWorktree: vi.fn<any>(),
+      },
+    });
+    service.runExclusiveRepoOperation.mockResolvedValueOnce({ started: false, reason: "locked" });
+
+    const result = await invoke(handleCreateWorktree, ctx, { branchName: "new-branch", baseBranch: "main" });
+    const body = parseResponse(result);
+
+    expect(body.code).toBe("SYNC_IN_PROGRESS");
+    expect(git.branchExists).not.toHaveBeenCalled();
+    expect(git.createBranch).not.toHaveBeenCalled();
+    expect(git.addWorktree).not.toHaveBeenCalled();
   });
 
   it("creates branch and worktree without pushing when push:false (push:false flow)", async () => {
@@ -382,12 +406,13 @@ describe("handleRemoveWorktree", () => {
   });
 
   it("skips safety check when force=true", async () => {
-    const { ctx, git } = makeCtx({
+    const { ctx, git, service } = makeCtx({
       git: { getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/foo", branch: "x" }]) },
     });
     const result = await invoke(handleRemoveWorktree, ctx, { path: "/foo", force: true });
     const body = parseResponse(result);
     expect(body.success).toBe(true);
+    expect(service.runExclusiveRepoOperation).toHaveBeenCalledTimes(1);
     expect(git.removeWorktree).toHaveBeenCalledWith("/foo");
   });
 
@@ -433,7 +458,7 @@ describe("handleSync", () => {
     expect(body.code).toBe("SYNC_IN_PROGRESS");
   });
 
-  it("initializes service before syncing when needed", async () => {
+  it("delegates initialization to service.sync when needed", async () => {
     const { ctx, service } = makeCtx({});
     service.isInitialized.mockReturnValue(false);
 
@@ -441,7 +466,7 @@ describe("handleSync", () => {
     const body = parseResponse(result);
 
     expect(body.success).toBe(true);
-    expect(service.initialize).toHaveBeenCalled();
+    expect(service.initialize).not.toHaveBeenCalled();
     expect(service.sync).toHaveBeenCalled();
   });
 
@@ -550,12 +575,13 @@ describe("case-insensitive path handling in handlers", () => {
 
 describe("handleUpdateWorktree", () => {
   it("calls updateWorktree on given path", async () => {
-    const { ctx, git } = makeCtx({
+    const { ctx, git, service } = makeCtx({
       git: { getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/w/feature", branch: "feature" }]) },
     });
     const result = await invoke(handleUpdateWorktree, ctx, { path: "/w/feature" });
     const body = parseResponse(result);
     expect(body.success).toBe(true);
+    expect(service.runExclusiveRepoOperation).toHaveBeenCalledTimes(1);
     expect(git.updateWorktree).toHaveBeenCalledWith("/w/feature");
   });
 
@@ -643,6 +669,7 @@ describe("handleInitialize", () => {
     expect(body.success).toBe(true);
     expect(body.defaultBranch).toBe("main");
     expect(body.worktreeDir).toBe("/repo/worktrees");
+    expect(service.runExclusiveRepoOperation).toHaveBeenCalledTimes(1);
     expect(service.initialize).toHaveBeenCalled();
   });
 });

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -34,14 +34,6 @@ function ensureCapability(discovered: DiscoveredRepoContext | null, key: Capabil
   }
 }
 
-async function ensureNotSyncing(ctx: RepositoryContext, repoName?: string): Promise<void> {
-  const entry = ctx.getEntry(repoName);
-  if (!entry?.service) return;
-  if (entry.service.isSyncInProgress()) {
-    throw new SyncInProgressError(entry.name);
-  }
-}
-
 async function getReadyService(
   ctx: RepositoryContext,
   repoName: string | undefined,
@@ -49,15 +41,11 @@ async function getReadyService(
     capability?: CapabilityKey;
     toolName?: string;
     ensureInitialized?: boolean;
-    ensureNotSyncing?: boolean;
   } = {},
 ): Promise<{ discovered: DiscoveredRepoContext | null; service: RepoService; git: RepoGitService }> {
   const discovered = ctx.getDiscoveredContext(repoName);
   if (options.capability && options.toolName) {
     ensureCapability(discovered, options.capability, options.toolName);
-  }
-  if (options.ensureNotSyncing) {
-    await ensureNotSyncing(ctx, repoName);
   }
 
   const service = await ctx.getService(repoName);
@@ -70,6 +58,20 @@ async function getReadyService(
     service,
     git: service.getGitService(),
   };
+}
+
+async function runExclusiveRepoOperation<T>(
+  ctx: RepositoryContext,
+  repoName: string | undefined,
+  service: RepoService,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const result = await service.runExclusiveRepoOperation(operation);
+  if (!result.started) {
+    const name = ctx.getEntry(repoName)?.name ?? repoName ?? "unknown";
+    throw new SyncInProgressError(name);
+  }
+  return result.value;
 }
 
 async function ensureRepoWorktreePath(
@@ -234,46 +236,50 @@ export async function handleCreateWorktree(
   const { service, git } = await getReadyService(ctx, params.repoName, {
     capability: "createWorktree",
     toolName: "create_worktree",
-    ensureInitialized: true,
-    ensureNotSyncing: true,
   });
 
-  const existence = await git.branchExists(branchName);
-
-  let created = false;
-  let pushed = false;
-
-  if (!existence.local && !existence.remote) {
-    if (!baseBranch) {
-      throw new Error(`Branch '${branchName}' does not exist. Provide 'baseBranch' to create it.`);
+  return runExclusiveRepoOperation(ctx, params.repoName, service, async () => {
+    if (!service.isInitialized()) {
+      await service.initialize();
     }
-    await git.createBranch(branchName, baseBranch);
-    created = true;
-  }
 
-  const worktreeDir = service.config.worktreeDir;
-  const worktreePath = pathResolution.getBranchWorktreePath(worktreeDir, branchName);
-  const existing = await git.getWorktrees();
-  const collision = existing.find((w) => pathsEqual(w.path, worktreePath) && w.branch !== branchName);
-  if (collision) {
-    throw new Error(
-      `Sanitized worktree path '${worktreePath}' collides with existing branch '${collision.branch}'. Rename or remove the conflicting branch first.`,
-    );
-  }
-  await git.addWorktree(branchName, worktreePath);
-  ctx.invalidateDiscovered();
+    const existence = await git.branchExists(branchName);
 
-  if (created && push) {
-    await git.pushBranch(branchName);
-    pushed = true;
-  }
+    let created = false;
+    let pushed = false;
 
-  return formatToolResponse({
-    success: true,
-    branchName,
-    worktreePath: path.resolve(worktreePath),
-    created,
-    pushed,
+    if (!existence.local && !existence.remote) {
+      if (!baseBranch) {
+        throw new Error(`Branch '${branchName}' does not exist. Provide 'baseBranch' to create it.`);
+      }
+      await git.createBranch(branchName, baseBranch);
+      created = true;
+    }
+
+    const worktreeDir = service.config.worktreeDir;
+    const worktreePath = pathResolution.getBranchWorktreePath(worktreeDir, branchName);
+    const existing = await git.getWorktrees();
+    const collision = existing.find((w) => pathsEqual(w.path, worktreePath) && w.branch !== branchName);
+    if (collision) {
+      throw new Error(
+        `Sanitized worktree path '${worktreePath}' collides with existing branch '${collision.branch}'. Rename or remove the conflicting branch first.`,
+      );
+    }
+    await git.addWorktree(branchName, worktreePath);
+    ctx.invalidateDiscovered();
+
+    if (created && push) {
+      await git.pushBranch(branchName);
+      pushed = true;
+    }
+
+    return formatToolResponse({
+      success: true,
+      branchName,
+      worktreePath: path.resolve(worktreePath),
+      created,
+      pushed,
+    });
   });
 }
 
@@ -282,27 +288,31 @@ export async function handleRemoveWorktree(
   params: { path: string; force?: boolean; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const { git } = await getReadyService(ctx, params.repoName, {
+  const { service, git } = await getReadyService(ctx, params.repoName, {
     capability: "removeWorktree",
     toolName: "remove_worktree",
-    ensureInitialized: true,
-    ensureNotSyncing: true,
   });
-  const removedPath = await ensureRepoWorktreePath(ctx, params, git);
 
-  if (!params.force) {
-    const status = await git.getFullWorktreeStatus(params.path, false);
-    if (!status.canRemove) {
-      throw new Error(`Cannot remove worktree: ${status.reasons.join(", ")}. Use force=true to override.`);
+  return runExclusiveRepoOperation(ctx, params.repoName, service, async () => {
+    if (!service.isInitialized()) {
+      await service.initialize();
     }
-  }
+    const removedPath = await ensureRepoWorktreePath(ctx, params, git);
 
-  await git.removeWorktree(params.path);
-  ctx.invalidateDiscovered();
+    if (!params.force) {
+      const status = await git.getFullWorktreeStatus(params.path, false);
+      if (!status.canRemove) {
+        throw new Error(`Cannot remove worktree: ${status.reasons.join(", ")}. Use force=true to override.`);
+      }
+    }
 
-  return formatToolResponse({
-    success: true,
-    removedPath,
+    await git.removeWorktree(params.path);
+    ctx.invalidateDiscovered();
+
+    return formatToolResponse({
+      success: true,
+      removedPath,
+    });
   });
 }
 
@@ -314,7 +324,6 @@ export async function handleSync(
   const { service } = await getReadyService(ctx, params.repoName, {
     capability: "sync",
     toolName: "sync",
-    ensureInitialized: true,
   });
 
   const dispose = attachProgressReporter(service, extra);
@@ -337,20 +346,24 @@ export async function handleUpdateWorktree(
   params: { path: string; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const { git } = await getReadyService(ctx, params.repoName, {
+  const { service, git } = await getReadyService(ctx, params.repoName, {
     capability: "updateWorktree",
     toolName: "update_worktree",
-    ensureInitialized: true,
-    ensureNotSyncing: true,
   });
-  const worktreePath = await ensureRepoWorktreePath(ctx, params, git);
 
-  await git.updateWorktree(params.path);
-  ctx.invalidateDiscovered();
+  return runExclusiveRepoOperation(ctx, params.repoName, service, async () => {
+    if (!service.isInitialized()) {
+      await service.initialize();
+    }
+    const worktreePath = await ensureRepoWorktreePath(ctx, params, git);
 
-  return formatToolResponse({
-    success: true,
-    worktreePath,
+    await git.updateWorktree(params.path);
+    ctx.invalidateDiscovered();
+
+    return formatToolResponse({
+      success: true,
+      worktreePath,
+    });
   });
 }
 
@@ -362,17 +375,18 @@ export async function handleInitialize(
   const { service } = await getReadyService(ctx, params.repoName, {
     capability: "initialize",
     toolName: "initialize",
-    ensureNotSyncing: true,
   });
   const dispose = attachProgressReporter(service, extra);
   try {
-    await service.initialize();
-    const git = service.getGitService();
-    ctx.invalidateDiscovered();
-    return formatToolResponse({
-      success: true,
-      defaultBranch: git.getDefaultBranch(),
-      worktreeDir: service.config.worktreeDir,
+    return await runExclusiveRepoOperation(ctx, params.repoName, service, async () => {
+      await service.initialize();
+      const git = service.getGitService();
+      ctx.invalidateDiscovered();
+      return formatToolResponse({
+        success: true,
+        defaultBranch: git.getDefaultBranch(),
+        worktreeDir: service.config.worktreeDir,
+      });
     });
   } finally {
     dispose();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -291,7 +291,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
       description:
         "Load or reload a sync-worktrees JavaScript config file into the server's session. Replaces any previously loaded repositories. " +
         "Call this before sync/initialize/create_worktree when using a config-driven workflow. " +
-        "Returns: { configPath, currentRepository, repositories: [{ name, repoPath, worktreeDir, ... }] }.",
+        "Returns: { configPath, currentRepository, repositories: [{ name, repoUrl, worktreeDir, source }] }.",
       inputSchema: {
         configPath: z
           .string()

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -60,7 +60,7 @@ describe("GitService", () => {
   const mockShowRef = (opts: { local: boolean; remote: boolean }): void => {
     (mockGit.raw as Mock).mockImplementation((args: unknown) => {
       if (Array.isArray(args) && args[0] === "show-ref" && args[1] === "--verify") {
-        const ref = args[3];
+        const ref = args[args.length - 1];
         if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
           return opts.local ? Promise.resolve("") : Promise.reject(new Error("show-ref: not found"));
         }
@@ -339,6 +339,50 @@ describe("GitService", () => {
     });
   });
 
+  describe("branchExists", () => {
+    it("checks refs with non-quiet show-ref so missing refs are observable", async () => {
+      const calls: string[][] = [];
+      (mockGit.raw as Mock).mockImplementation((args: unknown) => {
+        if (Array.isArray(args)) {
+          calls.push(args as string[]);
+          return Promise.reject(new Error("show-ref: not found"));
+        }
+        return Promise.resolve("");
+      });
+
+      await expect(gitService.branchExists("feat/new")).resolves.toEqual({ local: false, remote: false });
+
+      expect(calls).toEqual([
+        ["show-ref", "--verify", "refs/heads/feat/new"],
+        ["show-ref", "--verify", "refs/remotes/origin/feat/new"],
+      ]);
+      expect(calls.flat()).not.toContain("--quiet");
+    });
+  });
+
+  describe("createBranch", () => {
+    it("does not duplicate origin when baseBranch is already remote-qualified", async () => {
+      mockGit.revparse.mockResolvedValue("abc123\n" as any);
+
+      await gitService.createBranch("feat/new", "origin/main");
+
+      expect(mockGit.revparse).toHaveBeenCalledWith(["--verify", "origin/main"]);
+      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "feat/new", "origin/main"]);
+    });
+
+    it("falls back to a local base branch when origin branch is missing", async () => {
+      mockGit.revparse
+        .mockRejectedValueOnce(new Error("fatal: Needed a single revision") as any)
+        .mockResolvedValueOnce("abc123\n" as any);
+
+      await gitService.createBranch("feat/new", "main");
+
+      expect(mockGit.revparse).toHaveBeenNthCalledWith(1, ["--verify", "origin/main"]);
+      expect(mockGit.revparse).toHaveBeenNthCalledWith(2, ["--verify", "main"]);
+      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "feat/new", "main"]);
+    });
+  });
+
   describe("getRemoteBranches", () => {
     beforeEach(async () => {
       (fs.access as Mock<any>).mockResolvedValue(undefined);
@@ -528,7 +572,7 @@ describe("GitService", () => {
       (mockGit.raw as Mock).mockImplementation((args: unknown) => {
         if (Array.isArray(args)) {
           if (args[0] === "show-ref" && args[1] === "--verify") {
-            const ref = args[3];
+            const ref = args[args.length - 1];
             if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
               return Promise.reject(new Error("show-ref: not found"));
             }
@@ -554,7 +598,7 @@ describe("GitService", () => {
       (mockGit.raw as Mock).mockImplementation((args: unknown) => {
         if (Array.isArray(args)) {
           if (args[0] === "show-ref" && args[1] === "--verify") {
-            const ref = args[3];
+            const ref = args[args.length - 1];
             if (typeof ref === "string" && ref.startsWith("refs/heads/")) {
               return Promise.reject(new Error("show-ref: not found"));
             }
@@ -906,7 +950,7 @@ describe("GitService", () => {
         (mockGit.raw as Mock).mockImplementation((args: unknown) => {
           if (Array.isArray(args)) {
             if (args[0] === "show-ref" && args[1] === "--verify") {
-              const ref = args[3];
+              const ref = args[args.length - 1];
               if (typeof ref === "string" && ref.startsWith("refs/heads/")) return Promise.resolve("");
               if (typeof ref === "string" && ref.startsWith("refs/remotes/origin/")) {
                 return Promise.reject(new Error("show-ref: not found"));

--- a/src/services/__tests__/hook-execution.service.test.ts
+++ b/src/services/__tests__/hook-execution.service.test.ts
@@ -3,9 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HOOK_CONSTANTS } from "../../constants";
 import { HookExecutionService } from "../hook-execution.service";
 
-import type { HookContext } from "../../types";
-
-const WAIT_TIME = 500;
+import type { HookContext, HooksConfig } from "../../types";
+import type { HookExecutionCallbacks } from "../hook-execution.service";
 
 const NODE = process.execPath;
 
@@ -14,6 +13,29 @@ const nodeScript = (body: string): string => `"${NODE}" -e "${body.replace(/"/g,
 describe("HookExecutionService", () => {
   let service: HookExecutionService;
   let mockContext: HookContext;
+
+  const runAndWait = (
+    hooks: HooksConfig,
+    context: HookContext,
+    callbacks: HookExecutionCallbacks = {},
+  ): Promise<void> => {
+    const total = hooks.onBranchCreated?.length ?? 0;
+    if (total === 0) {
+      service.executeOnBranchCreated(hooks, context, callbacks);
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      let done = 0;
+      const userComplete = callbacks.onComplete;
+      service.executeOnBranchCreated(hooks, context, {
+        ...callbacks,
+        onComplete: (command, exitCode) => {
+          userComplete?.(command, exitCode);
+          if (++done === total) resolve();
+        },
+      });
+    });
+  };
 
   beforeEach(() => {
     service = new HookExecutionService();
@@ -42,7 +64,7 @@ describe("HookExecutionService", () => {
     it("should execute commands with correct environment variables", async () => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [nodeScript(`process.stdout.write(process.env['${HOOK_CONSTANTS.ENV_VARS.BRANCH_NAME}'])`)],
         },
@@ -50,15 +72,13 @@ describe("HookExecutionService", () => {
         { onStdout: stdoutCallback },
       );
 
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
-
       expect(stdoutCallback).toHaveBeenCalledWith(expect.stringContaining("feature/test-branch"));
     });
 
     it("should execute commands with correct environment variables for all context fields", async () => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [
             nodeScript(
@@ -69,8 +89,6 @@ describe("HookExecutionService", () => {
         mockContext,
         { onStdout: stdoutCallback },
       );
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
 
       expect(stdoutCallback).toHaveBeenCalledWith("feature/test-branch,test-repo,main");
     });
@@ -100,11 +118,7 @@ describe("HookExecutionService", () => {
     ])("should replace placeholders correctly ($desc)", async ({ template, expected }) => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated({ onBranchCreated: [template] }, mockContext, {
-        onStdout: stdoutCallback,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [template] }, mockContext, { onStdout: stdoutCallback });
 
       expect(stdoutCallback).toHaveBeenCalledWith(expected);
     });
@@ -113,11 +127,7 @@ describe("HookExecutionService", () => {
       const completeCallback = vi.fn();
       const command = nodeScript("process.stdout.write('success')");
 
-      service.executeOnBranchCreated({ onBranchCreated: [command] }, mockContext, {
-        onComplete: completeCallback,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [command] }, mockContext, { onComplete: completeCallback });
 
       expect(completeCallback).toHaveBeenCalledWith(command, 0);
     });
@@ -126,11 +136,7 @@ describe("HookExecutionService", () => {
       const completeCallback = vi.fn();
       const command = nodeScript("process.exit(1)");
 
-      service.executeOnBranchCreated({ onBranchCreated: [command] }, mockContext, {
-        onComplete: completeCallback,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [command] }, mockContext, { onComplete: completeCallback });
 
       expect(completeCallback).toHaveBeenCalledWith(command, 1);
     });
@@ -138,11 +144,9 @@ describe("HookExecutionService", () => {
     it("should call onStderr for commands that write to stderr", async () => {
       const stderrCallback = vi.fn();
 
-      service.executeOnBranchCreated({ onBranchCreated: [nodeScript("process.stderr.write('error')")] }, mockContext, {
+      await runAndWait({ onBranchCreated: [nodeScript("process.stderr.write('error')")] }, mockContext, {
         onStderr: stderrCallback,
       });
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
 
       expect(stderrCallback).toHaveBeenCalledWith("error");
     });
@@ -150,7 +154,7 @@ describe("HookExecutionService", () => {
     it("should execute multiple commands independently", async () => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [
             nodeScript("process.stdout.write('first')"),
@@ -161,8 +165,6 @@ describe("HookExecutionService", () => {
         mockContext,
         { onStdout: stdoutCallback },
       );
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
 
       expect(stdoutCallback).toHaveBeenCalledTimes(3);
       expect(stdoutCallback).toHaveBeenCalledWith("first");
@@ -191,7 +193,7 @@ describe("HookExecutionService", () => {
         worktreePath: "/tmp",
       };
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [nodeScript("process.stdout.write(process.argv[1])") + " {BRANCH_NAME}"],
         },
@@ -199,19 +201,13 @@ describe("HookExecutionService", () => {
         { onStdout: stdoutCallback },
       );
 
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
-
       expect(stdoutCallback).toHaveBeenCalledWith("feature/test-with-special-chars");
     });
 
     it("should not call callbacks for empty output", async () => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated({ onBranchCreated: [nodeScript("process.exit(0)")] }, mockContext, {
-        onStdout: stdoutCallback,
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [nodeScript("process.exit(0)")] }, mockContext, { onStdout: stdoutCallback });
 
       expect(stdoutCallback).not.toHaveBeenCalled();
     });
@@ -219,7 +215,7 @@ describe("HookExecutionService", () => {
     it("should pass both env vars and placeholders work in same command", async () => {
       const stdoutCallback = vi.fn();
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [
             nodeScript(
@@ -230,8 +226,6 @@ describe("HookExecutionService", () => {
         mockContext,
         { onStdout: stdoutCallback },
       );
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
 
       expect(stdoutCallback).toHaveBeenCalledWith("feature/test-branch test-repo");
     });
@@ -244,15 +238,13 @@ describe("HookExecutionService", () => {
         branchName: "'; echo INJECTED; '",
       };
 
-      service.executeOnBranchCreated(
+      await runAndWait(
         {
           onBranchCreated: [nodeScript("process.stdout.write(process.argv[1])") + " {BRANCH_NAME}"],
         },
         maliciousContext,
         { onStdout: stdoutCallback },
       );
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
 
       expect(stdoutCallback).not.toHaveBeenCalledWith("INJECTED");
       expect(stdoutCallback).toHaveBeenCalledWith("'; echo INJECTED; '");
@@ -276,23 +268,15 @@ describe("HookExecutionService", () => {
         worktreePath: "/tmp",
       };
 
-      service.executeOnBranchCreated(
-        { onBranchCreated: [nodeScript("process.stdout.write(process.cwd())")] },
-        contextWithTmpPath,
-        { onStdout: stdoutCallback },
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [nodeScript("process.stdout.write(process.cwd())")] }, contextWithTmpPath, {
+        onStdout: stdoutCallback,
+      });
 
       expect(stdoutCallback).toHaveBeenCalledWith(expect.stringContaining("tmp"));
     });
 
     it("should track active processes and remove on completion", async () => {
-      service.executeOnBranchCreated({ onBranchCreated: [nodeScript("process.stdout.write('done')")] }, mockContext);
-
-      expect((service as any).activeProcesses.size).toBeGreaterThanOrEqual(0);
-
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME));
+      await runAndWait({ onBranchCreated: [nodeScript("process.stdout.write('done')")] }, mockContext);
 
       expect((service as any).activeProcesses.size).toBe(0);
     });
@@ -308,14 +292,14 @@ describe("HookExecutionService", () => {
           onError: errorCallback,
         });
 
-        await new Promise((resolve) => setTimeout(resolve, 300));
-
-        expect(errorCallback).toHaveBeenCalledWith(
-          command,
-          expect.objectContaining({
-            message: expect.stringContaining("timed out"),
-          }),
-        );
+        await vi.waitFor(() => {
+          expect(errorCallback).toHaveBeenCalledWith(
+            command,
+            expect.objectContaining({
+              message: expect.stringContaining("timed out"),
+            }),
+          );
+        });
       } finally {
         service.cleanup();
       }

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -20,6 +20,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
   return {
     mockGitServiceInstance: {
       initialize: vi.fn<any>().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(true),
       fetchAll: vi.fn<any>().mockResolvedValue(undefined),
       fetchBranch: vi.fn<any>().mockResolvedValue(undefined),
       getRemoteBranches: vi.fn<any>().mockResolvedValue(["main", "feature-1", "feature-2"]),

--- a/src/services/__tests__/worktree-update.test.ts
+++ b/src/services/__tests__/worktree-update.test.ts
@@ -38,6 +38,7 @@ describe("WorktreeSyncService - Update Existing Worktrees", () => {
     // Mock GitService methods
     mockGitService = {
       initialize: vi.fn().mockResolvedValue(undefined),
+      isInitialized: vi.fn().mockReturnValue(true),
       fetchAll: vi.fn().mockResolvedValue(undefined),
       getRemoteBranches: vi.fn().mockResolvedValue(["main", "feature", "develop"]),
       getRemoteBranchesWithActivity: vi.fn().mockResolvedValue([

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1039,7 +1039,8 @@ export class GitService {
     const bareGit = this.getCachedGit(this.bareRepoPath);
     const checkRef = async (ref: string): Promise<boolean> => {
       try {
-        await bareGit.raw(["show-ref", "--verify", "--quiet", ref]);
+        // simple-git resolves `show-ref --quiet` when Git exits 1, so keep stdout enabled.
+        await bareGit.raw(["show-ref", "--verify", ref]);
         return true;
       } catch {
         return false;
@@ -1060,11 +1061,30 @@ export class GitService {
     return branches.all;
   }
 
+  private async resolveCreateBranchBaseRef(bareGit: SimpleGit, baseBranch: string): Promise<string> {
+    const candidates =
+      baseBranch.startsWith(GIT_CONSTANTS.REMOTE_PREFIX) || baseBranch.startsWith("refs/")
+        ? [baseBranch]
+        : [`${GIT_CONSTANTS.REMOTE_PREFIX}${baseBranch}`, baseBranch];
+
+    for (const candidate of candidates) {
+      try {
+        await bareGit.revparse(["--verify", candidate]);
+        return candidate;
+      } catch {
+        // Try the next candidate before letting git branch report the original failure.
+      }
+    }
+
+    return candidates[0];
+  }
+
   async createBranch(branchName: string, baseBranch: string): Promise<void> {
     const bareGit = this.getCachedGit(this.bareRepoPath);
+    const baseRef = await this.resolveCreateBranchBaseRef(bareGit, baseBranch);
 
-    await bareGit.raw(["branch", branchName, `origin/${baseBranch}`]);
-    this.logger.info(`Created branch '${branchName}' from '${baseBranch}'`);
+    await bareGit.raw(["branch", branchName, baseRef]);
+    this.logger.info(`Created branch '${branchName}' from '${baseRef}'`);
   }
 
   async pushBranch(branchName: string): Promise<void> {

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -24,6 +24,10 @@ export type SyncResult =
   | { started: false; reason: "in_progress" }
   | { started: false; reason: "locked" };
 
+export type ExclusiveRepoOperationResult<T> =
+  | { started: true; value: T }
+  | { started: false; reason: "in_progress" | "locked" };
+
 export interface ProgressEvent {
   phase: string;
   message: string;
@@ -71,6 +75,31 @@ export class WorktreeSyncService {
     return () => this.progressListeners.delete(listener);
   }
 
+  async runExclusiveRepoOperation<T>(operation: () => Promise<T>): Promise<ExclusiveRepoOperationResult<T>> {
+    if (this.syncInProgress) {
+      this.logger.warn("⚠️  Another repository operation is already in progress, skipping...");
+      return { started: false, reason: "in_progress" };
+    }
+
+    const release = await this.acquireBareLock();
+    if (release === null) {
+      this.logger.warn("⚠️  Another process holds the sync lock for this repo, skipping...");
+      return { started: false, reason: "locked" };
+    }
+
+    this.syncInProgress = true;
+    try {
+      return { started: true, value: await operation() };
+    } finally {
+      this.syncInProgress = false;
+      try {
+        await release();
+      } catch (releaseError) {
+        this.logger.warn(`Failed to release sync lock: ${getErrorMessage(releaseError)}`);
+      }
+    }
+  }
+
   private emitProgress(event: ProgressEvent): void {
     for (const listener of this.progressListeners) {
       try {
@@ -82,51 +111,39 @@ export class WorktreeSyncService {
   }
 
   async sync(): Promise<SyncResult> {
-    if (this.syncInProgress) {
-      this.logger.warn("⚠️  Sync already in progress, skipping...");
-      return { started: false, reason: "in_progress" };
-    }
-
-    const release = await this.acquireBareLock();
-    if (release === null) {
-      this.logger.warn("⚠️  Another process holds the sync lock for this repo, skipping...");
-      return { started: false, reason: "locked" };
-    }
-
-    this.syncInProgress = true;
-    this.logger.info(`[${new Date().toISOString()}] Starting worktree synchronization...`);
-
-    const totalTimer = new Timer();
-    const phaseTimer = new PhaseTimer();
-    const syncContext = { lfsSkipEnabled: false };
-    const retryOptions = this.createRetryOptions(syncContext);
-
-    try {
-      await retry(() => this.runSyncAttempt(phaseTimer, syncContext), retryOptions);
-    } catch (error) {
-      this.logger.error("\n❌ Error during worktree synchronization after all retry attempts:", error);
-      throw error;
-    } finally {
-      if (syncContext.lfsSkipEnabled && !this.config.skipLfs) {
-        this.gitService.setLfsSkipEnabled(false);
+    const result = await this.runExclusiveRepoOperation(async () => {
+      if (!this.isInitialized()) {
+        await this.initialize();
       }
-      this.syncInProgress = false;
+
+      this.logger.info(`[${new Date().toISOString()}] Starting worktree synchronization...`);
+
+      const totalTimer = new Timer();
+      const phaseTimer = new PhaseTimer();
+      const syncContext = { lfsSkipEnabled: false };
+      const retryOptions = this.createRetryOptions(syncContext);
+
       try {
-        await release();
-      } catch (releaseError) {
-        this.logger.warn(`Failed to release sync lock: ${getErrorMessage(releaseError)}`);
-      }
-      this.logger.info(`[${new Date().toISOString()}] Synchronization finished.\n`);
+        await retry(() => this.runSyncAttempt(phaseTimer, syncContext), retryOptions);
+      } catch (error) {
+        this.logger.error("\n❌ Error during worktree synchronization after all retry attempts:", error);
+        throw error;
+      } finally {
+        if (syncContext.lfsSkipEnabled && !this.config.skipLfs) {
+          this.gitService.setLfsSkipEnabled(false);
+        }
+        this.logger.info(`[${new Date().toISOString()}] Synchronization finished.\n`);
 
-      if (this.config.debug) {
-        const totalDuration = totalTimer.stop();
-        const phaseResults = phaseTimer.getResults();
-        const repoName = (this.config as { name?: string }).name;
-        this.logger.table(formatTimingTable(totalDuration, phaseResults, repoName));
+        if (this.config.debug) {
+          const totalDuration = totalTimer.stop();
+          const phaseResults = phaseTimer.getResults();
+          const repoName = (this.config as { name?: string }).name;
+          this.logger.table(formatTimingTable(totalDuration, phaseResults, repoName));
+        }
       }
-    }
+    });
 
-    return { started: true };
+    return result.started ? { started: true } : result;
   }
 
   private async acquireBareLock(): Promise<(() => Promise<void>) | null> {
@@ -139,16 +156,10 @@ export class WorktreeSyncService {
     }
 
     const barePath = this.gitService.getBareRepoPath();
-    const lockTarget = path.join(barePath, "HEAD");
+    await fs.mkdir(barePath, { recursive: true });
 
     try {
-      await fs.access(lockTarget);
-    } catch {
-      return async () => {};
-    }
-
-    try {
-      const release = await lockfile.lock(lockTarget, {
+      const release = await lockfile.lock(barePath, {
         stale: DEFAULT_CONFIG.LOCK_STALE_MS,
         update: DEFAULT_CONFIG.LOCK_UPDATE_MS,
         retries: 0,


### PR DESCRIPTION
## Summary

Fix create_worktree when the requested branch does not exist yet.

## Root Cause

simple-git resolves git show-ref --verify --quiet for missing refs, so branchExists treated missing refs as present and skipped branch creation.

## Changes

- Probe refs with non-quiet git show-ref --verify.
- Resolve baseBranch inputs including origin/main before branch creation.
- Add regression tests and a patch changeset.

## Validation

- pnpm exec vitest src/services/__tests__/git.service.test.ts src/mcp/__tests__/handlers.test.ts src/__tests__/integration.test.ts
- pnpm run typecheck
- pnpm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree/branch creation and verification, including support for remote-qualified base branches and more reliable branch-existence checks
  * Handlers now surface "sync in progress" when repository operations are locked, preventing concurrent mutations

* **Tests**
  * Expanded and hardened test coverage for branch/worktree flows and hook execution; mocks made more resilient

* **Documentation**
  * Updated tool description to clarify repository entry fields

* **Chores**
  * Added changeset entries for patch releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yordan-kanchelov/sync-worktrees/pull/79)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->