### PR TITLE
[codex] expose configured repos in MCP context

### DIFF
--- a/.changeset/breezy-worktrees-detect-context.md
+++ b/.changeset/breezy-worktrees-detect-context.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Make MCP repository discovery config-driven across multi-repo workspaces. `detect_context` now reports configured sibling repositories, including nested worktree directories and missing bare repo presence, can include all configured repo worktrees with `includeAllWorktrees`, and surfaces per-repo worktree enumeration errors. `list_worktrees` without `repoName` now groups worktrees across all configured repositories.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Add the server to your MCP client config. Use `npx` if the package is not instal
 
 If installed globally, replace `command` with `sync-worktrees-mcp` and drop `args`. `SYNC_WORKTREES_CONFIG` is optional — without it the server runs in **auto-detect mode**: when the client's CWD sits inside a worktree managed by sync-worktrees, the server locates the bare repo, enumerates sibling worktrees, and enables per-worktree operations. Sync and initialize require a loaded config (or call `load_config` at runtime).
 
+At session start, agents should call `detect_context` with `includeAllWorktrees: true`. With a loaded config, that returns config-driven `siblingRepositories` for every other configured repo, including nested `worktreeDir` paths, plus `allWorktreesByRepo` keyed by repository name. If a configured repo cannot be enumerated, `allWorktreeErrorsByRepo` carries the per-repo error.
+
 Client-specific locations:
 
 | Client | Config file |
@@ -125,8 +127,8 @@ Client-specific locations:
 
 | Tool | Purpose |
 |------|---------|
-| `detect_context` | Inspect a path, resolve the bare repo, enumerate sibling worktrees, report capabilities. |
-| `list_worktrees` | List worktrees with status label (`clean`/`dirty`/`stale`/`current`), divergence, `safeToRemove`, last sync. |
+| `detect_context` | Inspect a path, resolve the bare repo, enumerate sibling worktrees, report config-driven sibling repositories and capabilities. Pass `includeAllWorktrees: true` to include every configured repo's worktrees keyed by repo name. |
+| `list_worktrees` | List worktrees with status label (`clean`/`dirty`/`stale`/`current`), divergence, `safeToRemove`, last sync. Without `repoName` and with a loaded config, results are grouped across all configured repos. |
 | `get_worktree_status` | Detailed status for one worktree (dirty files, unpushed commits, stashes, operation in progress). |
 | `create_worktree` | Create a worktree for a branch; optionally create the branch from `baseBranch` and push. |
 | `remove_worktree` | Remove a worktree after safety checks; `force=true` skips validation. |

--- a/src/mcp/__tests__/context.test.ts
+++ b/src/mcp/__tests__/context.test.ts
@@ -339,7 +339,7 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
   });
 });
 
