### PR TITLE
refactor: polish follow-ups from /simplify review on PR #84

### DIFF
--- a/.changeset/polish-cli-collapse-followups.md
+++ b/.changeset/polish-cli-collapse-followups.md
@@ -1,0 +1,11 @@
+---
+"sync-worktrees": patch
+---
+
+Internal polish follow-up to the CLI collapse refactor:
+
+- Extract `fileExists()` helper, dedupe 8 inline `fs.access` existence checks across config + status paths.
+- Replace `InitConfigInput` interface with `Pick<RepositoryConfig, ...>` so init wizard input type auto-tracks `RepositoryConfig`.
+- Add `CLI_COMMANDS` const + discriminated `CliOptions` union; `main()` now uses `switch` with exhaustive `never` guard so future commands fail at compile time.
+- Collapse `runMultipleRepositories` signature — takes the loaded `ConfigFile` directly and derives `runOnce` / `maxParallel` internally.
+- Multi-repo runner already sets `process.exitCode = 1` on any init/sync failure (shipped in the parent PR).

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import { InteractiveUIService } from "./services/InteractiveUIService";
 import { Logger } from "./services/logger.service";
 import { WorktreeSyncService } from "./services/worktree-sync.service";
 import { parseArguments } from "./utils/cli";
-import { configFileExists, findConfigInCwd, generateConfigFile, getDefaultConfigPath } from "./utils/config-generator";
+import { findConfigInCwd, generateConfigFile, getDefaultConfigPath } from "./utils/config-generator";
+import { fileExists } from "./utils/file-exists";
 import { promptForInitConfig } from "./utils/interactive";
 import { setupSignalHandlers } from "./utils/signal-handlers";
 
@@ -187,7 +188,7 @@ async function runInit(configPath: string | undefined, force: boolean): Promise<
   // Preflight before prompts so user isn't asked 5 questions just to fail at write.
   // The atomic `wx` write below is still the source of truth — it closes the TOCTOU
   // window between this check and the write.
