### PR TITLE
fix: hero headline clipping + TUI progress/disk-usage cleanups

### DIFF
--- a/.changeset/fix-hero-headline-clipping.md
+++ b/.changeset/fix-hero-headline-clipping.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Fix the landing-page hero headline clipping the descenders of its gradient line. The `bg-clip-text` line had an implicit `line-height: 1`, so the gradient box stopped at the baseline and characters like "y"/"g" were cut off; added line-height and bottom padding so descenders render fully.

--- a/.changeset/fix-progress-and-disk-usage.md
+++ b/.changeset/fix-progress-and-disk-usage.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Tidy interactive UI progress and disk usage reporting: drop the StatusBar progress percent suffix that never fired (every git progress message already embeds its percentage) and relied on a fragile substring check, and mark repository disk-usage totals as approximate (`~`) when only some size paths fail instead of showing a confident undercount.

--- a/.changeset/fix-progress-and-disk-usage.md
+++ b/.changeset/fix-progress-and-disk-usage.md
@@ -2,4 +2,4 @@
 "sync-worktrees": patch
 ---
 
-Tidy interactive UI progress and disk usage reporting: drop the StatusBar progress percent suffix that never fired (every git progress message already embeds its percentage) and relied on a fragile substring check, and mark repository disk-usage totals as approximate (`~`) when only some size paths fail instead of showing a confident undercount.
+Tidy interactive UI progress and disk usage reporting: drop the StatusBar progress percent suffix that never fired (every git progress message already embeds its percentage) and relied on a fragile substring check, and mark repository disk-usage totals as a lower bound (`≥`) when only some size paths fail — the failed path counts as zero, so the total is a guaranteed undercount rather than a confident exact value.

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -54,9 +54,9 @@ const starLabel =
       </a>
     </div>
 
-    <h1 class="mt-8 text-balance text-center text-5xl font-bold tracking-tight text-ink-900 sm:text-6xl md:text-7xl">
+    <h1 class="mt-8 text-balance text-center text-5xl font-bold leading-[1.12] tracking-tight text-ink-900 sm:text-6xl md:text-7xl">
       {positioning.heroHeadlineLine1}
-      <span class="block bg-gradient-to-r from-accent-600 via-accent-500 to-accent-400 bg-clip-text text-transparent">
+      <span class="block bg-gradient-to-r from-accent-600 via-accent-500 to-accent-400 bg-clip-text pb-[0.15em] text-transparent">
         {positioning.heroHeadlineLine2}
       </span>
     </h1>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -60,13 +60,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
     return status === "syncing" ? "⟳" : "✓";
   };
 
-  const formatProgress = (syncProgress: AppSyncProgress): string => {
-    const percent =
-      syncProgress.progress === undefined || syncProgress.message.includes(`${syncProgress.progress}%`)
-        ? ""
-        : ` ${syncProgress.progress}%`;
-    return `[${syncProgress.repo}] ${syncProgress.message}${percent}`;
-  };
+  const formatProgress = (syncProgress: AppSyncProgress): string => `[${syncProgress.repo}] ${syncProgress.message}`;
 
   const progressLineCount = Math.max(1, maxProgressLines);
   const visibleProgress = syncProgressEntries.slice(-progressLineCount);

--- a/src/components/__tests__/StatusBar.test.tsx
+++ b/src/components/__tests__/StatusBar.test.tsx
@@ -126,6 +126,19 @@ describe("StatusBar", () => {
       expect(lastFrame()).not.toContain("Progress:");
       expect(lastFrame()).not.toContain("fetch remote");
     });
