### PR TITLE
[codex] Push created branches by default

### DIFF
--- a/.changeset/sharp-branches-push.md
+++ b/.changeset/sharp-branches-push.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Push newly created branches to origin by default from `create_worktree`, keep `push=false` as an explicit opt-out, and prevent created branches from inheriting the base branch's upstream.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Client-specific locations:
 | `detect_context` | Inspect a path, resolve the bare repo, enumerate sibling worktrees, report config-driven sibling repositories and capabilities. Pass `includeAllWorktrees: true` to include every configured repo's worktrees keyed by repo name. |
 | `list_worktrees` | List worktrees with status label (`clean`/`dirty`/`stale`/`current`), divergence, `safeToRemove`, last sync. Without `repoName` and with a loaded config, results are grouped across all configured repos. |
 | `get_worktree_status` | Detailed status for one worktree (dirty files, unpushed commits, stashes, operation in progress). |
-| `create_worktree` | Create a worktree for a branch; optionally create the branch from `baseBranch` and push. |
+| `create_worktree` | Create a worktree for a branch; optionally create the branch from `baseBranch`. Newly created branches are pushed to origin unless `push=false`. |
 | `remove_worktree` | Remove a worktree after safety checks; `force=true` skips validation. |
 | `update_worktree` | Fast-forward one worktree to match upstream. |
 | `sync` | Full sync cycle (fetch, create, prune, update). Requires config. Streams progress notifications. |
@@ -144,6 +144,7 @@ All tools that target a single repo accept an optional `repoName`. When omitted,
 
 - `remove_worktree` refuses to delete worktrees with uncommitted changes, unpushed commits, stashes, or operations in progress (merge/rebase/cherry-pick/revert/bisect). Pass `force=true` to override.
 - `create_worktree` rejects sanitized-path collisions (e.g. `feature/foo` vs `feature-foo` both resolving to `feature-foo/`) before touching disk.
+- Branches created by sync-worktrees use `--no-track` first, then publish with `git push -u origin <branch>`, so they do not inherit `origin/main` as their upstream.
 - Path-targeted tools verify the supplied path is a registered worktree of the selected repository.
 
 ## Options

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -347,7 +347,7 @@ describe("handleCreateWorktree", () => {
     expect(git.addWorktree).toHaveBeenCalledWith("feature/x", expect.stringContaining("feature-x"));
   });
 