-  if (!force && (await configFileExists(targetPath))) {
+  if (!force && (await fileExists(targetPath))) {
     exitConfigExists(targetPath);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,21 +16,26 @@ import { fileExists } from "./utils/file-exists";
 import { promptForInitConfig } from "./utils/interactive";
 import { setupSignalHandlers } from "./utils/signal-handlers";
 
-import type { RepositoryConfig } from "./types";
+import type { ConfigFile, RepositoryConfig } from "./types";
 import type { CliOptions } from "./utils/cli";
 
 const signalHandle = setupSignalHandlers();
 
 async function runMultipleRepositories(
+  configFile: ConfigFile,
   repositories: RepositoryConfig[],
-  runOnce: boolean,
   configPath?: string,
-  maxParallel?: number,
 ): Promise<void> {
   const services = new Map<string, WorktreeSyncService>();
   const globalLogger = Logger.createDefault();
 
-  const limit = pLimit(maxParallel ?? DEFAULT_CONFIG.PARALLELISM.MAX_REPOSITORIES);
+  const runOnce = configFile.defaults?.runOnce ?? false;
+  const maxParallel =
+    configFile.parallelism?.maxRepositories ??
+    configFile.defaults?.parallelism?.maxRepositories ??
+    DEFAULT_CONFIG.PARALLELISM.MAX_REPOSITORIES;
+
+  const limit = pLimit(maxParallel);
 
   if (runOnce) {
     globalLogger.info(`\n🔄 Syncing ${repositories.length} repositories...`);
@@ -154,15 +159,7 @@ async function runList(configPath: string, filter?: string): Promise<void> {
 async function runFromConfigFile(configPath: string): Promise<void> {
   const configLoader = new ConfigLoaderService();
   const { repositories, configFile } = await configLoader.buildRepositories(configPath);
-
-  const globalRunOnce = configFile.defaults?.runOnce ?? false;
-
-  const maxParallel =
-    configFile.parallelism?.maxRepositories ??
-    configFile.defaults?.parallelism?.maxRepositories ??
-    DEFAULT_CONFIG.PARALLELISM.MAX_REPOSITORIES;
-
-  await runMultipleRepositories(repositories, globalRunOnce, configPath, maxParallel);
+  await runMultipleRepositories(configFile, repositories, configPath);
 }
 
 async function resolveConfigOrExit(cliPath: string | undefined): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { ConfigLoaderService } from "./services/config-loader.service";
 import { InteractiveUIService } from "./services/InteractiveUIService";
 import { Logger } from "./services/logger.service";
 import { WorktreeSyncService } from "./services/worktree-sync.service";
-import { parseArguments } from "./utils/cli";
+import { CLI_COMMANDS, parseArguments } from "./utils/cli";
 import { findConfigInCwd, generateConfigFile, getDefaultConfigPath } from "./utils/config-generator";
 import { fileExists } from "./utils/file-exists";
 import { promptForInitConfig } from "./utils/interactive";
@@ -229,18 +229,20 @@ async function runSync(options: CliOptions): Promise<void> {
 async function main(): Promise<void> {
   const options = parseArguments();
 
-  if (options.command === "init") {
-    await runInit(options.config, options.force ?? false);
-    return;
+  switch (options.command) {
+    case CLI_COMMANDS.INIT:
+      return runInit(options.config, options.force);
+    case CLI_COMMANDS.LIST: {
+      const configPath = await resolveConfigOrExit(options.config);
+      return runList(configPath, options.filter);
+    }
+    case CLI_COMMANDS.RUN:
+      return runSync(options);
+    default: {
+      const _exhaustive: never = options;
+      throw new Error(`Unhandled command: ${JSON.stringify(_exhaustive)}`);
+    }
   }
-
-  if (options.command === "list") {
-    const configPath = await resolveConfigOrExit(options.config);
-    await runList(configPath, options.filter);
-    return;
-  }
-
-  await runSync(options);
 }
 
 main().catch((error) => {

--- a/src/services/clone-sync.service.ts
+++ b/src/services/clone-sync.service.ts
@@ -5,6 +5,7 @@ import simpleGit from "simple-git";
 
 import { DEFAULT_CONFIG, ENV_CONSTANTS, PATH_CONSTANTS } from "../constants";
 import { ConfigError } from "../errors";
+import { fileExists } from "../utils/file-exists";
 import { makeGitProgressHandler } from "../utils/git-progress";
 import { getErrorMessage, isLfsError } from "../utils/lfs-error";
 
@@ -240,15 +241,9 @@ export class CloneSyncService {
     }
 
     const looksIncomplete = entries.every((e) => e.startsWith("."));
-    let hasUsableGit = false;
-    if (entries.includes(PATH_CONSTANTS.GIT_DIR)) {
-      try {
-        await fs.access(path.join(worktreeDir, PATH_CONSTANTS.GIT_DIR, "HEAD"));
-        hasUsableGit = true;
-      } catch {
-        hasUsableGit = false;
-      }
-    }
+    const hasUsableGit =
+      entries.includes(PATH_CONSTANTS.GIT_DIR) &&
+      (await fileExists(path.join(worktreeDir, PATH_CONSTANTS.GIT_DIR, "HEAD")));
 
     if (looksIncomplete && !hasUsableGit) {
       try {
@@ -270,11 +265,8 @@ export class CloneSyncService {
 
   private async runInitialBranchActions(worktreeDir: string, branch: string): Promise<void> {
     const marker = this.getInitMarkerPath(worktreeDir);
-    try {
-      await fs.access(marker);
+    if (await fileExists(marker)) {
       return;
-    } catch {
-      // marker missing — fall through to run actions
     }
 
     const sourceDir = this.config.__configFileDir ?? worktreeDir;

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs/promises";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
@@ -7,6 +6,7 @@ import * as cron from "node-cron";
 import { CONFIG_FILE_NAMES, DEFAULT_CONFIG } from "../constants";
 import { ConfigFileNotFoundError, ConfigValidationError } from "../errors";
 import { matchesPattern } from "../utils/branch-filter";
+import { fileExists } from "../utils/file-exists";
 import { getDefaultBareRepoDir } from "../utils/git-url";
 import { normalizePathForCompare } from "../utils/path-compare";
 import { REPOSITORY_MODES, isRepositoryMode } from "../utils/repo-mode";
@@ -30,11 +30,8 @@ export class ConfigLoaderService {
     while (true) {
       for (const name of CONFIG_FILE_NAMES) {
         const candidate = path.join(current, name);
-        try {
-          await fs.access(candidate);
+        if (await fileExists(candidate)) {
           return candidate;
-        } catch {
-          /* try next */
         }
       }
       if (current === root) return null;
@@ -47,9 +44,7 @@ export class ConfigLoaderService {
   async loadConfigFile(configPath: string): Promise<ConfigFile> {
     const absolutePath = path.resolve(configPath);
 
-    try {
-      await fs.access(absolutePath);
-    } catch {
+    if (!(await fileExists(absolutePath))) {
       throw new ConfigFileNotFoundError(absolutePath);
     }
 

--- a/src/services/file-copy.service.ts
+++ b/src/services/file-copy.service.ts
@@ -3,6 +3,8 @@ import * as path from "path";
 
 import { glob } from "glob";
 
+import { fileExists } from "../utils/file-exists";
+
 const DEFAULT_IGNORE_PATTERNS = [
   "**/node_modules/**",
   "**/.git/**",
@@ -83,11 +85,8 @@ export class FileCopyService {
   }
 
   private async copyFile(sourcePath: string, destPath: string): Promise<boolean> {
-    try {
-      await fs.access(destPath);
+    if (await fileExists(destPath)) {
       return false;
-    } catch {
-      // File doesn't exist, proceed with copy
     }
 
     const destDir = path.dirname(destPath);

--- a/src/services/worktree-status.service.ts
+++ b/src/services/worktree-status.service.ts
@@ -5,6 +5,7 @@ import simpleGit from "simple-git";
 
 import { ENV_CONSTANTS, GIT_CONSTANTS, GIT_OPERATIONS, PATH_CONSTANTS } from "../constants";
 import { GitOperationError, WorktreeNotCleanError } from "../errors";
+import { fileExists } from "../utils/file-exists";
 import { getErrorMessage } from "../utils/lfs-error";
 
 import { Logger } from "./logger.service";
@@ -106,9 +107,7 @@ export class WorktreeStatusService {
     includeDetails = false,
     lastSyncCommit?: string,
   ): Promise<WorktreeStatusResult> {
-    try {
-      await fs.access(worktreePath);
-    } catch {
+    if (!(await fileExists(worktreePath))) {
       return {
         isClean: true,
         hasUnpushedCommits: false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,13 +130,10 @@ export interface RepositoryConfig extends Config {
   name: string;
 }
 
-export interface InitConfigInput {
-  repoUrl: string;
-  worktreeDir: string;
-  bareRepoDir?: string;
-  cronSchedule: string;
-  runOnce: boolean;
-}
+export type InitConfigInput = Pick<
+  RepositoryConfig,
+  "repoUrl" | "worktreeDir" | "bareRepoDir" | "cronSchedule" | "runOnce"
+>;
 
 export interface ConfigFile {
   defaults?: Partial<Config>;

--- a/src/utils/__tests__/cli.test.ts
+++ b/src/utils/__tests__/cli.test.ts
@@ -29,21 +29,21 @@ describe("parseArguments", () => {
 
   it("parses init subcommand", () => {
     const opts = parseArguments(["init"]);
-    expect(opts.command).toBe("init");
+    if (opts.command !== "init") throw new Error("expected init command");
     expect(opts.config).toBeUndefined();
     expect(opts.force).toBe(false);
   });
 
   it("parses init --config <path> --force", () => {
     const opts = parseArguments(["init", "--config", "/tmp/new.config.js", "--force"]);
-    expect(opts.command).toBe("init");
+    if (opts.command !== "init") throw new Error("expected init command");
     expect(opts.config).toBe("/tmp/new.config.js");
     expect(opts.force).toBe(true);
   });
 
   it("parses list subcommand with --config + --filter", () => {
     const opts = parseArguments(["list", "--config", "/etc/sync.config.js", "--filter", "backend-*"]);
-    expect(opts.command).toBe("list");
+    if (opts.command !== "list") throw new Error("expected list command");
     expect(opts.config).toBe("/etc/sync.config.js");
     expect(opts.filter).toBe("backend-*");
   });

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,14 +1,18 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-export type CliCommand = "run" | "init" | "list";
+export const CLI_COMMANDS = {
+  RUN: "run",
+  INIT: "init",
+  LIST: "list",
+} as const;
 
-export interface CliOptions {
-  command: CliCommand;
-  config?: string;
-  filter?: string;
-  force?: boolean;
-}
+export type CliCommand = (typeof CLI_COMMANDS)[keyof typeof CLI_COMMANDS];
+
+export type CliOptions =
+  | { command: typeof CLI_COMMANDS.RUN; config?: string }
+  | { command: typeof CLI_COMMANDS.INIT; config?: string; force: boolean }
+  | { command: typeof CLI_COMMANDS.LIST; config?: string; filter?: string };
 
 export function parseArguments(argv: string[] = hideBin(process.argv)): CliOptions {
   let parsed: CliOptions | undefined;
@@ -28,13 +32,13 @@ export function parseArguments(argv: string[] = hideBin(process.argv)): CliOptio
         }),
       (args) => {
         parsed = {
-          command: "run",
+          command: CLI_COMMANDS.RUN,
           config: args.config,
         };
       },
     )
     .command(
-      "init",
+      CLI_COMMANDS.INIT,
       "Create a new config file interactively",
       (y) =>
         y
@@ -50,14 +54,14 @@ export function parseArguments(argv: string[] = hideBin(process.argv)): CliOptio
           }),
       (args) => {
         parsed = {
-          command: "init",
+          command: CLI_COMMANDS.INIT,
           config: args.config,
           force: args.force,
         };
       },
     )
     .command(
-      "list",
+      CLI_COMMANDS.LIST,
       "List repositories configured in a config file and exit",
       (y) =>
         y
@@ -73,7 +77,7 @@ export function parseArguments(argv: string[] = hideBin(process.argv)): CliOptio
           }),
       (args) => {
         parsed = {
-          command: "list",
+          command: CLI_COMMANDS.LIST,
           config: args.config,
           filter: args.filter,
         };

--- a/src/utils/config-generator.ts
+++ b/src/utils/config-generator.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { CONFIG_FILE_NAMES } from "../constants";
 import { ConfigFileExistsError } from "../errors";
 
+import { fileExists } from "./file-exists";
 import { extractRepoNameFromUrl } from "./git-url";
 
 import type { InitConfigInput } from "../types";
@@ -106,15 +107,6 @@ export default ${serializeToESM(configObject)};
   }
 }
 
-export async function configFileExists(configPath: string): Promise<boolean> {
-  try {
-    await fs.access(configPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export function getDefaultConfigPath(): string {
   return path.join(process.cwd(), "sync-worktrees.config.js");
 }
@@ -122,11 +114,8 @@ export function getDefaultConfigPath(): string {
 export async function findConfigInCwd(cwd: string = process.cwd()): Promise<string | null> {
   for (const name of CONFIG_FILE_NAMES) {
     const full = path.join(cwd, name);
-    try {
-      await fs.access(full);
+    if (await fileExists(full)) {
       return full;
-    } catch {
-      /* try next */
     }
   }
   return null;

--- a/src/utils/file-exists.ts
+++ b/src/utils/file-exists.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs/promises";
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Five small, low-risk cleanups deferred from the `/simplify` review of #84. Stacked on top of `clone-mode` so the parent PR reviewer can land both together.

| # | Item | Files |
|---|------|-------|
| 1 | Extract `fileExists()` helper — dedupe 8 inline `fs.access` existence checks | new `src/utils/file-exists.ts`; migrate config-generator, config-loader, worktree-status, clone-sync, file-copy, index |
| 2 | `InitConfigInput` → `Pick<RepositoryConfig, ...>` — auto-tracks future field changes | `src/types/index.ts` |
| 3 + 5 | `CLI_COMMANDS` const + discriminated `CliOptions` union + exhaustive `switch` in `main()` | `src/utils/cli.ts`, `src/index.ts`, `src/utils/__tests__/cli.test.ts` |
| 4 | Collapse `runMultipleRepositories` — take `ConfigFile` directly, derive `runOnce` + `maxParallel` internally | `src/index.ts` |

Item 6 from the plan (CLAUDE.md doc fix for stale `PathResolutionService` methods) had no PR impact — that file is excluded by the user's global gitignore. Local-only fix, no commit.

### Why this stacks on `clone-mode`

PR #84 (`clone-mode` → `main`) is still open. These follow-ups touch code that only exists on that branch. Once #84 merges, this PR retargets to `main` automatically.

### Type contract changes

`CliOptions` shape changed (flat bag → discriminated union). The package exports it from `dist/index.js` but doesn't declare a `types` entry in `package.json` — it's a CLI binary, not a library consumed via type imports. Internal-only change.

## Test plan
- [x] `npx tsc --noEmit && npx tsc --noEmit -p tsconfig.spec.json` — clean
- [x] `npx eslint . --max-warnings 0` — clean
- [x] `npx vitest run` — 1075 passed, 1 skipped, 0 failed (same baseline as #84)
- [x] `node esbuild.config.js` — clean build
- [x] Changeset added (`.changeset/polish-cli-collapse-followups.md`, patch-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)