-describe("RepositoryContext.getAllConfiguredWorktrees", () => {
+describe("RepositoryContext.getAllConfiguredWorktreeDetails", () => {
   beforeEach(() => {
     mockRemoteUrl.mockReset();
     mockWorktreeList.mockReset();
@@ -376,11 +376,12 @@ describe("RepositoryContext.getAllConfiguredWorktrees", () => {
 
       const ctx = new RepositoryContext();
       const discovered = await ctx.detectFromPath(currentWt);
-      const allWorktrees = await ctx.getAllConfiguredWorktrees(discovered.currentWorktreePath);
+      const details = await ctx.getAllConfiguredWorktreeDetails(discovered.currentWorktreePath);
 
-      expect(Object.keys(allWorktrees)).toEqual(["repo-a", "repo-b"]);
-      expect(allWorktrees["repo-a"]).toEqual([{ path: currentWt, branch: "main", isCurrent: true }]);
-      expect(allWorktrees["repo-b"]).toEqual([{ path: siblingWt, branch: "feature-b", isCurrent: false }]);
+      expect(Object.keys(details.worktreesByRepo)).toEqual(["repo-a", "repo-b"]);
+      expect(details.worktreesByRepo["repo-a"]).toEqual([{ path: currentWt, branch: "main", isCurrent: true }]);
+      expect(details.worktreesByRepo["repo-b"]).toEqual([{ path: siblingWt, branch: "feature-b", isCurrent: false }]);
+      expect(details.errorsByRepo).toEqual({});
     } finally {
       await fs.rm(workspace, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/context.test.ts
+++ b/src/mcp/__tests__/context.test.ts
@@ -11,9 +11,9 @@ const mockWorktreeList = vi.fn<any>();
 
 vi.mock("simple-git", () => {
   return {
-    default: vi.fn(() => ({
-      remote: mockRemoteUrl,
-      raw: mockWorktreeList,
+    default: vi.fn((basePath?: string) => ({
+      remote: (...args: unknown[]) => (mockRemoteUrl as any)(...args),
+      raw: (...args: unknown[]) => (mockWorktreeList as any)(basePath, ...args),
     })),
   };
 });
@@ -209,11 +209,14 @@ describe("RepositoryContext.detectFromPath sibling discovery", () => {
       const ctx = new RepositoryContext();
       const result = await ctx.detectFromPath(currentWt);
 
-      expect(result.siblingRepositories.length).toBe(3);
+      expect(result.siblingRepositories.length).toBe(2);
       const names = result.siblingRepositories.map((s) => s.name).sort();
-      expect(names).toEqual(["repo-current", "repo-sibling-a", "repo-sibling-b"]);
+      expect(names).toEqual(["repo-sibling-a", "repo-sibling-b"]);
       for (const sib of result.siblingRepositories) {
         expect(sib.bareRepoPath).toMatch(/\.bare$/);
+        expect(sib.worktreeDir).toBeNull();
+        expect(sib.repoUrl).toBeNull();
+        expect(sib.present).toBe(true);
         expect(sib.configMatched).toBe(false);
       }
     } finally {
@@ -254,6 +257,51 @@ describe("RepositoryContext.detectFromPath sibling discovery", () => {
       const matched = result.siblingRepositories.find((s) => s.configMatched);
       expect(matched).toBeDefined();
       expect(matched?.name).toBe("named-sibling");
+      expect(matched?.repoUrl).toBe("https://github.com/test/sibling.git");
+      expect(matched?.worktreeDir).toBe(path.join(siblingA, "worktrees"));
+      expect(matched?.present).toBe(true);
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("populates config-driven sibling repos with nested worktreeDir even when bare repo is missing", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-siblings-nested-cfg-"));
+    try {
+      const currentBare = path.join(workspace, ".bare", "amusnet-react-ui");
+      const adminDir = path.join(currentBare, "worktrees", "stream-test");
+      await fs.mkdir(adminDir, { recursive: true });
+      const currentWt = path.join(workspace, "amusnet-react-ui", "stream-test");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${adminDir}\n`, "utf-8");
+
+      const rouletteBare = path.join(workspace, ".bare", "roulette-frontend");
+      const rouletteWorktreeDir = path.join(workspace, "frontend", "roulette-frontend");
+      const configPath = path.join(workspace, "sync-worktrees.config.js");
+      const cfgBody = `export default { repositories: [
+        { name: "amusnet-react-ui", repoUrl: "https://github.com/test/amusnet-react-ui.git", bareRepoDir: "./.bare/amusnet-react-ui", worktreeDir: "./amusnet-react-ui", cronSchedule: "0 * * * *", runOnce: true },
+        { name: "roulette-frontend", repoUrl: "https://github.com/test/roulette-frontend.git", bareRepoDir: "./.bare/roulette-frontend", worktreeDir: "./frontend/roulette-frontend", cronSchedule: "0 * * * *", runOnce: true }
+      ] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/amusnet-react-ui.git\n");
+      mockWorktreeList.mockResolvedValue([`worktree ${currentWt}`, "branch refs/heads/stream-test", ""].join("\n"));
+
+      const ctx = new RepositoryContext();
+      const result = await ctx.detectFromPath(currentWt);
+
+      expect(result.configPath).toBe(configPath);
+      expect(result.repoName).toBe("amusnet-react-ui");
+      expect(result.siblingRepositories).toEqual([
+        {
+          name: "roulette-frontend",
+          bareRepoPath: rouletteBare,
+          worktreeDir: rouletteWorktreeDir,
+          repoUrl: "https://github.com/test/roulette-frontend.git",
+          present: false,
+          configMatched: true,
+        },
+      ]);
     } finally {
       await fs.rm(workspace, { recursive: true, force: true });
     }
@@ -285,6 +333,94 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
       expect(result.configPath).toBe(configPath);
       expect(result.kind).toBe("managed");
       expect(result.repoName).toBe("auto-loaded");
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("RepositoryContext.getAllConfiguredWorktrees", () => {
+  beforeEach(() => {
+    mockRemoteUrl.mockReset();
+    mockWorktreeList.mockReset();
+  });
+
+  it("returns configured repo worktrees keyed by repo name", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-all-worktrees-"));
+    try {
+      const currentBare = path.join(workspace, ".bare", "repo-a");
+      const currentAdmin = path.join(currentBare, "worktrees", "main");
+      await fs.mkdir(currentAdmin, { recursive: true });
+      const currentWt = path.join(workspace, "repo-a", "main");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${currentAdmin}\n`, "utf-8");
+
+      const siblingBare = path.join(workspace, ".bare", "repo-b");
+      await fs.mkdir(path.join(siblingBare, "worktrees", "feature-b"), { recursive: true });
+      const siblingWt = path.join(workspace, "frontend", "repo-b", "feature-b");
+
+      const configPath = path.join(workspace, "sync-worktrees.config.js");
+      const cfgBody = `export default { repositories: [
+        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *", runOnce: true },
+        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./frontend/repo-b", cronSchedule: "0 * * * *", runOnce: true }
+      ] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo-a.git\n");
+      mockWorktreeList.mockImplementation((basePath: unknown) => {
+        if (basePath === siblingBare) {
+          return Promise.resolve([`worktree ${siblingWt}`, "branch refs/heads/feature-b", ""].join("\n"));
+        }
+        return Promise.resolve([`worktree ${currentWt}`, "branch refs/heads/main", ""].join("\n"));
+      });
+
+      const ctx = new RepositoryContext();
+      const discovered = await ctx.detectFromPath(currentWt);
+      const allWorktrees = await ctx.getAllConfiguredWorktrees(discovered.currentWorktreePath);
+
+      expect(Object.keys(allWorktrees)).toEqual(["repo-a", "repo-b"]);
+      expect(allWorktrees["repo-a"]).toEqual([{ path: currentWt, branch: "main", isCurrent: true }]);
+      expect(allWorktrees["repo-b"]).toEqual([{ path: siblingWt, branch: "feature-b", isCurrent: false }]);
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces per-repo worktree enumeration errors", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-all-worktrees-error-"));
+    try {
+      const currentBare = path.join(workspace, ".bare", "repo-a");
+      const currentAdmin = path.join(currentBare, "worktrees", "main");
+      await fs.mkdir(currentAdmin, { recursive: true });
+      const currentWt = path.join(workspace, "repo-a", "main");
+      await fs.mkdir(currentWt, { recursive: true });
+      await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${currentAdmin}\n`, "utf-8");
+
+      const siblingBare = path.join(workspace, ".bare", "repo-b");
+      await fs.mkdir(siblingBare, { recursive: true });
+
+      const configPath = path.join(workspace, "sync-worktrees.config.js");
+      const cfgBody = `export default { repositories: [
+        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *", runOnce: true },
+        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./repo-b", cronSchedule: "0 * * * *", runOnce: true }
+      ] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo-a.git\n");
+      mockWorktreeList.mockImplementation((basePath: unknown) => {
+        if (basePath === siblingBare) {
+          return Promise.reject(new Error("repo-b corrupt"));
+        }
+        return Promise.resolve([`worktree ${currentWt}`, "branch refs/heads/main", ""].join("\n"));
+      });
+
+      const ctx = new RepositoryContext();
+      const discovered = await ctx.detectFromPath(currentWt);
+      const details = await ctx.getAllConfiguredWorktreeDetails(discovered.currentWorktreePath);
+
+      expect(details.worktreesByRepo["repo-a"]).toEqual([{ path: currentWt, branch: "main", isCurrent: true }]);
+      expect(details.worktreesByRepo["repo-b"]).toEqual([]);
+      expect(details.errorsByRepo["repo-b"]).toContain("repo-b corrupt");
     } finally {
       await fs.rm(workspace, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -162,7 +162,6 @@ function makeCtx(opts: {
     getCurrentRepo: vi.fn<any>().mockReturnValue(opts.currentRepo ?? "test"),
     getRepositoryList: vi.fn<any>().mockReturnValue([]),
     getConfiguredRepositoryNames: vi.fn<any>().mockReturnValue(opts.configuredRepoNames ?? []),
-    getAllConfiguredWorktrees: vi.fn<any>().mockResolvedValue(opts.allConfiguredWorktrees ?? {}),
     getAllConfiguredWorktreeDetails: vi.fn<any>().mockResolvedValue({
       worktreesByRepo: opts.allConfiguredWorktrees ?? {},
       errorsByRepo: opts.allConfiguredWorktreeErrors ?? {},

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -119,6 +119,9 @@ function makeCtx(opts: {
   syncInProgress?: boolean;
   loadConfigImpl?: (configPath: string) => Promise<unknown>;
   currentRepo?: string;
+  configuredRepoNames?: string[];
+  allConfiguredWorktrees?: Record<string, Array<{ path: string; branch: string; isCurrent: boolean }>>;
+  allConfiguredWorktreeErrors?: Record<string, string>;
 }): { ctx: RepositoryContext; git: MockGit; service: any } {
   const git: MockGit = {
     getWorktrees: vi.fn<any>().mockResolvedValue([]),
@@ -148,6 +151,7 @@ function makeCtx(opts: {
   };
 
   const ctx = {
+    detectFromPath: vi.fn<any>().mockResolvedValue(opts.discovered ?? makeDiscovered()),
     getDiscoveredContext: vi.fn<any>().mockReturnValue(opts.discovered ?? makeDiscovered()),
     getEntry: vi.fn<any>().mockReturnValue({
       name: opts.currentRepo ?? "test",
@@ -157,6 +161,12 @@ function makeCtx(opts: {
     loadConfig: vi.fn<any>().mockImplementation((opts.loadConfigImpl ?? (async () => [])) as any),
     getCurrentRepo: vi.fn<any>().mockReturnValue(opts.currentRepo ?? "test"),
     getRepositoryList: vi.fn<any>().mockReturnValue([]),
+    getConfiguredRepositoryNames: vi.fn<any>().mockReturnValue(opts.configuredRepoNames ?? []),
+    getAllConfiguredWorktrees: vi.fn<any>().mockResolvedValue(opts.allConfiguredWorktrees ?? {}),
+    getAllConfiguredWorktreeDetails: vi.fn<any>().mockResolvedValue({
+      worktreesByRepo: opts.allConfiguredWorktrees ?? {},
+      errorsByRepo: opts.allConfiguredWorktreeErrors ?? {},
+    }),
     setCurrentRepo: vi.fn<any>(),
     invalidateDiscovered: vi.fn<any>(),
   } as unknown as RepositoryContext;
@@ -211,6 +221,113 @@ describe("handleListWorktrees", () => {
     const body = parseResponse(result);
     expect(body.error).toBe(true);
     expect(body.code).toBe("CAPABILITY_UNAVAILABLE");
+  });
+
+  it("groups all configured repos when repoName is omitted", async () => {
+    const cleanStatus = {
+      isClean: true,
+      hasUnpushedCommits: false,
+      hasStashedChanges: false,
+      hasOperationInProgress: false,
+      hasModifiedSubmodules: false,
+      upstreamGone: false,
+      canRemove: true,
+      reasons: [],
+    };
+    const gitByRepo = {
+      "repo-a": {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repos/a/main", branch: "main" }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue(cleanStatus),
+        getWorktreeMetadata: vi.fn<any>().mockResolvedValue({ lastSyncDate: "2026-05-17T00:00:00.000Z" }),
+      },
+      "repo-b": {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repos/b/feature", branch: "feature" }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue(cleanStatus),
+        getWorktreeMetadata: vi.fn<any>().mockResolvedValue(null),
+      },
+    };
+
+    const ctx = {
+      getConfiguredRepositoryNames: vi.fn<any>().mockReturnValue(["repo-a", "repo-b"]),
+      getDiscoveredContext: vi.fn<any>().mockImplementation((repoName: unknown) =>
+        makeDiscovered({
+          repoName: String(repoName),
+          currentWorktreePath: repoName === "repo-a" ? "/repos/a/main" : null,
+        }),
+      ),
+      getService: vi.fn<any>().mockImplementation(async (repoName: unknown) => {
+        const name = repoName as "repo-a" | "repo-b";
+        return {
+          isInitialized: vi.fn<any>().mockReturnValue(true),
+          getGitService: () => gitByRepo[name],
+        };
+      }),
+    } as unknown as RepositoryContext;
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+
+    expect(Object.keys(body.repositories)).toEqual(["repo-a", "repo-b"]);
+    expect(body.repositories["repo-a"].worktrees[0]).toMatchObject({
+      path: "/repos/a/main",
+      branch: "main",
+      isCurrent: true,
+      label: "current",
+    });
+    expect(body.repositories["repo-b"].worktrees[0]).toMatchObject({
+      path: "/repos/b/feature",
+      branch: "feature",
+      isCurrent: false,
+      label: "clean",
+    });
+  });
+
+  it("captures per-repo errors when grouped list_worktrees cannot read one repo", async () => {
+    const cleanStatus = {
+      isClean: true,
+      hasUnpushedCommits: false,
+      hasStashedChanges: false,
+      hasOperationInProgress: false,
+      hasModifiedSubmodules: false,
+      upstreamGone: false,
+      canRemove: true,
+      reasons: [],
+    };
+    const gitByRepo = {
+      "repo-a": {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/repos/a/main", branch: "main" }]),
+        getFullWorktreeStatus: vi.fn<any>().mockResolvedValue(cleanStatus),
+        getWorktreeMetadata: vi.fn<any>().mockResolvedValue(null),
+      },
+    };
+
+    const ctx = {
+      getConfiguredRepositoryNames: vi.fn<any>().mockReturnValue(["repo-a", "repo-b"]),
+      getDiscoveredContext: vi.fn<any>().mockImplementation((repoName: unknown) =>
+        makeDiscovered({
+          repoName: String(repoName),
+          currentWorktreePath: null,
+        }),
+      ),
+      getService: vi.fn<any>().mockImplementation(async (repoName: unknown) => {
+        if (repoName === "repo-b") {
+          throw new Error("repo-b unavailable");
+        }
+        return {
+          isInitialized: vi.fn<any>().mockReturnValue(true),
+          getGitService: () => gitByRepo["repo-a"],
+        };
+      }),
+    } as unknown as RepositoryContext;
+
+    const result = await invoke(handleListWorktrees, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.repositories["repo-a"].worktrees).toHaveLength(1);
+    expect(body.repositories["repo-b"]).toEqual({
+      worktrees: [],
+      error: "repo-b unavailable",
+    });
   });
 });
 
@@ -898,5 +1015,55 @@ describe("handleDetectContext includeStatus", () => {
     expect(body.allWorktrees[0].label).toBe("current");
     expect(body.allWorktrees[1].label).toBe("clean");
     expect(body.allWorktrees[0].staleHint).toBe(false);
+  });
+
+  it("adds allWorktreesByRepo when includeAllWorktrees=true", async () => {
+    const { ctx } = makeCtx({
+      discovered: makeDiscovered({
+        currentWorktreePath: "/repo/main",
+        allWorktrees: [{ path: "/repo/main", branch: "main", isCurrent: true }],
+      }),
+      allConfiguredWorktrees: {
+        test: [{ path: "/repo/main", branch: "main", isCurrent: true }],
+        other: [{ path: "/other/feature", branch: "feature", isCurrent: false }],
+      },
+    });
+
+    const result = await invoke(handleDetectContext, ctx, { includeAllWorktrees: true });
+    const body = parseResponse(result);
+
+    expect(body.allWorktreesByRepo).toEqual({
+      test: [{ path: "/repo/main", branch: "main", isCurrent: true }],
+      other: [{ path: "/other/feature", branch: "feature", isCurrent: false }],
+    });
+    expect(ctx.getAllConfiguredWorktreeDetails).toHaveBeenCalledWith("/repo/main");
+  });
+
+  it("enriches allWorktreesByRepo and returns per-repo errors when both include flags are true", async () => {
+    const { ctx } = makeCtx({
+      discovered: makeDiscovered({
+        currentWorktreePath: "/repo/main",
+        allWorktrees: [{ path: "/repo/main", branch: "main", isCurrent: true }],
+      }),
+      allConfiguredWorktrees: {
+        test: [{ path: "/repo/main", branch: "main", isCurrent: true }],
+        other: [{ path: "/other/feature", branch: "feature", isCurrent: false }],
+      },
+      allConfiguredWorktreeErrors: {
+        broken: "git worktree list failed",
+      },
+    });
+
+    const result = await invoke(handleDetectContext, ctx, { includeAllWorktrees: true, includeStatus: true });
+    const body = parseResponse(result);
+
+    expect(body.allWorktrees[0]).toMatchObject({ path: "/repo/main", label: "current", staleHint: false });
+    expect(body.allWorktreesByRepo.test[0]).toMatchObject({ path: "/repo/main", label: "current", staleHint: false });
+    expect(body.allWorktreesByRepo.other[0]).toMatchObject({
+      path: "/other/feature",
+      label: "clean",
+      staleHint: false,
+    });
+    expect(body.allWorktreeErrorsByRepo).toEqual({ broken: "git worktree list failed" });
   });
 });

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -132,8 +132,8 @@ describe("createServer", () => {
 
 describe("buildInstructions", () => {
   const baseInstructions =
-    "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, sibling repositories under the workspace root, and which capabilities are available. " +
-    "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, lists sibling worktrees, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
+    "Before running git worktree operations, call `detect_context` with `includeAllWorktrees: true` at session start to learn every configured repository and worktree, plus the current repo, current branch, sibling repositories, and available capabilities. " +
+    "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, reports config-driven sibling repositories, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
 
   function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): DiscoveredRepoContext {
     return {
@@ -209,7 +209,16 @@ describe("buildInstructions", () => {
         { path: "/repos/my-repo/worktrees/main", branch: "main", isCurrent: false },
         { path: "/repos/my-repo/worktrees/feature-x", branch: "feature-x", isCurrent: true },
       ],
-      siblingRepositories: [{ name: "other-repo", bareRepoPath: "/repos/other-repo/.bare", configMatched: true }],
+      siblingRepositories: [
+        {
+          name: "other-repo",
+          bareRepoPath: "/repos/other-repo/.bare",
+          worktreeDir: "/repos/other-repo/worktrees",
+          repoUrl: "https://example.com/other-repo.git",
+          present: true,
+          configMatched: true,
+        },
+      ],
     });
     const result = buildInstructions({ discovered });
 

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -40,6 +40,10 @@ export interface DiscoveredWorktree {
 export interface SiblingRepository {
   name: string;
   bareRepoPath: string;
+  worktreeDir: string | null;
+  repoUrl: string | null;
+  sparseCheckout?: RepositoryConfig["sparseCheckout"];
+  present: boolean;
   configMatched: boolean;
 }
 
@@ -52,6 +56,8 @@ export interface DiscoveredRepoContext {
   repoUrl: string | null;
   worktreeDir: string | null;
   allWorktrees: DiscoveredWorktree[];
+  allWorktreesByRepo?: Record<string, DiscoveredWorktree[]>;
+  allWorktreeErrorsByRepo?: Record<string, string>;
   siblingRepositories: SiblingRepository[];
   configPath: string | null;
   repoName: string | null;
@@ -237,16 +243,42 @@ export class RepositoryContext {
   }
 
   private async discoverSiblingRepositories(currentBareRepoPath: string): Promise<SiblingRepository[]> {
+    const currentBare = normalizePathForCompare(currentBareRepoPath);
+    const results = new Map<string, SiblingRepository>();
+
+    for (const entry of this.repos.values()) {
+      if (entry.source !== "config" || !entry.config.bareRepoDir) continue;
+
+      const bareRepoPath = path.resolve(entry.config.bareRepoDir);
+      const foldedBare = normalizePathForCompare(bareRepoPath);
+      if (foldedBare === currentBare) continue;
+
+      const sibling: SiblingRepository = {
+        name: entry.name,
+        bareRepoPath,
+        worktreeDir: path.resolve(entry.config.worktreeDir),
+        repoUrl: entry.config.repoUrl,
+        present: await isDirectory(bareRepoPath),
+        configMatched: true,
+      };
+      if (entry.config.sparseCheckout) {
+        sibling.sparseCheckout = entry.config.sparseCheckout;
+      }
+      results.set(foldedBare, sibling);
+    }
+
     const repoDir = path.dirname(currentBareRepoPath);
     const workspaceRoot = path.dirname(repoDir);
 
-    if (workspaceRoot === repoDir) return [];
+    if (workspaceRoot === repoDir) {
+      return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
+    }
 
     let entries: string[];
     try {
       entries = await fs.readdir(workspaceRoot);
     } catch {
-      return [];
+      return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
     }
 
     const configBares = new Map<string, string>();
@@ -256,7 +288,6 @@ export class RepositoryContext {
       }
     }
 
-    const results: SiblingRepository[] = [];
     await Promise.all(
       entries.map(async (entry) => {
         const candidate = path.join(workspaceRoot, entry);
@@ -269,17 +300,22 @@ export class RepositoryContext {
         }
 
         const resolvedBare = path.resolve(bareCandidate);
+        const foldedBare = normalizePathForCompare(resolvedBare);
+        if (foldedBare === currentBare || results.has(foldedBare)) return;
+
         const matchedName = configBares.get(normalizePathForCompare(resolvedBare));
-        results.push({
+        results.set(foldedBare, {
           name: matchedName ?? entry,
           bareRepoPath: resolvedBare,
+          worktreeDir: null,
+          repoUrl: null,
+          present: true,
           configMatched: matchedName !== undefined,
         });
       }),
     );
 
-    results.sort((a, b) => a.name.localeCompare(b.name));
-    return results;
+    return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
   }
 
   private bootstrapCurrentRepo(candidate: string, force = false): void {
@@ -535,13 +571,67 @@ export class RepositoryContext {
     }));
   }
 
+  getConfiguredRepositoryNames(): string[] {
+    return Array.from(this.repos.values())
+      .filter((entry) => entry.source === "config")
+      .map((entry) => entry.name);
+  }
+
+  async getAllConfiguredWorktrees(
+    currentWorktreePath: string | null = null,
+  ): Promise<Record<string, DiscoveredWorktree[]>> {
+    const details = await this.getAllConfiguredWorktreeDetails(currentWorktreePath);
+    return details.worktreesByRepo;
+  }
+
+  async getAllConfiguredWorktreeDetails(
+    currentWorktreePath: string | null = null,
+  ): Promise<{ worktreesByRepo: Record<string, DiscoveredWorktree[]>; errorsByRepo: Record<string, string> }> {
+    const entries = Array.from(this.repos.values()).filter((entry) => entry.source === "config");
+    const results = await Promise.all(
+      entries.map(async (entry) => ({
+        name: entry.name,
+        result: await this.readConfiguredWorktrees(entry, currentWorktreePath),
+      })),
+    );
+
+    const worktreesByRepo: Record<string, DiscoveredWorktree[]> = {};
+    const errorsByRepo: Record<string, string> = {};
+
+    for (const entry of results) {
+      worktreesByRepo[entry.name] = entry.result.worktrees;
+      if (entry.result.error) {
+        errorsByRepo[entry.name] = entry.result.error;
+      }
+    }
+
+    return { worktreesByRepo, errorsByRepo };
+  }
+
   getConfigPath(): string | null {
     return this.configPath;
   }
+
+  private async readConfiguredWorktrees(
+    entry: RepoEntry,
+    currentWorktreePath: string | null,
+  ): Promise<{ worktrees: DiscoveredWorktree[]; error?: string }> {
+    if (entry.source !== "config" || !entry.config.bareRepoDir) return { worktrees: [] };
+
+    const bareRepoPath = path.resolve(entry.config.bareRepoDir);
+    if (!(await isDirectory(bareRepoPath))) return { worktrees: [] };
+
+    try {
+      const output = await simpleGit(bareRepoPath).raw(["worktree", "list", "--porcelain"]);
+      return { worktrees: parseWorktreeList(output, currentWorktreePath) };
+    } catch (err) {
+      return { worktrees: [], error: err instanceof Error ? err.message : String(err) };
+    }
+  }
 }
 
-function parseWorktreeList(output: string, currentPath: string): DiscoveredWorktree[] {
-  const foldedCurrent = normalizePathForCompare(currentPath);
+function parseWorktreeList(output: string, currentPath: string | null): DiscoveredWorktree[] {
+  const foldedCurrent = currentPath ? normalizePathForCompare(currentPath) : null;
   const results: DiscoveredWorktree[] = [];
   for (const wt of parseWorktreeListPorcelain(output)) {
     const resolved = path.resolve(wt.path);
@@ -550,7 +640,7 @@ function parseWorktreeList(output: string, currentPath: string): DiscoveredWorkt
     results.push({
       path: resolved,
       branch,
-      isCurrent: normalizePathForCompare(resolved) === foldedCurrent,
+      isCurrent: foldedCurrent !== null && normalizePathForCompare(resolved) === foldedCurrent,
     });
   }
   return results;
@@ -566,6 +656,15 @@ async function safeMtimeMs(filePath: string): Promise<number | null> {
     return stat.mtimeMs;
   } catch {
     return null;
+  }
+}
+
+async function isDirectory(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isDirectory();
+  } catch {
+    return false;
   }
 }
 

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -245,65 +245,59 @@ export class RepositoryContext {
   private async discoverSiblingRepositories(currentBareRepoPath: string): Promise<SiblingRepository[]> {
     const currentBare = normalizePathForCompare(currentBareRepoPath);
     const results = new Map<string, SiblingRepository>();
+    const byName = (a: SiblingRepository, b: SiblingRepository): number => a.name.localeCompare(b.name);
 
-    for (const entry of this.repos.values()) {
-      if (entry.source !== "config" || !entry.config.bareRepoDir) continue;
+    const configCandidates = Array.from(this.repos.values())
+      .filter((entry) => entry.source === "config" && !!entry.config.bareRepoDir)
+      .map((entry) => {
+        const bareRepoPath = path.resolve(entry.config.bareRepoDir as string);
+        return { entry, bareRepoPath, foldedBare: normalizePathForCompare(bareRepoPath) };
+      })
+      .filter((c) => c.foldedBare !== currentBare);
 
-      const bareRepoPath = path.resolve(entry.config.bareRepoDir);
-      const foldedBare = normalizePathForCompare(bareRepoPath);
-      if (foldedBare === currentBare) continue;
-
+    const configPresence = await Promise.all(configCandidates.map((c) => isDirectory(c.bareRepoPath)));
+    configCandidates.forEach(({ entry, bareRepoPath, foldedBare }, i) => {
       const sibling: SiblingRepository = {
         name: entry.name,
         bareRepoPath,
         worktreeDir: path.resolve(entry.config.worktreeDir),
         repoUrl: entry.config.repoUrl,
-        present: await isDirectory(bareRepoPath),
+        present: configPresence[i],
         configMatched: true,
       };
       if (entry.config.sparseCheckout) {
         sibling.sparseCheckout = entry.config.sparseCheckout;
       }
       results.set(foldedBare, sibling);
-    }
+    });
 
     const repoDir = path.dirname(currentBareRepoPath);
     const workspaceRoot = path.dirname(repoDir);
 
     if (workspaceRoot === repoDir) {
-      return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
+      return Array.from(results.values()).sort(byName);
     }
 
     let entries: string[];
     try {
       entries = await fs.readdir(workspaceRoot);
     } catch {
-      return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
+      return Array.from(results.values()).sort(byName);
     }
 
-    const configBares = new Map<string, string>();
-    for (const entry of this.repos.values()) {
-      if (entry.source === "config" && entry.config.bareRepoDir) {
-        configBares.set(normalizePathForCompare(entry.config.bareRepoDir), entry.name);
-      }
-    }
+    const configBares = new Map(configCandidates.map((c) => [c.foldedBare, c.entry.name]));
 
     await Promise.all(
       entries.map(async (entry) => {
         const candidate = path.join(workspaceRoot, entry);
         const bareCandidate = path.join(candidate, GIT_CONSTANTS.BARE_DIR_NAME);
-        try {
-          const stat = await fs.stat(bareCandidate);
-          if (!stat.isDirectory()) return;
-        } catch {
-          return;
-        }
+        if (!(await isDirectory(bareCandidate))) return;
 
         const resolvedBare = path.resolve(bareCandidate);
         const foldedBare = normalizePathForCompare(resolvedBare);
         if (foldedBare === currentBare || results.has(foldedBare)) return;
 
-        const matchedName = configBares.get(normalizePathForCompare(resolvedBare));
+        const matchedName = configBares.get(foldedBare);
         results.set(foldedBare, {
           name: matchedName ?? entry,
           bareRepoPath: resolvedBare,
@@ -315,7 +309,7 @@ export class RepositoryContext {
       }),
     );
 
-    return Array.from(results.values()).sort((a, b) => a.name.localeCompare(b.name));
+    return Array.from(results.values()).sort(byName);
   }
 
   private bootstrapCurrentRepo(candidate: string, force = false): void {
@@ -575,13 +569,6 @@ export class RepositoryContext {
     return Array.from(this.repos.values())
       .filter((entry) => entry.source === "config")
       .map((entry) => entry.name);
-  }
-
-  async getAllConfiguredWorktrees(
-    currentWorktreePath: string | null = null,
-  ): Promise<Record<string, DiscoveredWorktree[]>> {
-    const details = await this.getAllConfiguredWorktreeDetails(currentWorktreePath);
-    return details.worktreesByRepo;
   }
 
   async getAllConfiguredWorktreeDetails(

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -14,6 +14,7 @@ import { deriveLabel, deriveSafeToRemove, getDivergence } from "./worktree-summa
 
 import type { Capabilities, DiscoveredRepoContext, DiscoveredWorktree, RepositoryContext } from "./context";
 import type { HandlerExtra } from "./utils";
+import type { WorktreeLabel } from "./worktree-summary";
 import type { ProgressEvent } from "../services/worktree-sync.service";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -27,7 +28,7 @@ type ListedWorktree = {
   path: string;
   branch: string;
   isCurrent: boolean;
-  label: string;
+  label: WorktreeLabel;
   status: Awaited<ReturnType<RepoGitService["getFullWorktreeStatus"]>> | null;
   divergence: Awaited<ReturnType<typeof getDivergence>>;
   safeToRemove: ReturnType<typeof deriveSafeToRemove>;

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -22,6 +22,18 @@ type RepoScopedParams = { repoName?: string };
 type WorktreePathParams = RepoScopedParams & { path: string };
 type RepoService = Awaited<ReturnType<RepositoryContext["getService"]>>;
 type RepoGitService = ReturnType<RepoService["getGitService"]>;
+type Limit = ReturnType<typeof pLimit>;
+type ListedWorktree = {
+  path: string;
+  branch: string;
+  isCurrent: boolean;
+  label: string;
+  status: Awaited<ReturnType<RepoGitService["getFullWorktreeStatus"]>> | null;
+  divergence: Awaited<ReturnType<typeof getDivergence>>;
+  safeToRemove: ReturnType<typeof deriveSafeToRemove>;
+  lastSyncAt: string | null;
+  sizeBytes: number | null;
+};
 
 const pathResolution = new PathResolutionService();
 
@@ -107,21 +119,55 @@ async function ensurePathBelongsToRepo(
 
 export async function handleDetectContext(
   ctx: RepositoryContext,
-  params: { path?: string; includeStatus?: boolean },
+  params: { path?: string; includeStatus?: boolean; includeAllWorktrees?: boolean },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
   const target = params.path ?? process.cwd();
   const discovered = await ctx.detectFromPath(target);
+  let response: DiscoveredRepoContext = discovered;
 
-  if (!params.includeStatus || discovered.allWorktrees.length === 0) {
-    return formatToolResponse(discovered);
+  if (params.includeAllWorktrees) {
+    const details = await ctx.getAllConfiguredWorktreeDetails(discovered.currentWorktreePath);
+    const errorsByRepo = Object.keys(details.errorsByRepo).length > 0 ? details.errorsByRepo : undefined;
+    response = {
+      ...response,
+      allWorktreesByRepo: details.worktreesByRepo,
+      allWorktreeErrorsByRepo: errorsByRepo,
+    };
+  }
+
+  if (!params.includeStatus) {
+    return formatToolResponse(response);
   }
 
   const statusService = new WorktreeStatusService();
-  const limit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
+  const statusLimit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
 
-  const enriched: DiscoveredWorktree[] = await Promise.all(
-    discovered.allWorktrees.map((wt) =>
+  const enriched = await enrichDetectedWorktrees(response.allWorktrees, statusService, statusLimit);
+  let allWorktreesByRepo = response.allWorktreesByRepo;
+
+  if (allWorktreesByRepo) {
+    const entries = await Promise.all(
+      Object.entries(allWorktreesByRepo).map(async ([repoName, worktrees]) => [
+        repoName,
+        await enrichDetectedWorktrees(worktrees, statusService, statusLimit),
+      ]),
+    );
+    allWorktreesByRepo = Object.fromEntries(entries);
+  }
+
+  return formatToolResponse({ ...response, allWorktrees: enriched, allWorktreesByRepo });
+}
+
+async function enrichDetectedWorktrees(
+  worktrees: DiscoveredWorktree[],
+  statusService: WorktreeStatusService,
+  limit: Limit,
+): Promise<DiscoveredWorktree[]> {
+  if (worktrees.length === 0) return worktrees;
+
+  return Promise.all(
+    worktrees.map((wt) =>
       limit(async () => {
         const [status, divergence] = await Promise.all([
           statusService.getFullWorktreeStatus(wt.path, false).catch(() => null),
@@ -140,8 +186,6 @@ export async function handleDetectContext(
       }),
     ),
   );
-
-  return formatToolResponse({ ...discovered, allWorktrees: enriched });
 }
 
 export async function handleListWorktrees(
@@ -149,7 +193,47 @@ export async function handleListWorktrees(
   params: { repoName?: string; includeSize?: boolean },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const { discovered, git } = await getReadyService(ctx, params.repoName, {
+  const configuredRepoNames = params.repoName ? [] : ctx.getConfiguredRepositoryNames();
+  if (configuredRepoNames.length > 0) {
+    const limit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_REPOSITORIES);
+    const statusLimit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
+    const repositories = await Promise.all(
+      configuredRepoNames.map((repoName) =>
+        limit(async () => {
+          try {
+            return [
+              repoName,
+              {
+                worktrees: await listWorktreesForRepo(ctx, repoName, params.includeSize, statusLimit),
+              },
+            ] as const;
+          } catch (err) {
+            return [
+              repoName,
+              {
+                worktrees: [],
+                error: err instanceof Error ? err.message : String(err),
+              },
+            ] as const;
+          }
+        }),
+      ),
+    );
+
+    return formatToolResponse({ repositories: Object.fromEntries(repositories) });
+  }
+
+  const results = await listWorktreesForRepo(ctx, params.repoName, params.includeSize);
+  return formatToolResponse({ worktrees: results });
+}
+
+async function listWorktreesForRepo(
+  ctx: RepositoryContext,
+  repoName: string | undefined,
+  includeSize: boolean | undefined,
+  limit: Limit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS),
+): Promise<ListedWorktree[]> {
+  const { discovered, git } = await getReadyService(ctx, repoName, {
     capability: "listWorktrees",
     toolName: "list_worktrees",
   });
@@ -167,7 +251,6 @@ export async function handleListWorktrees(
 
   const currentPath = discovered?.currentWorktreePath ?? null;
 
-  const limit = pLimit(DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS);
   const results = await Promise.all(
     worktrees.map((wt) =>
       limit(async () => {
@@ -178,7 +261,7 @@ export async function handleListWorktrees(
           git.getFullWorktreeStatus(wt.path, false).catch(() => null),
           getDivergence(wt.path),
           git.getWorktreeMetadata(wt.path).catch(() => null),
-          params.includeSize ? calculateDirectorySize(wt.path).catch(() => null) : Promise.resolve(null),
+          includeSize ? calculateDirectorySize(wt.path).catch(() => null) : Promise.resolve(null),
         ]);
 
         return {
@@ -196,7 +279,7 @@ export async function handleListWorktrees(
     ),
   );
 
-  return formatToolResponse({ worktrees: results });
+  return results;
 }
 
 export async function handleGetWorktreeStatus(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,8 +24,8 @@ const REPO_NAME_DESCRIBE =
 const PATH_DESCRIBE_SUFFIX = "Absolute path preferred; relative paths resolve from the server's CWD.";
 
 const SERVER_INSTRUCTIONS =
-  "Before running git worktree operations, call `detect_context` to learn the current repo, current branch, sibling repositories under the workspace root, and which capabilities are available. " +
-  "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, lists sibling worktrees, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
+  "Before running git worktree operations, call `detect_context` with `includeAllWorktrees: true` at session start to learn every configured repository and worktree, plus the current repo, current branch, sibling repositories, and available capabilities. " +
+  "It walks up to auto-discover sync-worktrees.config.{js,mjs,cjs,ts}, reports config-driven sibling repositories, and reports per-capability {available, reason} so you can tell which tool is gated and why.";
 
 export interface ServerSnapshot {
   discovered: DiscoveredRepoContext | null;
@@ -87,16 +87,22 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "detect_context",
     {
       description:
-        "Detect sync-worktrees structure from a filesystem path. Reads .git file, resolves bare repo, discovers sibling worktrees, walks up for a sync-worktrees.config.{js,mjs,cjs,ts}, and lists sibling bare repos under the workspace root. Defaults to CWD. " +
+        "Detect sync-worktrees structure from a filesystem path. Reads .git file, resolves bare repo, discovers sibling worktrees, walks up for a sync-worktrees.config.{js,mjs,cjs,ts}, and lists configured sibling repositories. Defaults to CWD. " +
         "Use when: bootstrapping from an unknown checkout. " +
         "Returns: discovered repo root, bare repo path, all sibling worktrees, sibling repositories, current worktree path, configPath (auto-found), per-capability {available, reason}, notes[].",
       inputSchema: {
         path: z.string().optional().describe("Directory path to inspect. Defaults to the server's CWD."),
+        includeAllWorktrees: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, includes allWorktreesByRepo with worktrees for every configured repository, keyed by repoName, and allWorktreeErrorsByRepo for repos that could not be enumerated. Default: false.",
+          ),
         includeStatus: z
           .boolean()
           .optional()
           .describe(
-            "If true, enriches each entry in allWorktrees with label, divergence, and staleHint. Adds one git status + rev-list per worktree. Default: false (cheap path).",
+            "If true, enriches worktree entries with label, divergence, and staleHint. Adds one git status + rev-list per worktree. Default: false (cheap path).",
           ),
       },
       annotations: {
@@ -113,10 +119,15 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "list_worktrees",
     {
       description:
-        "List all worktrees of a repository with enriched status. " +
-        "Returns: array of { path, branch, isCurrent, label (clean|dirty|stale|current|unknown), status, divergence (ahead/behind), safeToRemove: { safe, reason }, lastSyncAt, sizeBytes }.",
+        "List worktrees with enriched status. Without repoName and with a loaded config, returns all configured repositories grouped by repoName. With repoName, returns that single repository. " +
+        "Returns worktree entries as { path, branch, isCurrent, label (clean|dirty|stale|current|unknown), status, divergence (ahead/behind), safeToRemove: { safe, reason }, lastSyncAt, sizeBytes }.",
       inputSchema: {
-        repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
+        repoName: z
+          .string()
+          .optional()
+          .describe(
+            "Repository name from loaded config. If omitted and a config is loaded, lists all configured repos.",
+          ),
         includeSize: z
           .boolean()
           .optional()


### PR DESCRIPTION
## Summary

- Make MCP `detect_context` populate sibling repositories from loaded config first, including nested `worktreeDir`, `repoUrl`, sparse checkout metadata, and bare repo presence.
- Add `includeAllWorktrees` support so agents can retrieve worktrees across every configured repository, with per-repo enumeration errors when a configured bare repo cannot be read.
- Change config-mode `list_worktrees` without `repoName` to return grouped results across all configured repositories, with shared status concurrency.
- Update MCP instructions, README documentation, and add a patch changeset.

## Why

Agents working inside one managed worktree could see that a config existed, but could not discover the other configured repositories or their nested worktree locations without shelling out. The previous sibling discovery path was filesystem-walk driven and missed nested config entries.

## Validation

- `pnpm exec vitest run src/mcp/__tests__/context.test.ts src/mcp/__tests__/handlers.test.ts src/mcp/__tests__/server.test.ts --reporter=dot`
- `pnpm run typecheck`
- `pnpm run lint`
- `SKIP_E2E_TESTS=true pnpm exec vitest run --reporter=dot`
- `pnpm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-repository worktree discovery with config-driven sibling repository detection
  * Grouped worktree enumeration across all configured repositories when specified
  * Per-repository error reporting for worktree enumeration failures
  * Support for nested worktree directories in repository configuration

* **Documentation**
  * Updated initialization guidance requiring session startup discovery call with all-worktrees option enabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yordan-kanchelov/sync-worktrees/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->