-  it("creates branch when it does not exist and baseBranch provided", async () => {
+  it("creates and pushes a missing branch by default when baseBranch is provided", async () => {
     const { ctx, git } = makeCtx({
       git: {
         branchExists: vi.fn<any>().mockResolvedValue({ local: false, remote: false }),
@@ -357,7 +357,6 @@ describe("handleCreateWorktree", () => {
     const result = await invoke(handleCreateWorktree, ctx, {
       branchName: "new-branch",
       baseBranch: "main",
-      push: true,
     });
     const body = parseResponse(result);
     expect(body.created).toBe(true);
@@ -442,7 +441,6 @@ describe("handleCreateWorktree", () => {
     const result = await invoke(handleCreateWorktree, ctx, {
       branchName: "new-branch",
       baseBranch: "main",
-      push: true,
     });
     const body = parseResponse(result);
     expect(body.error).toBe(true);
@@ -493,7 +491,6 @@ describe("handleCreateWorktree", () => {
     await invoke(handleCreateWorktree, ctx, {
       branchName: "new-branch",
       baseBranch: "main",
-      push: true,
     });
 
     expect(callOrder).toEqual(["createBranch", "addWorktree", "pushBranch"]);

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -310,7 +310,8 @@ export async function handleCreateWorktree(
   params: { branchName: string; baseBranch?: string; push?: boolean; repoName?: string },
   _extra?: HandlerExtra,
 ): Promise<CallToolResult> {
-  const { branchName, baseBranch, push } = params;
+  const { branchName, baseBranch } = params;
+  const push = params.push ?? true;
 
   const validation = isValidGitBranchName(branchName);
   if (!validation.valid) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -173,8 +173,8 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "create_worktree",
     {
       description:
-        "Create a worktree for a branch. If the branch exists (local or remote), checks it out; otherwise creates it from baseBranch. Optionally pushes the new branch to origin. " +
-        "Key params: baseBranch is required only when the branch does not yet exist — pass it defensively if unsure. push=true only affects newly created branches. " +
+        "Create a worktree for a branch. If the branch exists (local or remote), checks it out; otherwise creates it from baseBranch and pushes the new branch to origin by default. " +
+        "Key params: baseBranch is required only when the branch does not yet exist — pass it defensively if unsure. push=false opts out for newly created branches. " +
         "Preconditions: repository must be initialized (auto-runs on first call). " +
         "Returns: { success, branchName, worktreePath, created, pushed }.",
       inputSchema: {
@@ -190,7 +190,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
         push: z
           .boolean()
           .optional()
-          .describe("Push the newly created branch to origin. Ignored if the branch already existed."),
+          .describe("Push the newly created branch to origin. Default: true. Ignored if the branch already existed."),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       },
       annotations: {

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -96,6 +96,7 @@ describe("GitService", () => {
       status: vi.fn<any>().mockResolvedValue(buildGitStatusResponse({ isClean: true })) as any,
       clone: vi.fn<any>().mockResolvedValue(undefined) as any,
       addConfig: vi.fn<any>().mockResolvedValue(undefined) as any,
+      push: vi.fn<any>().mockResolvedValue(undefined) as any,
       revparse: vi.fn<any>().mockResolvedValue("abc123") as any,
     }) as Mocked<SimpleGit>;
 
@@ -367,7 +368,7 @@ describe("GitService", () => {
       await gitService.createBranch("feat/new", "origin/main");
 
       expect(mockGit.revparse).toHaveBeenCalledWith(["--verify", "origin/main"]);
-      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "feat/new", "origin/main"]);
+      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "--no-track", "feat/new", "origin/main"]);
     });
 
     it("falls back to a local base branch when origin branch is missing", async () => {
@@ -379,7 +380,15 @@ describe("GitService", () => {
 
       expect(mockGit.revparse).toHaveBeenNthCalledWith(1, ["--verify", "origin/main"]);
       expect(mockGit.revparse).toHaveBeenNthCalledWith(2, ["--verify", "main"]);
-      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "feat/new", "main"]);
+      expect(mockGit.raw).toHaveBeenCalledWith(["branch", "--no-track", "feat/new", "main"]);
+    });
+  });
+
+  describe("pushBranch", () => {
+    it("sets the new branch upstream to the same branch on origin", async () => {
+      await gitService.pushBranch("feat/new");
+
+      expect(mockGit.push).toHaveBeenCalledWith(["origin", "feat/new:feat/new", "-u"]);
     });
   });
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1083,7 +1083,7 @@ export class GitService {
     const bareGit = this.getCachedGit(this.bareRepoPath);
     const baseRef = await this.resolveCreateBranchBaseRef(bareGit, baseBranch);
 
-    await bareGit.raw(["branch", branchName, baseRef]);
+    await bareGit.raw(["branch", "--no-track", branchName, baseRef]);
     this.logger.info(`Created branch '${branchName}' from '${baseRef}'`);
   }
 


### PR DESCRIPTION
## Summary

- Push newly created branches from create_worktree by default, with push=false as the opt-out.
- Create branches with --no-track so they do not inherit origin/main as upstream.
- Document the upstream behavior and add a patch changeset.

## Root Cause

Branches created from origin/main could inherit origin/main as their upstream, and MCP-created branches were only pushed when push=true was passed explicitly. That made local branches easy to miss on the remote and could route a later push toward the wrong upstream.

## Validation

- pnpm exec vitest run src/mcp/__tests__/handlers.test.ts
- pnpm exec vitest run src/services/__tests__/git.service.test.ts
- pnpm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branches created via the `create_worktree` tool are now pushed to `origin` by default unless `push=false` is specified.
  * Created branches are isolated from the base branch's upstream configuration.

* **Documentation**
  * Updated documentation clarifying branch creation and default push behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yordan-kanchelov/sync-worktrees/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->