+
+    it("should not synthesize a percent that is absent from the progress message", () => {
+      const { lastFrame } = render(
+        <StatusBar
+          {...defaultProps}
+          status="syncing"
+          syncProgressEntries={[{ repo: "repo", phase: "fetch", message: "Receiving objects", progress: 42 }]}
+        />,
+      );
+
+      expect(lastFrame()).toContain("[repo] Receiving objects");
+      expect(lastFrame()).not.toContain("42%");
+    });
   });
 
   describe("last sync time", () => {

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -475,7 +475,7 @@ export class InteractiveUIService {
       repoIndex,
       repoName,
       sizeBytes: failedAllPaths ? null : sizeBytes,
-      sizeFormatted: failedAllPaths ? "N/A" : partialFailure ? `~${formatBytes(sizeBytes)}` : formatBytes(sizeBytes),
+      sizeFormatted: failedAllPaths ? "N/A" : partialFailure ? `≥${formatBytes(sizeBytes)}` : formatBytes(sizeBytes),
       bareSizeBytes,
       worktreeSizeBytes,
       error: errors.length > 0 ? errors.join("; ") : undefined,

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -469,12 +469,13 @@ export class InteractiveUIService {
 
     const sizeBytes = bareSizeBytes + worktreeSizeBytes;
     const failedAllPaths = errors.length === sizeTargets.length;
+    const partialFailure = errors.length > 0 && !failedAllPaths;
 
     return {
       repoIndex,
       repoName,
       sizeBytes: failedAllPaths ? null : sizeBytes,
-      sizeFormatted: failedAllPaths ? "N/A" : formatBytes(sizeBytes),
+      sizeFormatted: failedAllPaths ? "N/A" : partialFailure ? `~${formatBytes(sizeBytes)}` : formatBytes(sizeBytes),
       bareSizeBytes,
       worktreeSizeBytes,
       error: errors.length > 0 ? errors.join("; ") : undefined,

--- a/src/services/__tests__/interactive-ui.service.test.ts
+++ b/src/services/__tests__/interactive-ui.service.test.ts
@@ -1557,9 +1557,9 @@ describe("InteractiveUIService", () => {
         service.destroy();
       });
 
-      it("should mark the size approximate when only some paths fail", async () => {
-        // Bare succeeds, worktree path fails: the total is a known undercount,
-        // so it must be flagged approximate instead of shown as an exact size.
+      it("should mark the size as a lower bound when only some paths fail", async () => {
+        // Bare succeeds, worktree path fails: the failed path counts as 0, so
+        // the total is a guaranteed undercount and must read as "at least" (≥).
         vi.mocked(calculateDirectorySize)
           .mockResolvedValueOnce(1024)
           .mockRejectedValueOnce(new Error("ENOENT"));
@@ -1567,7 +1567,7 @@ describe("InteractiveUIService", () => {
 
         const usage = await service.getRepositoryDiskUsage(0);
 
-        expect(usage.sizeFormatted).toMatch(/^~/);
+        expect(usage.sizeFormatted).toMatch(/^≥/);
         expect(usage.sizeBytes).toBe(1024);
         expect(usage.error).toContain("ENOENT");
 

--- a/src/services/__tests__/interactive-ui.service.test.ts
+++ b/src/services/__tests__/interactive-ui.service.test.ts
@@ -1557,6 +1557,23 @@ describe("InteractiveUIService", () => {
         service.destroy();
       });
 
+      it("should mark the size approximate when only some paths fail", async () => {
+        // Bare succeeds, worktree path fails: the total is a known undercount,
+        // so it must be flagged approximate instead of shown as an exact size.
+        vi.mocked(calculateDirectorySize)
+          .mockResolvedValueOnce(1024)
+          .mockRejectedValueOnce(new Error("ENOENT"));
+        const service = new InteractiveUIService([mockSyncService]);
+
+        const usage = await service.getRepositoryDiskUsage(0);
+
+        expect(usage.sizeFormatted).toMatch(/^~/);
+        expect(usage.sizeBytes).toBe(1024);
+        expect(usage.error).toContain("ENOENT");
+
+        service.destroy();
+      });
+
       it("should throw for invalid repo index", async () => {
         const service = new InteractiveUIService([mockSyncService]);
 


### PR DESCRIPTION
## Summary
- **Hero headline clipping**: the gradient (`bg-clip-text`) second line inherited an implicit `line-height: 1`, so its paint box ended at the baseline and clipped descenders like "y"/"g". Added `leading-[1.12]` on the `h1` and `pb-[0.15em]` on the gradient span. Verified in-browser: "For you and your AI agents." now renders full descenders.
- **StatusBar progress suffix**: removed the synthetic `progress%` suffix. It never fired (every git progress message already embeds its `%`) and used a fragile substring check.
- **Repository disk usage**: partial-failure totals are now marked approximate (`~`) instead of showing a confident undercount; full failure still reports `N/A`.

## Test plan
- [x] `vitest run` StatusBar + interactive-ui suites (125 passed) — includes new cases for the dropped suffix and the approximate partial-failure total
- [x] Hero fix confirmed visually via astro dev + screenshot at desktop width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hero headline gradient text clipping where descenders were cut off
  * Removed incorrect progress percentage suffix from status display
  * Improved disk usage reporting to indicate lower bound (≥) when some checks fail

* **Tests**
  * Added test coverage for progress display without percentage values
  * Added test for partial disk usage calculation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yordan-kanchelov/sync-worktrees/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->