### PR TITLE
docs(mcp): document clone vs worktree repo modes in server instructions

### DIFF
--- a/.changeset/mcp-repo-mode-instructions.md
+++ b/.changeset/mcp-repo-mode-instructions.md
@@ -1,0 +1,7 @@
+---
+"sync-worktrees": patch
+---
+
+Document the clone vs worktree repo-mode distinction in the MCP server instructions.
+
+The two modes previously surfaced only as an output discriminator in `detect_context`'s schema, so agents had to guess what the modes meant and whether tool behavior differed. The server `instructions` string now defines both modes and notes that `create_worktree`/`update_worktree` are worktree-mode only. Those two tool descriptions gain a matching clause, and `sync`'s cross-references are qualified to worktree mode (they pointed at tools that error in clone mode).

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -171,7 +171,7 @@ describe("createServer", () => {
 
 describe("buildInstructions", () => {
   const baseInstructions =
-    "Call `detect_context` for the project map and live worktree state; `configuredRepositories` in its response is the server-wide loaded-config inventory. Use `set_current_repository` to switch repos. Auto-loads sync-worktrees.config.{js,mjs,cjs,ts} via walk-up.";
+    "Call `detect_context` for the project map and live worktree state; `configuredRepositories` in its response is the server-wide loaded-config inventory. Use `set_current_repository` to switch repos. Auto-loads sync-worktrees.config.{js,mjs,cjs,ts} via walk-up. Repos run in one of two modes. worktree (default): a bare repo plus branch worktrees, with new worktrees created under worktreeDir. clone: one standalone checkout where worktreeDir is the repo root. create_worktree and update_worktree are worktree-mode only; in clone mode, use sync to update the checkout.";
 
   function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): DiscoveredRepoContext {
     return {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,7 +23,7 @@ const REPO_NAME_DESCRIBE =
 const PATH_DESCRIBE_SUFFIX = "Absolute preferred; relative resolves from server CWD.";
 
 const SERVER_INSTRUCTIONS =
-  "Call `detect_context` for the project map and live worktree state; `configuredRepositories` in its response is the server-wide loaded-config inventory. Use `set_current_repository` to switch repos. Auto-loads sync-worktrees.config.{js,mjs,cjs,ts} via walk-up.";
+  "Call `detect_context` for the project map and live worktree state; `configuredRepositories` in its response is the server-wide loaded-config inventory. Use `set_current_repository` to switch repos. Auto-loads sync-worktrees.config.{js,mjs,cjs,ts} via walk-up. Repos run in one of two modes. worktree (default): a bare repo plus branch worktrees, with new worktrees created under worktreeDir. clone: one standalone checkout where worktreeDir is the repo root. create_worktree and update_worktree are worktree-mode only; in clone mode, use sync to update the checkout.";
 
 export interface ServerSnapshot {
   discovered: DiscoveredRepoContext | null;
@@ -174,7 +174,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "create_worktree",
     {
       description:
-        "Create worktree for a branch. Existing branch (local/remote) = checkout. New branch = create from baseBranch + push to origin (default). baseBranch required only for new branches — pass defensively if unsure. push=false opts out. Preconditions: repo initialized (auto-runs). Returns: {success, branchName, worktreePath, created, pushed}.",
+        "Worktree-mode only; clone-mode repos error here. Create worktree for a branch. Existing branch (local/remote) = checkout. New branch = create from baseBranch + push to origin (default). baseBranch required only for new branches — pass defensively if unsure. push=false opts out. Preconditions: repo initialized (auto-runs). Returns: {success, branchName, worktreePath, created, pushed}.",
       inputSchema: {
         branchName: z.string().describe("Branch name. Slashes/special chars sanitized for dir name."),
         baseBranch: z
@@ -201,7 +201,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "sync",
     {
       description:
-        "Repo-wide sync: fetch, create worktrees for new remote branches, remove pruned (clean only), fast-forward existing. Emits progress. Single worktree? Use update_worktree. Single create? Use create_worktree. Preconditions: config loaded + repo initialized (auto-runs). Returns: {success, duration, skips}.",
+        "Repo-wide sync: fetch, create worktrees for new remote branches, remove pruned (clean only), fast-forward existing. Emits progress. In worktree mode: single worktree? Use update_worktree. Single create? Use create_worktree. Preconditions: config loaded + repo initialized (auto-runs). Returns: {success, duration, skips}.",
       inputSchema: {
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       },
@@ -220,7 +220,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "update_worktree",
     {
       description:
-        "Fast-forward one worktree to upstream. No merge, no rebase, aborts if not fast-forwardable. Whole repo? Use sync.",
+        "Worktree-mode only; clone-mode repos error here; use sync to update the checkout. Fast-forward one worktree to upstream. No merge, no rebase, aborts if not fast-forwardable. Whole repo? Use sync.",
       inputSchema: {
         path: z.string().describe(`Worktree path to fast-forward. ${PATH_DESCRIBE_SUFFIX}`),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),


### PR DESCRIPTION
## Problem

The sync-worktrees MCP server distinguishes two repo modes — `clone` and `worktree` — but nothing an agent reads up front explains the distinction. It surfaced **only** as an output discriminator inside `detect_context`'s schema (`clone → {checkoutPath}`, `worktree → {worktreeDir}`), which agents load lazily. So an agent had to *guess* what the modes mean and whether they change tool behavior.

## Ground truth (source-verified)

- **worktree** (default — `resolveMode` in `src/utils/repo-mode.ts`): bare repo + one git worktree per branch; new worktrees created under `worktreeDir`.
- **clone**: single standalone checkout where `worktreeDir` **is** the repo root (`bareRepoPath: null`, `allWorktrees` is exactly one entry — `src/mcp/context.ts` `buildCloneModeContext`).
- **Behavioral divergence:** `create_worktree` and `update_worktree` are **worktree-mode only** — they throw `CapabilityUnavailableError` on clone-mode repos (`src/mcp/handlers.ts` `ensureWorktreeModeService`; capabilities set `available:false` in `context.ts`). `sync` works in both modes. `detect_context` already documents its mode-discriminated output.

## Changes

- **`SERVER_INSTRUCTIONS`** (`src/mcp/server.ts`): add a factual mode definition + note that `create_worktree`/`update_worktree` are worktree-mode only.
- **`create_worktree` / `update_worktree` descriptions**: add a clone-mode clause (they error there).
- **`sync` description**: qualify the "use update_worktree / create_worktree" redirects to worktree mode — both targets error in clone mode, so the redirect was factually wrong for clone-mode repos.
- **`detect_context`**: unchanged (already documents its output shape).
- Updated `buildInstructions` test baseline; added changeset.

Minimal diff — instructions string + three tool descriptions + one test string. Every added sentence verified against source.

## Verification

- `tsc --noEmit` — clean
- `vitest run` — 1399 passed / 18 skipped (E2E skipped)
- `eslint` on changed files — clean

## Provenance

Approach and exact wording were reviewed against the source with OpenAI Codex (gpt-5.5) before implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository mode guidance in the MCP server help text, distinguishing between clone and worktree setups.
  * Updated tool descriptions to show which actions are available only in worktree mode and when to use sync instead.
  * Aligned test expectations with the revised user-facing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->