### PR TITLE
fix: resolve code-review findings F1-F20

### DIFF
--- a/.changeset/twenty-review-fixes.md
+++ b/.changeset/twenty-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Fix 20 code-review findings across safety, CLI, MCP, and config subsystems (F1–F20 in REVIEW_FINDINGS.md): orphan cleanup can no longer delete a bare repo nested in worktreeDir; `filesToCopyOnBranchCreate` works again (patterns stay relative, absolute/escaping patterns rejected); default branches containing `/` are detected correctly; MCP `create_worktree`/`update_worktree` fetch before acting; runOnce exit codes no longer mask failures (SIGINT exits 130, per-repo `runOnce` rejected in favor of `defaults.runOnce`); diverged-replace preserves stashes; trash pin refs are namespaced per trash root; config validation rejects malformed `branchInclude`/`branchExclude`/`branchMaxAge`/parallelism values; `.cjs` configs hot-reload; plus assorted smaller fixes (retry classification, timing table, init wizard validation, LFS sampling, metadata guard, MCP registration probing).

--- a/REVIEW_FINDINGS.md
+++ b/REVIEW_FINDINGS.md
@@ -1,0 +1,430 @@
+# Code Review Findings — 2026-07-07
+
+Full-codebase review (bugs + design issues). Each finding is written as a self-contained
+task spec: an agent should be able to implement it from this document alone, without the
+original review conversation.
+
+Conventions used below:
+
+- **Location** — primary files/lines (line numbers as of commit `59b897d`).
+- **Current behavior** — what the code does today, with the failure scenario.
+- **Expected behavior** — the spec to implement.
+- **Acceptance** — how to verify (tests to add/adjust). All existing tests must keep passing;
+  run `pnpm lint && pnpm typecheck && pnpm test`.
+
+Status legend: `[ ]` open · `[x]` done · `[~]` needs product decision first.
+
+---
+
+## High severity
+
+### [x] F1. Orphan cleanup can destroy the bare repo when `bareRepoDir` is inside `worktreeDir`
+
+- **Severity**: High (permanent data loss: shared object DB + all unpushed commits)
+- **Location**: `src/services/worktree-mode-sync-runner.ts:878` (`cleanupOrphanedDirectories`),
+  `src/services/config-loader.service.ts:577-583` (bareRepoDir resolution — no containment check)
+- **Current behavior**: `cleanupOrphanedDirectories` treats every non-dot, non-worktree
+  directory directly under `worktreeDir` as an orphan and trashes/deletes it. Nothing
+  validates that `bareRepoDir` lies outside `worktreeDir`. A config with
+  `bareRepoDir: "./worktrees/repo-bare"` (any non-dot name inside `worktreeDir`) has its
+  bare repository removed on the next sync: a bare repo has no `.git` entry, so the
+  live-checkout quarantine guard does not fire. With trash disabled this is `fs.rm -rf` of
+  the entire object database; with trash enabled it's recoverable but still breaks every
+  worktree (their `.git` files point into the moved bare repo).
+- **Expected behavior**:
+  1. Config validation (`ConfigLoaderService`) rejects any worktree-mode repository whose
+     resolved `bareRepoDir` is equal to or inside the resolved `worktreeDir`, and vice versa
+     (worktreeDir inside bareRepoDir), with a clear `ConfigError` naming both paths.
+     Use the existing case-folding path comparison (`src/utils/path-compare.ts` /
+     `normalizePathForCompare`) so macOS/Windows case-insensitivity is handled.
+  2. Defense in depth: `cleanupOrphanedDirectories` additionally skips (with a warning) any
+     candidate directory whose resolved path equals the configured `bareRepoDir`
+     (`gitService.getBareRepoPath()`), regardless of validation.
+- **Acceptance**: unit test in config-loader tests: config with `bareRepoDir` inside
+  `worktreeDir` throws at load; test for the reverse nesting; runner test: a directory that
+  matches the bare repo path is never passed to trash/rm even if unregistered.
+
+### [x] F2. `filesToCopyOnBranchCreate` is functionally broken (absolute-path glob mangling)
+
+- **Severity**: High (documented feature silently does nothing / errors per file)
+- **Location**: `src/services/config-loader.service.ts:624` (patterns resolved to absolute
+  paths), `src/services/file-copy.service.ts:43-44` (`path.join(sourceDir, relativePath)`)
+- **Current behavior**: the loader maps every pattern through
+  `this.resolvePath(f, configDir)`, producing absolute patterns. `glob` ignores `cwd` for
+  absolute patterns and returns absolute matches. `FileCopyService` then joins that
+  absolute match onto `sourceDir`, producing paths like `/cfg/cfg/.env` → ENOENT for every
+  file; destination paths would be wrong even when the join accidentally resolves.
+  (Verified experimentally: `glob('/etc/hosts', {cwd:'/etc'})` → `['/etc/hosts']`.)
+- **Expected behavior**: patterns stay **relative** end-to-end. The loader must NOT
+  path-resolve `filesToCopyOnBranchCreate` entries; `FileCopyService` globs them relative
+  to `sourceDir` (`cwd: sourceDir`) and copies each relative match `sourceDir/<rel>` →
+  `worktreePath/<rel>`. Reject (or warn and skip) absolute patterns and patterns escaping
+  `sourceDir` (`..`) — file copy must never read or write outside `sourceDir`/`worktreePath`.
+- **Acceptance**: integration-style test with a temp config dir containing `.env` and a
+  nested `config/local.json`: after the copy step both exist inside the target worktree at
+  the same relative paths. Test that an absolute pattern and a `../escape` pattern are
+  rejected/skipped with a warning. Verify both call sites: clone-mode initial copy
+  (`clone-sync.service.ts:745`, `runInitialFileCopy`) and the TUI/hook branch-created path
+  (`branch-created-actions.service.ts`).
+
+### [x] F3. MCP `update_worktree` (and `create_worktree`) act on stale refs — no fetch
+
+- **Severity**: High (reports success while doing nothing / creates divergent branches)
+- **Location**: `src/mcp/handlers.ts:447-472` (`update_worktree`), `handlers.ts:363-399`
+  (`create_worktree`), `src/services/git.service.ts:1105-1127` (`updateWorktree` — merge
+  only, no fetch), `git.service.ts:1297-1315` (`branchExists` — local refs only)
+- **Current behavior**: the only fetch in the MCP path happens inside `initialize()` on the
+  *first* call per service instance. In a long-lived MCP session, `update_worktree` then
+  runs `merge origin/<branch> --ff-only` against a stale remote-tracking ref, no-ops, and
+  returns `{success: true, updated: true?}` while the worktree is behind the real remote.
+  `create_worktree` decides "branch is new" from stale local `refs/remotes/origin/*`; if a
+  teammate pushed the branch after the last fetch and `baseBranch` is supplied (the tool
+  description recommends it), it creates a **divergent duplicate** branch from
+  `baseBranch`, then `pushBranch` fails non-fast-forward, and the handler reports pure
+  failure with the half-created worktree left behind (see F13 for the reporting half).
+- **Expected behavior**:
+  1. `update_worktree` fetches the target branch before merging: `fetchBranch(branch)`
+     (worktree mode) prior to `updateWorktree`. Failure to fetch is a reported error, not a
+     silent stale success.
+  2. `create_worktree` fetches (at minimum `fetchBranch(branchName)` tolerating
+     missing-ref, or a full `fetchAll`) before calling `branchExists`, so the
+     local/remote existence matrix reflects the actual remote.
+  3. Both still run inside `runExclusiveRepoOperation` as today.
+- **Acceptance**: handler tests with a mocked GitService asserting fetch is called before
+  merge/branch-matrix; a test that a remote-updated branch results in an actual update
+  (mock `fetchBranch` mutating the mocked ref state).
+
+### [x] F4. Worktree-mode default-branch detection breaks on branch names containing `/`
+
+- **Severity**: High for affected repos (initialization fails outright)
+- **Location**: `src/services/git.service.ts:1033-1068` (`detectDefaultBranch`)
+- **Current behavior**: `headRef.trim().split("/").pop()` turns
+  `refs/remotes/origin/release/2024` into `2024`. Initialization then attempts
+  `worktree add --track -b 2024 origin/2024`, which fails (`origin/2024` doesn't exist) and
+  aborts init. The clone-mode equivalent `getRemoteDefaultBranch` (`git.service.ts:247-294`)
+  parses correctly with a regex on `refs/heads/(...)`.
+- **Expected behavior**: strip only the known prefix: branch =
+  `headRef.trim().replace(/^refs\/remotes\/origin\//, "")` (both in the primary
+  `symbolic-ref` path and the post-`remote set-head` retry). Everything downstream
+  (`mainWorktreePath = path.join(worktreeDir, defaultBranch)`) already handles nested
+  paths — `cleanupOrphanedDirectories` matches via `startsWith(dir + path.sep)`.
+- **Acceptance**: unit test: `detectDefaultBranch` (or an extracted pure parser) returns
+  `release/2024` for `refs/remotes/origin/release/2024\n`; e2e-style test optional.
+
+---
+
+## Medium severity
+
+### [x] F5. Stashed changes are silently lost in the diverged-replace flow
+
+- **Severity**: Medium (data loss; requires diverged history + stash combo)
+- **Location**: `src/services/worktree-mode-sync-runner.ts:684-761` (Phase 4a gate),
+  `:960-1036` (`handleDivergedBranch`), `src/services/trash.service.ts:130-207` (pin covers
+  HEAD only)
+- **Current behavior**: the prune path blocks removal when `hasStashedChanges` is true, but
+  the update path's eligibility gate only checks `hasOperationInProgress` +
+  `checkWorktreeStatus` (uncommitted changes). A diverged worktree **with a stash** goes
+  through diverged-replace: payload directory is preserved, but
+  `removeWorktree(..., {force: true})` deletes the per-worktree admin dir including its
+  stash ref. The trash pin ref only pins `headOid`, so stash commits become unreachable and
+  are collected by gc (immediately under `maintenance.aggressive` → `gc --prune=now`).
+- **Expected behavior**: the diverged-replace path (both branches of `handleDivergedBranch`
+  that end in worktree removal/reset — specifically the "has local changes → move aside"
+  branch) must first check `hasStashedChanges(worktreePath)`. If stashed changes exist,
+  skip the replace: log a warning telling the user to pop/apply or drop the stash, record
+  `outcome.recordSkipped("worktree", "stash_present", …)`, and leave the worktree
+  untouched. (Alternative — pinning each stash commit alongside the HEAD pin — is
+  acceptable but larger; skipping is the minimal safe spec.)
+- **Acceptance**: runner test: diverged worktree with a mocked stash count > 0 is not moved
+  to .diverged/trash, not removed, and shows up as skipped in the outcome; diverged
+  worktree without stash behaves as before.
+
+### [x] F6. runOnce exit-code masking (soft-skip hides hard failure; SIGINT exits 0; per-repo `runOnce` dead)
+
+- **Severity**: Medium (CI sees success on failed/aborted runs)
+- **Location**: `src/index.ts:152-158` (failedCount filter), `src/index.ts:40,189` +
+  `src/utils/signal-handlers.ts:43-46` (signal path), `src/index.ts:50` +
+  `src/services/config-loader.service.ts:560` (per-repo runOnce resolved but unused)
+- **Current behavior** (three related defects):
+  1. `failedCount` excludes any rejected repo whose name appears in `skippedNames`
+     (populated from `getRecordedSkips()` regardless of final outcome). A repo that records
+     a clone-mode soft skip during init and then hard-fails (e.g. network error) is counted
+     as "skipped" → `process.exitCode` stays 0.
+  2. Cleanup functions are only registered in the daemon branch, so SIGINT/SIGTERM during a
+     runOnce sync resolves `Promise.allSettled([])` immediately and exits **0** mid-sync.
+  3. Per-repository `runOnce: true` is validated and resolved by the loader but never read:
+     only `configFile.defaults?.runOnce` selects the mode, so the documented per-repo
+     override does nothing.
+- **Expected behavior**:
+  1. A rejected sync always increments `failedCount` (exit code 1), independent of any
+     soft skips it recorded earlier. Soft skips only suppress failure when the run
+     *completed* without throwing.
+  2. In runOnce mode, first SIGINT/SIGTERM exits with a non-zero code (130 conventional)
+     after best-effort abort; the "second signal / watchdog" behavior stays as is.
+  3. Decide the semantics of per-repo `runOnce` and implement one of: (a) honor it — a repo
+     with `runOnce: true` syncs once while others stay scheduled (mode is then per-repo,
+     not global), or (b) remove it from the per-repo schema and document `runOnce` as
+     defaults-only. Option (b) is the smaller, less surprising change; pick it unless the
+     maintainer says otherwise.
+- **Acceptance**: test: repo records skip then `sync()` rejects → exit code 1. Test (or
+  manual verification note) for signal exit code in runOnce. For (3b): per-repo `runOnce`
+  rejected by validation with a pointer to `defaults.runOnce`.
+
+### [x] F7. Trash reaper can delete another config's live pin refs (shared `bareRepoDir`)
+
+- **Severity**: Medium (silent data loss; requires two configs sharing a bare repo)
+- **Location**: `src/services/trash-reaper.service.ts:190-204` (orphaned-pin sweep)
+- **Current behavior**: the sweep deletes any `refs/sync-worktrees/trash/<id>` whose `<id>`
+  has no matching container under *this config's* trash root. Two config files pointing at
+  the same `bareRepoDir` with different `worktreeDir`s (the duplicate-bareRepoDir check is
+  per-file and cannot see across configs) each store trash containers in their own
+  `.trash/` — so config A's reaper sees config B's pin ids as orphans and deletes them,
+  making B's trashed unpushed commits gc-eligible.
+- **Expected behavior**: pin refs must be attributable to their trash root. Spec: include a
+  stable trash-root discriminator in the ref name (e.g.
+  `refs/sync-worktrees/trash/<rootHash>/<id>`, `rootHash` = first 16 hex of sha256 of the
+  canonical trash-root path — same recipe as `lock-path.ts`), and the sweep only considers
+  refs under its own `<rootHash>/` namespace. Migration: refs in the old flat namespace are
+  left untouched by the sweep (warn once), and the existing trash-migration service may
+  adopt them. Restore/reap must resolve both layouts during the transition.
+- **Acceptance**: reaper test: refs under a foreign rootHash namespace (and legacy flat
+  refs) survive the sweep; own-namespace refs without containers are still cleaned.
+
+### [x] F8. MCP repo-selection state machine: stuck auto-detect entry, silent first-repo pin, stale `discovered`
+
+- **Severity**: Medium (wrong-target operations, permanent bogus errors in a session)
+- **Location**: `src/mcp/context.ts:217-223` (loadConfig currentRepo handling), `:368`
+  (`bootstrapCurrentRepo` early-return), `:268-270` (`invalidateDiscovered`),
+  `src/mcp/handlers.ts:45-52,114-118` (readers of `entry.discovered`)
+- **Current behavior** (three related defects):
+  1. Server starts in auto-detect mode → `currentRepo = "__auto_detected__:…"` with
+     `sync` capability unavailable. A later `load_config` keeps that entry in the map, so
+     `currentRepo` survives, and `sync` fails forever with "no config file loaded" even
+     though it is.
+  2. `load_config` pins `currentRepo` to `repositories[0]` whenever nothing is selected —
+     bypassing the designed ambiguity error (`selectDefaultRepository`), so repo-scoped
+     tools silently target repo A while the user works in repo B.
+  3. `invalidateDiscovered()` clears only `discoveryCache`, never `entry.discovered`;
+     capability checks and worktree-membership validation keep reading pre-mutation state
+     (e.g. a worktree removed by `sync` still passes membership and produces a raw git
+     error).
+- **Expected behavior**:
+  1. After `load_config`, if `currentRepo` points at a *detected* pseudo-entry whose path
+     is now covered by a configured repository, reselect: switch `currentRepo` to that
+     configured repo (path match via the existing discovery machinery).
+  2. `load_config` must not auto-pin `repositories[0]` when the config has >1 repository
+     and no unambiguous match with the CWD — leave `currentRepo` null so the existing
+     ambiguity error/selection flow triggers. Auto-pin remains OK for single-repo configs.
+  3. `invalidateDiscovered()` also nulls `entry.discovered` for the affected repo(s) so the
+     next capability/membership read re-discovers.
+- **Acceptance**: context tests covering all three transitions (start-detected →
+  load_config → sync succeeds; multi-repo load_config leaves selection empty; post-sync
+  membership check re-discovers instead of reading stale lists).
+
+### [x] F9. Config validation gaps + `.cjs` reload staleness + local-path `repoUrl` contradiction
+
+- **Severity**: Medium (invalid configs accepted → runtime crashes; stale config in daemons)
+- **Location**: `src/services/config-loader.service.ts:91-168` (validation), `:56`
+  (import cache-buster), `:690` + `src/utils/git-url.ts:7-47` (URL validation vs
+  `extractRepoNameFromUrl`), `:363-367` (parallelism validation)
+- **Current behavior**:
+  1. `branchInclude`/`branchExclude` accept non-arrays (`branchInclude: "main"` crashes
+     mid-sync with `include.some is not a function`); `branchMaxAge: "14 days"` passes and
+     silently disables the age filter; `skipLfs`/`updateExistingWorktrees` types unchecked;
+     parallelism fields accept non-integers (`pLimit(1.5)` throws at runtime).
+  2. The `?t=` query cache-buster does not bust the CJS require cache — long-lived
+     processes (MCP `load_config`, daemon) silently keep the first-loaded `.cjs` config
+     (verified experimentally).
+  3. `isValidGitUrl` accepts absolute local paths and trailing-slash URLs, but
+     `extractRepoNameFromUrl` (used to default `bareRepoDir`) has no pattern for them and
+     throws `Invalid Git URL format` — validator-blessed config fails with a contradictory
+     error.
+- **Expected behavior**:
+  1. Load-time validation: `branchInclude`/`branchExclude` must be arrays of strings;
+     `branchMaxAge` must match `parseDuration`'s grammar (`^\d+[hdwmy]$`) — reject, don't
+     silently ignore; `skipLfs`/`updateExistingWorktrees` must be booleans; parallelism
+     values must be positive **integers**. Every rejection is a `ConfigError` naming the
+     repo and field.
+  2. `.cjs` reload: before importing a `.cjs` config, delete its entry (and its child
+     module subtree) from `require.cache` — or document + enforce that `.cjs` configs
+     cannot be hot-reloaded and have `load_config` return an explicit error for a repeated
+     `.cjs` load. Pick the cache-delete approach unless it proves unworkable under ESM.
+  3. Either extend `extractRepoNameFromUrl` to handle plain absolute paths (basename minus
+     `.git`, tolerating a trailing slash) or make validation require an explicit
+     `bareRepoDir` for path-style URLs. Extending the parser is preferred (smaller user
+     burden).
+- **Acceptance**: loader tests for each rejected shape; a `.cjs` reload test (write file,
+  load, rewrite, reload → new values); `repoUrl: "/srv/git/repo.git"` without
+  `bareRepoDir` loads and resolves `bareRepoDir` to `.bare/repo`.
+
+### [x] F10. MCP clone-mode `initialize` reports wrong `defaultBranch`
+
+- **Severity**: Medium (misleading API output)
+- **Location**: `src/mcp/handlers.ts:495`, `src/services/git.service.ts:54`
+- **Current behavior**: the handler returns `git.getDefaultBranch()`, but clone-mode init
+  never runs `GitService.initialize`, so it returns the constructor constant `"main"`
+  regardless of the tracked branch (`develop`, etc.).
+- **Expected behavior**: for clone-mode repos the handler reports the clone's resolved
+  branch (`CloneSyncService.resolveBranch()` — expose it via `WorktreeSyncService` if
+  needed), falling back to config `branch`. Never report the worktree-mode constant for a
+  clone-mode repo.
+- **Acceptance**: handler test: clone-mode repo with `branch: "develop"` →
+  `initialize` response contains `defaultBranch: "develop"`.
+
+---
+
+## Low severity
+
+### [x] F11. Retry util: unbounded retry of permanent errors; `NaN` maxAttempts
+
+- **Location**: `src/utils/retry.ts:32-70`
+- **Current**: default `shouldRetry` retries `ENOENT`/`EACCES` (typically permanent);
+  util-level default `maxAttempts` is `"unlimited"` (product default 3 is applied only by
+  `SyncRetryPolicy`); `maxAttempts: NaN` passes the `< 1` check.
+- **Expected**: classify `EACCES`/`EPERM`/`EROFS`/`ENOSPC` (and plain `ENOENT`) as
+  non-retryable by default; validate `maxAttempts` with `Number.isFinite` (mirroring the
+  trash config validation) unless it is the literal string `"unlimited"`.
+- **Acceptance**: retry unit tests for each error class and for `NaN` rejection.
+
+### [x] F12. `timing.ts` "Efficiency" column is fake math
+
+- **Location**: `src/utils/timing.ts:73-78`
+- **Current**: `theoreticalSequentialTime = count * (duration / batches)` reduces to
+  `efficiency = count/batches` — a pure function of count and configured parallelism,
+  independent of measured time (6 items at parallelism 3 always prints 300%).
+- **Expected**: drop the column (preferred — it cannot be computed without per-item
+  timings) or compute it from real per-item durations if the PhaseTimer records them.
+- **Acceptance**: timing table test updated; no misleading percentage in debug output.
+
+### [x] F13. MCP `create_worktree` partial success reported as pure failure
+
+- **Location**: `src/mcp/handlers.ts:385-399`
+- **Current**: `addWorktree` succeeds, then `pushBranch` throws → response carries only the
+  push error; retrying agents then hit unexplained "already exists".
+- **Expected**: when worktree creation succeeded but push failed, the response must say so:
+  structured payload with `created: true, pushed: false, pushError: <msg>` and a
+  non-success status — not a bare error losing the created state.
+- **Acceptance**: handler test with mocked push failure asserting the structured partial
+  result.
+
+### [x] F14. `ensurePathBelongsToRepo` misattributes infrastructure failures
+
+- **Location**: `src/mcp/handlers.ts:120-127`
+- **Current**: a thrown worktree-listing error is swallowed and reported as
+  "Path '…' is not a registered worktree", blaming the caller's path.
+- **Expected**: listing failure surfaces as its own error ("could not verify worktree
+  membership: <cause>"), distinct from a genuine membership rejection.
+- **Acceptance**: handler test with `getWorktrees` throwing.
+
+### [x] F15. Init wizard: weak cron validation and duplicate-name generation
+
+- **Location**: `src/utils/interactive.ts:130-138`, `src/utils/config-generator.ts`
+- **Current**: cron input only needs ≥5 whitespace-separated fields (`a b c d e` accepted →
+  config fails on every load); two URLs ending in the same repo name generate duplicate
+  `name` fields the loader rejects. Wizard reports success; config never loads.
+- **Expected**: validate cron with `node-cron`'s `validate` (already a dependency, already
+  used by the loader); de-duplicate generated names (suffix `-2`, `-3`, …) or prompt.
+- **Acceptance**: wizard unit tests for both.
+
+### [x] F16. Duplicate, conflicting `isLfsError` implementations
+
+- **Location**: `src/errors/index.ts:127-130` vs `src/utils/lfs-error.ts`
+- **Current**: the errors-module version matches any message containing bare `"LFS"`
+  (via `ERROR_MESSAGES.LFS_ERROR`); all runtime code uses the stricter utils version. The
+  loose one is exported dead code and a misclassification landmine.
+- **Expected**: delete the loose implementation (and the `ERROR_MESSAGES.LFS_ERROR`
+  patterns if then unused); re-export the utils version from `errors/index.ts` only if
+  external callers need it.
+- **Acceptance**: typecheck + grep shows one implementation; existing LFS classification
+  tests still pass.
+
+### [x] F17. Hook timeout leaves a live 5s SIGKILL timer
+
+- **Location**: `src/services/hook-execution.service.ts:119-127,157-163`
+- **Current**: after a hook timeout, the `close` handler returns early on `timedOut` and
+  never clears the SIGKILL `killTimer`; it isn't `unref`'d either, so a runOnce process
+  lingers up to 5 extra seconds per timed-out hook.
+- **Expected**: clear the kill timer on child exit in all paths (or `unref()` it at
+  creation).
+- **Acceptance**: hook execution test asserting no open timer handle after a timed-out
+  hook's child exits.
+
+### [x] F18. `verifyLfsFilesDownloaded`: sampling with replacement + long blocking poll
+
+- **Location**: `src/services/git.service.ts:399-455`
+- **Current**: samples up to 5 files **with replacement** (can check the same file 5×) and
+  polls up to 30 × 1s per worktree, serially blocking the sync.
+- **Expected**: sample without replacement (shuffle-take or index set); make the retry
+  budget configurable and/or drastically shorter by default; consider verifying in the
+  background of the create phase. Minimal spec: no-replacement sampling + extract the 30s
+  constant to `DEFAULT_CONFIG` so it's tunable.
+- **Acceptance**: unit test that 5 distinct files are sampled when ≥5 exist.
+
+### [x] F19. Metadata keyed by worktree-path basename with an incorrect justifying comment
+
+- **Location**: `src/services/worktree-metadata.service.ts:20-27`
+- **Current**: metadata is stored under `<bareRepo>/.git/worktrees/<basename>/`; the
+  comment claims git uses the basename as the internal admin-dir name — git actually
+  de-duplicates with `-1` suffixes, and this store is a sibling directory the tool owns,
+  not git's admin dir. Safe today only because hash-suffixed worktree names make basenames
+  unique; a future naming change could silently collide metadata between worktrees.
+- **Expected**: fix the comment to state the actual invariant ("we key by basename; unique
+  because sanitizeBranchName guarantees unique basenames") and add a guard: when saving
+  metadata, if an existing file's `upstreamBranch` refers to a *different* branch, warn and
+  refuse to overwrite. (Full path-hash keying is out of scope unless the naming scheme
+  changes.)
+- **Acceptance**: unit test for the mismatch guard.
+
+### [x] F20. `mcp-registration` treats every exit-1 as "unregistered"
+
+- **Location**: `src/utils/mcp-registration.ts:36-38`
+- **Current**: `code === 1` from `claude`/`codex` CLIs is assumed to mean "server missing";
+  any other exit-1 failure (corrupt config, auth) triggers a registration prompt and an
+  `mcp add` that may duplicate/overwrite.
+- **Expected**: additionally match the CLI's "not found"-style stderr/stdout before
+  concluding "unregistered"; on unrecognized exit-1 output, report "could not determine
+  registration state" and do nothing.
+- **Acceptance**: unit test with a fake CLI emitting an unrelated exit-1 error → no
+  registration attempt.
+
+---
+
+## Needs product decision (do not implement without maintainer sign-off)
+
+### [~] D1. Hash suffix on every worktree directory name vs docs
+
+- **Location**: `src/services/path-resolution.service.ts:11-18` (`sanitizeBranchName`),
+  README / CLAUDE.md examples showing `worktrees/main/`, `feature-1/`
+- **Tension**: since PR #54, every branch worktree directory is `<stem>-<8-hex-hash>`
+  (e.g. `feature-x-a1b2c3d4/`) — collision-proof, but user-facing directory names people
+  cd into, and the docs still show plain names. Options:
+  - (a) Keep always-hash; update README/CLAUDE.md examples to match reality.
+  - (b) Hash only when needed (name contains `/` or other substituted chars, or a
+    collision with an existing reserved path is detected by the planner). Prettier names;
+    requires care in `extractBranchFromWorktreePath`/metadata keying (see F19) and a
+    migration story for existing hashed dirs.
+- **Decision needed**: (a) or (b). Note F19's metadata-uniqueness guard becomes mandatory
+  under (b).
+
+### [~] D2. `GitService` decomposition
+
+- **Location**: `src/services/git.service.ts` (1372 lines)
+- **Observation**: mixes clone/init orchestration, the worktree-add matrix with three
+  near-identical rollback blocks (`addWorktree`, ~200 lines), LFS verification, metadata
+  delegation, and ~30 thin git wrappers. The extracted services (status, path, sparse) show
+  the intended shape. Suggested cut if approved: extract `WorktreeCreationService`
+  (add-matrix + rollback + metadata) and `LfsVerificationService`; keep `GitService` as the
+  thin git/porcelain wrapper. Pure refactor, no behavior change, high test-churn — needs
+  maintainer appetite before anyone starts.
+
+---
+
+## Suggested task batching for agents
+
+- **Batch 1 (independent, small, high value)**: F1, F2, F4, F16, F17 — no cross-coupling.
+- **Batch 2 (CLI/runOnce semantics)**: F6 (+F11, F12, F15 nearby).
+- **Batch 3 (MCP layer)**: F3, F8, F10, F13, F14, F20 — same files, do as one series.
+- **Batch 4 (config loader)**: F9 — one file, several validations.
+- **Batch 5 (safety subsystems, review carefully)**: F5, F7, F18, F19 — touch the
+  removal/trash paths; require the most careful tests.
+- D1/D2 blocked on maintainer decision.

--- a/src/__tests__/index.run-once.test.ts
+++ b/src/__tests__/index.run-once.test.ts
@@ -168,6 +168,7 @@ describe("runMultipleRepositories", () => {
     await runMultipleRepositories(configFile, [repo]);
 
     expect(mocks.logger.info).toHaveBeenCalledWith(expect.stringContaining("1 failed"));
+    expect(mocks.logger.info).toHaveBeenCalledWith(expect.stringContaining("0 skipped"));
     expect(process.exitCode).toBe(1);
   });
 });

--- a/src/__tests__/index.run-once.test.ts
+++ b/src/__tests__/index.run-once.test.ts
@@ -49,6 +49,7 @@ vi.mock("../services/worktree-sync.service", () => ({
 vi.mock("../utils/signal-handlers", () => ({
   setupSignalHandlers: vi.fn(() => ({
     register: mocks.registerSignalHandler,
+    dispose: vi.fn(),
   })),
 }));
 
@@ -157,6 +158,16 @@ describe("runMultipleRepositories", () => {
     expect(summary).toMatch(/0 (skipped|with clone-mode skips|with skips)/);
     expect(summary).toContain("1 failed");
     expect(summary).not.toContain("with partial skips");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("counts a rejected sync as failed even when the repo recorded a soft skip first", async () => {
+    mocks.getRecordedSkips.mockReturnValue([{ kind: "dirty_tree", worktreePath: "/tmp/repo-a" }]);
+    mocks.sync.mockRejectedValue(new Error("network failed"));
+
+    await runMultipleRepositories(configFile, [repo]);
+
+    expect(mocks.logger.info).toHaveBeenCalledWith(expect.stringContaining("1 failed"));
     expect(process.exitCode).toBe(1);
   });
 });

--- a/src/__tests__/rebased-branch-handling.test.ts
+++ b/src/__tests__/rebased-branch-handling.test.ts
@@ -51,6 +51,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
       updateRef: vi.fn<any>().mockResolvedValue(undefined),
       deleteLocalBranch: vi.fn<any>().mockResolvedValue(undefined),
       getGit: vi.fn<any>(),
+      getBareRepoPath: vi.fn(() => "/test/.bare/repo.git"),
     } as any,
   };
 });

--- a/src/__tests__/utils/retry.test.ts
+++ b/src/__tests__/utils/retry.test.ts
@@ -63,6 +63,15 @@ describe("retry", () => {
       expect(mockFn).toHaveBeenCalledTimes(3);
     });
 
+    it("should reject NaN maxAttempts", async () => {
+      const mockFn = vi.fn().mockResolvedValue("success");
+
+      await expect(retry(mockFn, { maxAttempts: Number.NaN })).rejects.toThrow(
+        "maxAttempts must be 'unlimited' or a finite positive number",
+      );
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+
     it("should retry unlimited times when maxAttempts is 'unlimited'", async () => {
       let attempts = 0;
       const mockFn = vi.fn().mockImplementation(() => {
@@ -209,6 +218,18 @@ describe("retry", () => {
       expect(result).toBe("success");
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
+
+    it.each(["EACCES", "EPERM", "EROFS", "ENOSPC", "ENOENT"])(
+      "should not retry permanent filesystem error %s by default",
+      async (code) => {
+        const error = new Error(code);
+        (error as any).code = code;
+        const mockFn = vi.fn().mockRejectedValue(error);
+
+        await expect(retry(mockFn)).rejects.toThrow(code);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 
   describe("onRetry callback", () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,7 @@ export const DEFAULT_CONFIG = {
   CLONE_TIMEOUT_MS: 900_000,
   LOCK_STALE_MS: 600_000,
   LOCK_UPDATE_MS: 30_000,
+  LFS_VERIFICATION_MAX_RETRIES: 30,
   MAINTENANCE: {
     ENABLED: true,
     INTERVAL: "7d",
@@ -84,7 +85,6 @@ export const ERROR_MESSAGES = {
     "fatal: ambiguous argument",
     "unknown revision or path",
   ],
-  LFS_ERROR: ["smudge filter lfs failed", "git-lfs", "LFS"],
   EXDEV: "EXDEV",
 } as const;
 

--- a/src/errors/__tests__/index.test.ts
+++ b/src/errors/__tests__/index.test.ts
@@ -82,8 +82,8 @@ describe("Error Detection Functions", () => {
 
     it("should detect LFS errors from string messages", () => {
       expect(isLfsError("smudge filter lfs failed")).toBe(true);
-      expect(isLfsError("git-lfs pull failed")).toBe(true);
-      expect(isLfsError("LFS: error downloading")).toBe(true);
+      expect(isLfsError("Object does not exist on the server")).toBe(true);
+      expect(isLfsError("external filter 'git-lfs filter-process' failed")).toBe(true);
     });
 
     it("should return false for non-LFS errors", () => {
@@ -91,10 +91,9 @@ describe("Error Detection Functions", () => {
       expect(isLfsError("regular git error")).toBe(false);
     });
 
-    it("should detect all LFS error patterns", () => {
-      ERROR_MESSAGES.LFS_ERROR.forEach((pattern) => {
-        expect(isLfsError(pattern)).toBe(true);
-      });
+    it("should use the stricter shared LFS classifier", () => {
+      expect(isLfsError("git-lfs pull failed")).toBe(false);
+      expect(isLfsError("LFS: error downloading")).toBe(false);
     });
   });
 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -124,10 +124,7 @@ export class LfsError extends GitError {
   }
 }
 
-export function isLfsError(error: Error | string): boolean {
-  const message = typeof error === "string" ? error : error.message;
-  return ERROR_MESSAGES.LFS_ERROR.some((pattern) => message.includes(pattern));
-}
+export { isLfsErrorFromError as isLfsError } from "../utils/lfs-error";
 
 export function isFastForwardError(error: Error | string): boolean {
   const message = typeof error === "string" ? error : error.message;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,6 @@ export type {
   SyncWorktreesTrashConfig,
 } from "./types";
 
-const signalHandle = setupSignalHandlers();
-
 export async function runMultipleRepositories(
   configFile: ConfigFile,
   repositories: RepositoryConfig[],
@@ -56,6 +54,7 @@ export async function runMultipleRepositories(
   const limit = pLimit(maxParallel);
 
   if (runOnce) {
+    const runOnceSignalHandle = setupSignalHandlers({ exitAfterCleanupCode: 130 });
     globalLogger.info(`\n🔄 Syncing ${repositories.length} repositories...`);
 
     const initResults = await Promise.allSettled(
@@ -149,12 +148,8 @@ export async function runMultipleRepositories(
       }
     }
 
-    const initFailures = initResults.filter(
-      (result, index) => result.status === "rejected" && !skippedNames.has(repositories[index].name),
-    ).length;
-    const syncFailures = syncResults.filter(
-      (result, index) => result.status === "rejected" && !skippedNames.has(servicesToSync[index].name),
-    ).length;
+    const initFailures = initResults.filter((result) => result.status === "rejected").length;
+    const syncFailures = syncResults.filter((result) => result.status === "rejected").length;
     const failedCount = initFailures + syncFailures + outcomeFailedNames.size;
     const skippedCount = skippedNames.size;
     const successCount = syncResults.filter((result, index) => {
@@ -176,7 +171,9 @@ export async function runMultipleRepositories(
     if (failedCount > 0) {
       process.exitCode = 1;
     }
+    runOnceSignalHandle.dispose();
   } else {
+    const signalHandle = setupSignalHandlers();
     for (const repoConfig of repositories) {
       const syncService = new WorktreeSyncService(repoConfig);
       services.set(repoConfig.name, syncService);

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,13 +110,12 @@ export async function runMultipleRepositories(
     const partialSkipNames = new Set<string>();
     for (let i = 0; i < servicesToSync.length; i++) {
       const { name, service } = servicesToSync[i];
+      const result = syncResults[i];
       const reasons = service.getRecordedSkips();
       if (reasons.length > 0) {
         skipsByRepo.push({ repo: name, reasons });
-        skippedNames.add(name);
       }
 
-      const result = syncResults[i];
       if (result.status === "fulfilled") {
         if (!result.value.started) {
           skippedNames.add(name);
@@ -124,6 +123,10 @@ export async function runMultipleRepositories(
         }
 
         const counts = result.value.outcome?.counts;
+        const hasFailedOutcome = Boolean(counts && counts.failed > 0);
+        if (reasons.length > 0 && !hasFailedOutcome) {
+          skippedNames.add(name);
+        }
         if (counts) {
           if (counts.failed > 0) {
             outcomeFailedNames.add(name);

--- a/src/mcp/__tests__/context.test.ts
+++ b/src/mcp/__tests__/context.test.ts
@@ -20,13 +20,15 @@ vi.mock("simple-git", () => {
 
 vi.mock("../../services/worktree-sync.service", () => {
   return {
-    WorktreeSyncService: vi.fn().mockImplementation((config) => ({
-      config,
-      initialize: vi.fn(),
-      isInitialized: () => false,
-      isSyncInProgress: () => false,
-      getGitService: vi.fn(),
-    })),
+    WorktreeSyncService: vi.fn().mockImplementation(function (config) {
+      return {
+        config,
+        initialize: vi.fn(),
+        isInitialized: () => false,
+        isSyncInProgress: () => false,
+        getGitService: vi.fn(),
+      };
+    }),
   };
 });
 
@@ -304,9 +306,9 @@ describe("RepositoryContext.detectFromPath sibling discovery", () => {
       const rouletteBare = path.join(workspace, ".bare", "roulette-frontend");
       const rouletteWorktreeDir = path.join(workspace, "frontend", "roulette-frontend");
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "amusnet-react-ui", repoUrl: "https://github.com/test/amusnet-react-ui.git", bareRepoDir: "./.bare/amusnet-react-ui", worktreeDir: "./amusnet-react-ui", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "roulette-frontend", repoUrl: "https://github.com/test/roulette-frontend.git", bareRepoDir: "./.bare/roulette-frontend", worktreeDir: "./frontend/roulette-frontend", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "amusnet-react-ui", repoUrl: "https://github.com/test/amusnet-react-ui.git", bareRepoDir: "./.bare/amusnet-react-ui", worktreeDir: "./amusnet-react-ui", cronSchedule: "0 * * * *" },
+        { name: "roulette-frontend", repoUrl: "https://github.com/test/roulette-frontend.git", bareRepoDir: "./.bare/roulette-frontend", worktreeDir: "./frontend/roulette-frontend", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -347,7 +349,7 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
       await fs.writeFile(path.join(currentWt, ".git"), `gitdir: ${adminDir}\n`, "utf-8");
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [{ name: "auto-loaded", repoUrl: "https://github.com/test/repo.git", bareRepoDir: ${JSON.stringify(currentBare)}, worktreeDir: ${JSON.stringify(path.join(currentRepo, "worktrees"))}, cronSchedule: "0 * * * *", runOnce: true }] };`;
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [{ name: "auto-loaded", repoUrl: "https://github.com/test/repo.git", bareRepoDir: ${JSON.stringify(currentBare)}, worktreeDir: ${JSON.stringify(path.join(currentRepo, "worktrees"))}, cronSchedule: "0 * * * *" }] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
       mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
@@ -373,8 +375,8 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
       await fs.mkdir(nestedPath, { recursive: true });
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "game-platform-slots", repoUrl: "https://github.com/test/game-platform.git", worktreeDir: "./slots/game-platform", mode: "clone", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "game-platform-slots", repoUrl: "https://github.com/test/game-platform.git", worktreeDir: "./slots/game-platform", mode: "clone", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -415,8 +417,8 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
       await fs.mkdir(path.join(cloneDir, ".git"), { recursive: true });
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "game-platform-slots", repoUrl: "https://github.com/test/game-platform.git", worktreeDir: "./slots/game-platform", mode: "clone", branch: "configured-main", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "game-platform-slots", repoUrl: "https://github.com/test/game-platform.git", worktreeDir: "./slots/game-platform", mode: "clone", branch: "configured-main", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -440,6 +442,91 @@ describe("RepositoryContext.detectFromPath config auto-discovery", () => {
   });
 });
 
+describe("RepositoryContext.loadConfig selection state", () => {
+  beforeEach(() => {
+    mockRemoteUrl.mockReset();
+    mockWorktreeList.mockReset();
+  });
+
+  it("reselects a detected repo when the loaded config covers it", async () => {
+    const fixture = await makeWorktreeFixture();
+    try {
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
+      mockWorktreeList.mockResolvedValue(
+        [`worktree ${fixture.currentWorktree}`, "branch refs/heads/feature-x", ""].join("\n"),
+      );
+
+      const ctx = new RepositoryContext();
+      await ctx.detectFromPath(fixture.currentWorktree);
+      expect(ctx.getCurrentRepo()).toMatch(/^__auto_detected__:/);
+
+      const configPath = path.join(fixture.root, "sync-worktrees.config.js");
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "configured", repoUrl: "https://github.com/test/repo.git", bareRepoDir: ${JSON.stringify(fixture.bareRepo)}, worktreeDir: ${JSON.stringify(fixture.worktreesDir)}, cronSchedule: "0 * * * *" }
+      ] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      await ctx.loadConfig(configPath);
+
+      expect(ctx.getCurrentRepo()).toBe("configured");
+      await expect(ctx.getService()).resolves.toBeDefined();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("does not pin the first repo when a multi-repo config has no current match", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-load-multi-"));
+    try {
+      const configPath = path.join(workspace, "sync-worktrees.config.js");
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "alpha", repoUrl: "https://github.com/test/alpha.git", bareRepoDir: "./.bare/alpha", worktreeDir: "./alpha", cronSchedule: "0 * * * *" },
+        { name: "beta", repoUrl: "https://github.com/test/beta.git", bareRepoDir: "./.bare/beta", worktreeDir: "./beta", cronSchedule: "0 * * * *" }
+      ] };`;
+      await fs.writeFile(configPath, cfgBody, "utf-8");
+
+      const ctx = new RepositoryContext();
+      await ctx.loadConfig(configPath);
+
+      expect(ctx.getCurrentRepo()).toBeNull();
+      await expect(ctx.getService()).rejects.toThrow(/repository selection is ambiguous|No repository specified/);
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("clears stale discovered state when discovery is invalidated", async () => {
+    const fixture = await makeWorktreeFixture();
+    try {
+      mockRemoteUrl.mockResolvedValue("https://github.com/test/repo.git\n");
+      mockWorktreeList.mockResolvedValue(
+        [`worktree ${fixture.currentWorktree}`, "branch refs/heads/feature-x", ""].join("\n"),
+      );
+
+      const ctx = new RepositoryContext();
+      ctx.__registerForTest("configured", {
+        config: {
+          repoUrl: "https://github.com/test/repo.git",
+          bareRepoDir: path.resolve(fixture.bareRepo),
+          worktreeDir: fixture.worktreesDir,
+          cronSchedule: "0 * * * *",
+          runOnce: true,
+        },
+        source: "config" as const,
+      });
+
+      await ctx.detectFromPath(fixture.currentWorktree);
+      expect(ctx.getDiscoveredContext("configured")).not.toBeNull();
+
+      ctx.invalidateDiscovered();
+
+      expect(ctx.getDiscoveredContext("configured")).toBeNull();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});
+
 describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
   beforeEach(() => {
     mockRemoteUrl.mockReset();
@@ -450,9 +537,9 @@ describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-repo-summary-"));
     try {
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", cronSchedule: "0 * * * *" },
+        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -460,7 +547,7 @@ describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
       await ctx.loadConfig(configPath);
 
       await expect(ctx.getConfiguredRepositorySummaries()).resolves.toEqual([
-        { name: "ui", mode: "clone", checkoutPath: path.join(workspace, "ui"), isCurrent: true },
+        { name: "ui", mode: "clone", checkoutPath: path.join(workspace, "ui"), isCurrent: false },
         { name: "frontend", mode: "worktree", worktreeDir: path.join(workspace, "frontend"), isCurrent: false },
       ]);
     } finally {
@@ -477,10 +564,10 @@ describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
       await fs.mkdir(bareDir, { recursive: true });
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", branch: "main", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "missing", repoUrl: "https://github.com/test/missing.git", bareRepoDir: "./.bare/missing", worktreeDir: "./missing", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", branch: "main", cronSchedule: "0 * * * *" },
+        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *" },
+        { name: "missing", repoUrl: "https://github.com/test/missing.git", bareRepoDir: "./.bare/missing", worktreeDir: "./missing", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -497,7 +584,7 @@ describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
           checkoutPath: cloneDir,
           repoUrl: "https://github.com/test/ui.git",
           branch: "main",
-          isCurrent: true,
+          isCurrent: false,
           localReady: true,
         },
         {
@@ -528,9 +615,9 @@ describe("RepositoryContext.getConfiguredRepositorySummaries", () => {
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-repo-summary-scope-"));
     try {
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "ui", repoUrl: "https://github.com/test/ui.git", worktreeDir: "./ui", mode: "clone", cronSchedule: "0 * * * *" },
+        { name: "frontend", repoUrl: "https://github.com/test/frontend.git", bareRepoDir: "./.bare/frontend", worktreeDir: "./frontend", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -567,9 +654,9 @@ describe("RepositoryContext.getAllConfiguredWorktreeDetails", () => {
       const siblingWt = path.join(workspace, "frontend", "repo-b", "feature-b");
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./frontend/repo-b", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *" },
+        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./frontend/repo-b", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 
@@ -608,9 +695,9 @@ describe("RepositoryContext.getAllConfiguredWorktreeDetails", () => {
       await fs.mkdir(siblingBare, { recursive: true });
 
       const configPath = path.join(workspace, "sync-worktrees.config.js");
-      const cfgBody = `export default { repositories: [
-        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *", runOnce: true },
-        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./repo-b", cronSchedule: "0 * * * *", runOnce: true }
+      const cfgBody = `export default { defaults: { runOnce: true }, repositories: [
+        { name: "repo-a", repoUrl: "https://github.com/test/repo-a.git", bareRepoDir: "./.bare/repo-a", worktreeDir: "./repo-a", cronSchedule: "0 * * * *" },
+        { name: "repo-b", repoUrl: "https://github.com/test/repo-b.git", bareRepoDir: "./.bare/repo-b", worktreeDir: "./repo-b", cronSchedule: "0 * * * *" }
       ] };`;
       await fs.writeFile(configPath, cfgBody, "utf-8");
 

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -839,7 +839,7 @@ describe("case-insensitive path handling in handlers", () => {
     const result = await invoke(handleUpdateWorktree, ctx, { path: "/users/foo/repo/feature" });
     const body = parseResponse(result);
     expect(body.success).toBe(true);
-    expect(git.updateWorktree).toHaveBeenCalledWith("/users/foo/repo/feature");
+    expect(git.updateWorktree).toHaveBeenCalledWith("/Users/foo/Repo/Feature");
   });
 
   it("rejects mixed-case worktree path on linux (case-sensitive)", async () => {

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -99,6 +99,8 @@ function makeDiscovered(overrides: Partial<DiscoveredRepoContext> = {}): Discove
 }
 
 type MockGit = {
+  fetchAll: ReturnType<typeof vi.fn>;
+  fetchBranch: ReturnType<typeof vi.fn>;
   getWorktrees: ReturnType<typeof vi.fn>;
   getFullWorktreeStatus: ReturnType<typeof vi.fn>;
   branchExists: ReturnType<typeof vi.fn>;
@@ -125,6 +127,8 @@ function makeCtx(opts: {
   service?: Record<string, unknown>;
 }): { ctx: RepositoryContext; git: MockGit; service: any } {
   const git: MockGit = {
+    fetchAll: vi.fn<any>().mockResolvedValue(undefined),
+    fetchBranch: vi.fn<any>().mockResolvedValue(undefined),
     getWorktrees: vi.fn<any>().mockResolvedValue([]),
     getFullWorktreeStatus: vi.fn<any>(),
     branchExists: vi.fn<any>(),
@@ -157,6 +161,7 @@ function makeCtx(opts: {
       },
     }),
     getGitService: () => git,
+    getDefaultBranch: vi.fn<any>().mockResolvedValue("main"),
     getWorktrees: vi.fn<any>().mockImplementation(() => (git.getWorktrees as any)()),
     isCloneMode: vi.fn<any>().mockReturnValue(false),
     getRecordedSkips: vi.fn<any>().mockReturnValue([]),
@@ -401,6 +406,29 @@ describe("handleCreateWorktree", () => {
     expect(git.addWorktree).toHaveBeenCalledWith("feature/x", expect.stringContaining("feature-x"));
   });
 
+  it("fetches before checking the branch matrix", async () => {
+    const callOrder: string[] = [];
+    let remoteExists = false;
+    const { ctx } = makeCtx({
+      git: {
+        fetchAll: vi.fn<any>().mockImplementation(async () => {
+          callOrder.push("fetchAll");
+          remoteExists = true;
+        }),
+        branchExists: vi.fn<any>().mockImplementation(async () => {
+          callOrder.push("branchExists");
+          return { local: false, remote: remoteExists };
+        }),
+      },
+    });
+
+    const result = await invoke(handleCreateWorktree, ctx, { branchName: "feature/fresh" });
+    const body = parseResponse(result);
+
+    expect(body.success).toBe(true);
+    expect(callOrder).toEqual(["fetchAll", "branchExists"]);
+  });
+
   it("creates and pushes a missing branch by default when baseBranch is provided", async () => {
     const { ctx, git } = makeCtx({
       git: {
@@ -550,6 +578,30 @@ describe("handleCreateWorktree", () => {
     expect(callOrder).toEqual(["createBranch", "addWorktree", "pushBranch"]);
     expect(git.addWorktree).toHaveBeenCalled();
     expect(git.pushBranch).toHaveBeenCalledWith("new-branch");
+  });
+
+  it("returns partial success details when push fails after worktree creation", async () => {
+    const { ctx, git } = makeCtx({
+      git: {
+        branchExists: vi.fn<any>().mockResolvedValue({ local: false, remote: false }),
+        pushBranch: vi.fn<any>().mockRejectedValue(new Error("non-fast-forward")),
+      },
+    });
+
+    const result = await invoke(handleCreateWorktree, ctx, {
+      branchName: "new-branch",
+      baseBranch: "main",
+    });
+    const body = parseResponse(result);
+
+    expect(body).toMatchObject({
+      success: false,
+      branchName: "new-branch",
+      created: true,
+      pushed: false,
+      pushError: "non-fast-forward",
+    });
+    expect(git.addWorktree).toHaveBeenCalled();
   });
 
   it("is unavailable for clone-mode repositories", async () => {
@@ -726,6 +778,21 @@ describe("handleSync", () => {
 });
 
 describe("handleInitialize", () => {
+  it("reports clone-mode configured branch as defaultBranch", async () => {
+    const { ctx, service } = makeCtx({
+      service: {
+        isCloneMode: vi.fn<any>().mockReturnValue(true),
+        getDefaultBranch: vi.fn<any>().mockResolvedValue("develop"),
+      },
+    });
+
+    const result = await invoke(handleInitialize, ctx, {});
+    const body = parseResponse(result);
+
+    expect(body.defaultBranch).toBe("develop");
+    expect(service.getDefaultBranch).toHaveBeenCalled();
+  });
+
   it("sends progress notifications when service emits events", async () => {
     const { ctx, service } = makeCtx({});
     service.isInitialized.mockReturnValue(false);
@@ -797,7 +864,29 @@ describe("handleUpdateWorktree", () => {
     const body = parseResponse(result);
     expect(body.success).toBe(true);
     expect(service.runExclusiveRepoOperation).toHaveBeenCalledTimes(1);
+    expect(git.fetchBranch).toHaveBeenCalledWith("feature");
     expect(git.updateWorktree).toHaveBeenCalledWith("/w/feature");
+  });
+
+  it("fetches the target branch before updating the worktree", async () => {
+    const callOrder: string[] = [];
+    const { ctx } = makeCtx({
+      git: {
+        getWorktrees: vi.fn<any>().mockResolvedValue([{ path: "/w/feature", branch: "feature" }]),
+        fetchBranch: vi.fn<any>().mockImplementation(async () => {
+          callOrder.push("fetchBranch");
+        }),
+        updateWorktree: vi.fn<any>().mockImplementation(async () => {
+          callOrder.push("updateWorktree");
+        }),
+      },
+    });
+
+    const result = await invoke(handleUpdateWorktree, ctx, { path: "/w/feature" });
+    const body = parseResponse(result);
+
+    expect(body.success).toBe(true);
+    expect(callOrder).toEqual(["fetchBranch", "updateWorktree"]);
   });
 
   it("rejects path outside repository", async () => {
@@ -808,6 +897,20 @@ describe("handleUpdateWorktree", () => {
     const body = parseResponse(result);
     expect(body.error).toBe(true);
     expect(body.message).toContain("not a registered worktree");
+  });
+
+  it("surfaces worktree listing failures as verification errors", async () => {
+    const { ctx } = makeCtx({
+      discovered: makeDiscovered({ allWorktrees: [] }),
+      git: { getWorktrees: vi.fn<any>().mockRejectedValue(new Error("bare repo corrupt")) },
+    });
+
+    const result = await invoke(handleUpdateWorktree, ctx, { path: "/w/feature" });
+    const body = parseResponse(result);
+
+    expect(body.error).toBe(true);
+    expect(body.message).toContain("Could not verify worktree membership: bare repo corrupt");
+    expect(body.message).not.toContain("not a registered worktree");
   });
 
   it("is unavailable for clone-mode repositories", async () => {

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -214,15 +214,17 @@ export class RepositoryContext {
       });
     }
 
+    this.reselectDetectedCurrentRepoIfConfigured();
+
     if (this.currentRepo && !this.repos.has(this.currentRepo)) {
       this.currentRepo = null;
     }
 
-    if (setDefaultCurrent && !this.currentRepo && configFile.repositories.length > 0) {
-      this.currentRepo = configFile.repositories[0].name;
+    if (setDefaultCurrent && !this.currentRepo && resolvedAll.length === 1) {
+      this.currentRepo = resolvedAll[0].name;
     }
 
-    this.discoveryCache.clear();
+    this.invalidateDiscovered();
 
     return configFile.repositories;
   }
@@ -267,6 +269,9 @@ export class RepositoryContext {
 
   invalidateDiscovered(): void {
     this.discoveryCache.clear();
+    for (const entry of this.repos.values()) {
+      entry.discovered = undefined;
+    }
   }
 
   /** @internal Test-only helper — registers a repo entry without going through config loading. */
@@ -365,10 +370,48 @@ export class RepositoryContext {
   }
 
   private bootstrapCurrentRepo(candidate: string, force = false): void {
-    if (this.currentRepo !== null) return;
+    if (this.currentRepo !== null) {
+      if (!force || this.repos.get(this.currentRepo)?.source !== "detected") return;
+    }
     if (!this.repos.has(candidate)) return;
     if (!force && this.repos.size !== 1) return;
     this.currentRepo = candidate;
+  }
+
+  private reselectDetectedCurrentRepoIfConfigured(): void {
+    if (!this.currentRepo) return;
+    const current = this.repos.get(this.currentRepo);
+    if (current?.source !== "detected") return;
+    const match = this.findConfiguredEntryForDetected(current);
+    if (match) {
+      this.currentRepo = match.name;
+    }
+  }
+
+  private findConfiguredEntryForDetected(detected: RepoEntry): RepoEntry | null {
+    const discovered = detected.discovered;
+    const detectedBare = discovered?.bareRepoPath ?? detected.config.bareRepoDir ?? null;
+    const detectedWorktree = discovered?.currentWorktreePath ?? detected.config.worktreeDir;
+
+    for (const entry of this.repos.values()) {
+      if (entry.source !== "config") continue;
+      if (
+        detectedBare &&
+        entry.config.bareRepoDir &&
+        normalizePathForCompare(path.resolve(entry.config.bareRepoDir)) ===
+          normalizePathForCompare(path.resolve(detectedBare))
+      ) {
+        return entry;
+      }
+      if (
+        resolveMode(entry.config) === REPOSITORY_MODES.CLONE &&
+        normalizePathForCompare(path.resolve(entry.config.worktreeDir)) ===
+          normalizePathForCompare(path.resolve(detectedWorktree))
+      ) {
+        return entry;
+      }
+    }
+    return null;
   }
 
   private async isCacheFresh(cached: CachedDiscovery): Promise<boolean> {

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -476,7 +476,7 @@ export async function handleUpdateWorktree(
     const worktree = await ensureRepoWorktree(ctx, params, service, git);
 
     await git.fetchBranch(worktree.branch);
-    await git.updateWorktree(params.path);
+    await git.updateWorktree(worktree.path);
     ctx.invalidateDiscovered();
 
     return formatToolResponse({

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -26,6 +26,7 @@ type WorktreePathParams = RepoScopedParams & { path: string };
 type RepoService = Awaited<ReturnType<RepositoryContext["getService"]>>;
 type RepoGitService = ReturnType<RepoService["getGitService"]>;
 type Limit = ReturnType<typeof pLimit>;
+type RepoWorktree = { path: string; branch: string };
 type ListedWorktree = {
   path: string;
   branch: string;
@@ -100,28 +101,29 @@ async function ensureRepoWorktreePath(
   service: RepoService,
   git: RepoGitService,
 ): Promise<string> {
-  await ensurePathBelongsToRepo(ctx, params.path, params.repoName, service, git);
-  return path.resolve(params.path);
+  return (await ensureRepoWorktree(ctx, params, service, git)).path;
 }
 
-async function ensurePathBelongsToRepo(
+async function ensureRepoWorktree(
   ctx: RepositoryContext,
-  targetPath: string,
-  repoName: string | undefined,
+  params: WorktreePathParams,
   service: RepoService,
   git: RepoGitService,
-): Promise<void> {
-  const discovered = ctx.getDiscoveredContext(repoName);
+): Promise<RepoWorktree> {
+  const targetPath = params.path;
+  const discovered = ctx.getDiscoveredContext(params.repoName);
   if (discovered?.allWorktrees.length) {
-    const match = discovered.allWorktrees.some((w) => pathsEqual(w.path, targetPath));
-    if (match) return;
+    const match = discovered.allWorktrees.find((w) => pathsEqual(w.path, targetPath));
+    if (match) return { path: path.resolve(match.path), branch: match.branch };
   }
 
   try {
     const worktrees = await getWorktreesFromService(service, git);
-    if (worktrees.some((w) => pathsEqual(w.path, targetPath))) return;
-  } catch {
-    // fall through to rejection
+    const match = worktrees.find((w) => pathsEqual(w.path, targetPath));
+    if (match) return { path: path.resolve(match.path), branch: match.branch };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not verify worktree membership: ${cause}`);
   }
 
   throw new Error(`Path '${targetPath}' is not a registered worktree of the current repository`);
@@ -360,6 +362,7 @@ export async function handleCreateWorktree(
       await service.initializeUnlocked();
     }
 
+    await git.fetchAll();
     const existence = await git.branchExists(branchName);
 
     let created = false;
@@ -386,8 +389,19 @@ export async function handleCreateWorktree(
     ctx.invalidateDiscovered();
 
     if (created && push) {
-      await git.pushBranch(branchName);
-      pushed = true;
+      try {
+        await git.pushBranch(branchName);
+        pushed = true;
+      } catch (err) {
+        return formatToolResponse({
+          success: false,
+          branchName,
+          worktreePath: path.resolve(worktreePath),
+          created: true,
+          pushed: false,
+          pushError: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     return formatToolResponse({
@@ -459,14 +473,15 @@ export async function handleUpdateWorktree(
     if (!service.isInitialized()) {
       await service.initializeUnlocked();
     }
-    const worktreePath = await ensureRepoWorktreePath(ctx, params, service, git);
+    const worktree = await ensureRepoWorktree(ctx, params, service, git);
 
+    await git.fetchBranch(worktree.branch);
     await git.updateWorktree(params.path);
     ctx.invalidateDiscovered();
 
     return formatToolResponse({
       success: true,
-      worktreePath,
+      worktreePath: worktree.path,
     });
   });
 }
@@ -488,11 +503,10 @@ export async function handleInitialize(
       // one-shot suppression token so a later independent `sync` re-detects and
       // reports a wrong-branch / unreadable-HEAD clone instead of swallowing it.
       service.clearPendingInitSkip();
-      const git = service.getGitService();
       ctx.invalidateDiscovered();
       return formatToolResponse({
         success: true,
-        defaultBranch: git.getDefaultBranch(),
+        defaultBranch: await service.getDefaultBranch(),
         worktreeDir: service.config.worktreeDir,
       });
     });

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { TEST_URLS, cleanupTempDirectories, createTempDirectory } from "../../__tests__/test-utils";
+import { ConfigError } from "../../errors";
 import { ConfigLoaderService } from "../config-loader.service";
 
 describe("ConfigLoaderService", () => {
@@ -221,19 +222,19 @@ describe("ConfigLoaderService", () => {
       );
     });
 
-    it("should throw error for invalid runOnce type", async () => {
+    it("should reject repository runOnce with a defaults.runOnce pointer", async () => {
       const configPath = path.join(tempDir, "invalid-runonce.config.js");
       const configContent = `
         export default {
           repositories: [
-            { name: "test", repoUrl: "https://github.com/test/repo.git", worktreeDir: "/path", runOnce: "yes" }
+            { name: "test", repoUrl: "https://github.com/test/repo.git", worktreeDir: "/path", runOnce: true }
           ]
         };
       `;
       await fs.writeFile(configPath, configContent);
 
       await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
-        "Repository 'test' has invalid 'runOnce' property",
+        "Repository 'test' cannot set 'runOnce'; use defaults.runOnce",
       );
     });
 
@@ -250,6 +251,34 @@ describe("ConfigLoaderService", () => {
 
       await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
         "Repository 'test' has invalid 'debug' property",
+      );
+    });
+
+    it.each([
+      ["branchInclude", `branchInclude: "main"`],
+      ["branchExclude", `branchExclude: [123]`],
+      ["branchMaxAge", `branchMaxAge: "14 days"`],
+      ["skipLfs", `skipLfs: "yes"`],
+      ["updateExistingWorktrees", `updateExistingWorktrees: 1`],
+    ])("rejects invalid repository %s at load time", async (field, line) => {
+      const configPath = path.join(tempDir, `invalid-${field}.config.js`);
+      const configContent = `
+        export default {
+          repositories: [
+            {
+              name: "test-repo",
+              repoUrl: "${TEST_URLS.github}",
+              worktreeDir: "/path",
+              ${line}
+            }
+          ]
+        };
+      `;
+      await fs.writeFile(configPath, configContent);
+
+      await expect(configLoader.loadConfigFile(configPath)).rejects.toBeInstanceOf(ConfigError);
+      await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
+        new RegExp(`Repository 'test-repo'.*${field}`),
       );
     });
 
@@ -365,7 +394,7 @@ describe("ConfigLoaderService", () => {
       expect(resolved.runOnce).toBe(true);
     });
 
-    it("should override defaults with repo config", () => {
+    it("should not let repository runOnce override defaults", () => {
       const repo = {
         name: "test",
         repoUrl: "https://github.com/test/repo.git",
@@ -382,7 +411,7 @@ describe("ConfigLoaderService", () => {
       const resolved = configLoader.resolveRepositoryConfig(repo, defaults);
 
       expect(resolved.cronSchedule).toBe("0 0 * * *");
-      expect(resolved.runOnce).toBe(false);
+      expect(resolved.runOnce).toBe(true);
     });
 
     it("should preserve debug from defaults for config-only runs", () => {
@@ -963,6 +992,33 @@ describe("ConfigLoaderService", () => {
       expect(repo2.skipLfs).toBe(false);
     });
 
+    it("reloads .cjs configs and their required child modules", async () => {
+      const childPath = path.join(tempDir, "repo-name.cjs");
+      const configPath = path.join(tempDir, "sync-worktrees.config.cjs");
+      await fs.writeFile(childPath, `module.exports = { name: "first" };`);
+      await fs.writeFile(
+        configPath,
+        `
+          const child = require("./repo-name.cjs");
+          module.exports = {
+            repositories: [{
+              name: child.name,
+              repoUrl: "${TEST_URLS.github}",
+              worktreeDir: "./worktrees"
+            }]
+          };
+        `,
+      );
+
+      const first = await configLoader.loadConfigFile(configPath);
+      expect(first.repositories[0].name).toBe("first");
+
+      await fs.writeFile(childPath, `module.exports = { name: "second" };`);
+
+      const second = await configLoader.loadConfigFile(configPath);
+      expect(second.repositories[0].name).toBe("second");
+    });
+
     it("should default skipLfs to false when not specified", () => {
       const repo = {
         name: "test",
@@ -1107,6 +1163,7 @@ describe("ConfigLoaderService", () => {
       { field: "maxWorktreeUpdates", invalidValue: 0 },
       { field: "maxWorktreeRemoval", invalidValue: 0 },
       { field: "maxStatusChecks", invalidValue: 0 },
+      { field: "maxBranchFetches", invalidValue: 1.5 },
     ])("should reject invalid $field", async ({ field, invalidValue }) => {
       const configPath = path.join(tempDir, `invalid-${field}.config.js`);
       const configContent = `
@@ -1124,7 +1181,7 @@ describe("ConfigLoaderService", () => {
       await fs.writeFile(configPath, configContent);
 
       await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
-        `Invalid '${field}' in global parallelism config. Must be a positive number`,
+        `Invalid configuration for 'global parallelism.${field}': must be a positive integer`,
       );
     });
 
@@ -1215,7 +1272,7 @@ describe("ConfigLoaderService", () => {
       await fs.writeFile(configPath, configContent);
 
       await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
-        "Invalid 'maxRepositories' in defaults parallelism config",
+        "Invalid configuration for 'defaults parallelism.maxRepositories': must be a positive integer",
       );
     });
   });
@@ -1534,7 +1591,7 @@ describe("ConfigLoaderService", () => {
       expect(resolved.hooks?.onBranchCreated).toEqual(["repo-command"]);
     });
 
-    it("should resolve filesToCopyOnBranchCreate paths relative to config dir", () => {
+    it("should keep filesToCopyOnBranchCreate patterns relative", () => {
       const repo = {
         name: "test",
         repoUrl: "https://github.com/test/repo.git",
@@ -1546,10 +1603,10 @@ describe("ConfigLoaderService", () => {
 
       const resolved = configLoader.resolveRepositoryConfig(repo, {}, "/base/dir");
 
-      expect(resolved.filesToCopyOnBranchCreate).toEqual(["/base/dir/.env.local", "/base/dir/configs/settings.json"]);
+      expect(resolved.filesToCopyOnBranchCreate).toEqual([".env.local", "./configs/settings.json"]);
     });
 
-    it("should preserve absolute filesToCopyOnBranchCreate paths", () => {
+    it("should leave unsafe filesToCopyOnBranchCreate patterns for copy-time rejection", () => {
       const repo = {
         name: "test",
         repoUrl: "https://github.com/test/repo.git",
@@ -1562,6 +1619,52 @@ describe("ConfigLoaderService", () => {
       const resolved = configLoader.resolveRepositoryConfig(repo, {}, "/base/dir");
 
       expect(resolved.filesToCopyOnBranchCreate).toEqual(["/absolute/.env.local"]);
+    });
+
+    it("rejects worktree-mode bareRepoDir inside worktreeDir", () => {
+      const repo = {
+        name: "test",
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "./worktrees",
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+        bareRepoDir: "./worktrees/repo-bare",
+      };
+
+      expect(() => configLoader.resolveRepositoryConfig(repo, {}, "/base/dir")).toThrow(/bareRepoDir\/worktreeDir/);
+    });
+
+    it("rejects worktree-mode worktreeDir inside bareRepoDir", () => {
+      const repo = {
+        name: "test",
+        repoUrl: "https://github.com/test/repo.git",
+        worktreeDir: "./repo-bare/worktrees",
+        cronSchedule: "0 * * * *",
+        runOnce: false,
+        bareRepoDir: "./repo-bare",
+      };
+
+      expect(() => configLoader.resolveRepositoryConfig(repo, {}, "/base/dir")).toThrow(/bareRepoDir\/worktreeDir/);
+    });
+
+    it("derives bareRepoDir from an absolute local repoUrl", async () => {
+      const configPath = path.join(tempDir, "local-path.config.js");
+      await fs.writeFile(
+        configPath,
+        `
+          export default {
+            repositories: [{
+              name: "local",
+              repoUrl: "/srv/git/repo.git",
+              worktreeDir: "./worktrees"
+            }]
+          };
+        `,
+      );
+
+      const { repositories } = await configLoader.buildRepositories(configPath);
+
+      expect(repositories[0].bareRepoDir).toBe(path.join(tempDir, ".bare", "repo"));
     });
 
     it("should not set hooks when neither repo nor defaults have hooks", () => {

--- a/src/services/__tests__/config-loader.service.test.ts
+++ b/src/services/__tests__/config-loader.service.test.ts
@@ -233,8 +233,9 @@ describe("ConfigLoaderService", () => {
       `;
       await fs.writeFile(configPath, configContent);
 
+      await expect(configLoader.loadConfigFile(configPath)).rejects.toBeInstanceOf(ConfigError);
       await expect(configLoader.loadConfigFile(configPath)).rejects.toThrow(
-        "Repository 'test' cannot set 'runOnce'; use defaults.runOnce",
+        /Repository 'test' runOnce.*defaults\.runOnce/,
       );
     });
 

--- a/src/services/__tests__/file-copy.service.test.ts
+++ b/src/services/__tests__/file-copy.service.test.ts
@@ -145,6 +145,31 @@ describe("FileCopyService", () => {
       expect(result.copied.sort()).toEqual(["a/b/file2.md", "a/file1.md"].sort());
     });
 
+    it("should copy relative config files into the same target paths", async () => {
+      await fs.mkdir(path.join(sourceDir, "config"), { recursive: true });
+      await fs.writeFile(path.join(sourceDir, ".env"), "SECRET=value");
+      await fs.writeFile(path.join(sourceDir, "config", "local.json"), "{}");
+
+      const result = await service.copyFiles(sourceDir, destDir, [".env", "config/*.json"]);
+
+      expect(result.copied.sort()).toEqual([".env", "config/local.json"].sort());
+      await expect(fs.readFile(path.join(destDir, ".env"), "utf-8")).resolves.toBe("SECRET=value");
+      await expect(fs.readFile(path.join(destDir, "config", "local.json"), "utf-8")).resolves.toBe("{}");
+    });
+
+    it("should reject absolute and escaping patterns", async () => {
+      await fs.writeFile(path.join(sourceDir, ".env"), "SECRET=value");
+
+      const result = await service.copyFiles(sourceDir, destDir, [path.join(sourceDir, ".env"), "../escape"]);
+
+      expect(result.copied).toEqual([]);
+      expect(result.errors).toEqual([
+        { file: path.join(sourceDir, ".env"), error: "Pattern must be relative and stay inside source directory" },
+        { file: "../escape", error: "Pattern must be relative and stay inside source directory" },
+      ]);
+      await expect(fs.stat(path.join(destDir, ".env"))).rejects.toThrow();
+    });
+
     it("should preserve file content exactly", async () => {
       const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe]);
       await fs.writeFile(path.join(sourceDir, "binary.bin"), binaryContent);

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -1092,6 +1092,37 @@ describe("GitService", () => {
       bufferSpy.mockRestore();
     });
 
+    it("samples distinct LFS files when at least five are available", async () => {
+      mockShowRef({ local: false, remote: true });
+
+      const worktreeGitMock = {
+        raw: vi.fn<any>().mockResolvedValue("file1.png\nfile2.png\nfile3.png\nfile4.png\nfile5.png\nfile6.png\n"),
+        revparse: vi.fn<any>().mockResolvedValue("abc123"),
+      };
+
+      (simpleGit as unknown as Mock).mockImplementation((gitPath?: any) => {
+        if (gitPath && gitPath.includes("feature-1")) {
+          return worktreeGitMock;
+        }
+        return mockGit;
+      });
+
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+      const mockFileHandle = {
+        read: vi.fn<any>().mockResolvedValue({ bytesRead: 18 }),
+        close: vi.fn<any>().mockResolvedValue(undefined),
+      };
+      (fs.open as Mock<any>).mockResolvedValue(mockFileHandle);
+
+      await gitService.addWorktree("feature-1", "/test/worktrees/feature-1");
+
+      const openedFiles = (fs.open as Mock<any>).mock.calls.map(([filePath]) => path.basename(String(filePath)));
+      expect(openedFiles).toHaveLength(5);
+      expect(new Set(openedFiles).size).toBe(5);
+
+      randomSpy.mockRestore();
+    });
+
     it("should skip LFS verification when skipLfs is enabled", async () => {
       const configWithSkipLfs = createMockConfig({ skipLfs: true });
 
@@ -1928,6 +1959,12 @@ prunable
   });
 
   describe("initialize - failure scenarios", () => {
+    it("detects default branches whose names contain slashes", async () => {
+      mockGit.raw.mockResolvedValueOnce("refs/remotes/origin/release/2024\n" as any);
+
+      await expect((gitService as any).detectDefaultBranch(mockGit)).resolves.toBe("release/2024");
+    });
+
     it("should throw when fetch fails during initialization", async () => {
       (fs.access as Mock<any>).mockResolvedValue(undefined);
       mockGit.raw.mockRejectedValueOnce(new Error("config not found"));

--- a/src/services/__tests__/hook-execution.service.test.ts
+++ b/src/services/__tests__/hook-execution.service.test.ts
@@ -304,5 +304,22 @@ describe("HookExecutionService", () => {
         service.cleanup();
       }
     });
+
+    it("should clear the SIGKILL timer after a timed-out hook exits", async () => {
+      const command = nodeScript("setInterval(() => {}, 1000)");
+
+      service.setTimeoutMs(100);
+
+      try {
+        service.executeOnBranchCreated({ onBranchCreated: [command] }, mockContext);
+
+        await vi.waitFor(() => {
+          expect((service as any).killTimers.size).toBe(0);
+          expect((service as any).activeProcesses.size).toBe(0);
+        });
+      } finally {
+        service.cleanup();
+      }
+    });
   });
 });

--- a/src/services/__tests__/trash-reaper.service.test.ts
+++ b/src/services/__tests__/trash-reaper.service.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -87,6 +88,8 @@ describe("TrashReaperService", () => {
     return entry;
   }
 
+  const rootHash = (root: string): string => createHash("sha256").update(path.resolve(root)).digest("hex").slice(0, 16);
+
   it("deletes only expired entries, each on its own clock, and removes their pin refs", async () => {
     const expired = await makeEntry("expired", { ageDays: 31, branch: "expired" });
     const fresh = await makeEntry("fresh", { ageDays: 5, branch: "fresh" });
@@ -150,24 +153,28 @@ describe("TrashReaperService", () => {
     expect(gitStub.listRefs).not.toHaveBeenCalled();
   });
 
-  it("sweeps pin refs whose container is gone, keeping refs for existing containers — even invalid-manifest ones", async () => {
+  it("sweeps only own-namespace orphan pin refs, leaving foreign and legacy refs alone", async () => {
     const kept = await makeEntry("kept", { ageDays: 1, branch: "kept" });
     const invalidManifest = await makeEntry("invalid-manifest", { ageDays: 1, branch: "inv" });
     await fs.writeFile(path.join(invalidManifest.containerPath, "manifest.json"), "{not json");
+    const ownPrefix = `refs/sync-worktrees/trash/${rootHash(trashService.getTrashRoot())}/`;
+    const foreignPrefix = "refs/sync-worktrees/trash/0123456789abcdef/";
     gitStub.listRefs.mockResolvedValue([
-      `refs/sync-worktrees/trash/${kept.manifest.id}`,
-      `refs/sync-worktrees/trash/${invalidManifest.manifest.id}`,
-      "refs/sync-worktrees/trash/gone-entry-id",
-      "refs/sync-worktrees/trash/nested/odd",
+      `${ownPrefix}${kept.manifest.id}`,
+      `${ownPrefix}${invalidManifest.manifest.id}`,
+      `${ownPrefix}gone-entry-id`,
+      `${foreignPrefix}foreign-entry-id`,
+      "refs/sync-worktrees/trash/legacy-flat-id",
     ]);
 
     await reaper.reapExpiredUnlocked();
 
-    expect(gitStub.deleteRef).toHaveBeenCalledWith("refs/sync-worktrees/trash/gone-entry-id");
-    expect(gitStub.deleteRef).not.toHaveBeenCalledWith(`refs/sync-worktrees/trash/${kept.manifest.id}`);
-    expect(gitStub.deleteRef).not.toHaveBeenCalledWith(`refs/sync-worktrees/trash/${invalidManifest.manifest.id}`);
-    expect(gitStub.deleteRef).not.toHaveBeenCalledWith("refs/sync-worktrees/trash/nested/odd");
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("unexpected ref"));
+    expect(gitStub.deleteRef).toHaveBeenCalledWith(`${ownPrefix}gone-entry-id`);
+    expect(gitStub.deleteRef).not.toHaveBeenCalledWith(`${ownPrefix}${kept.manifest.id}`);
+    expect(gitStub.deleteRef).not.toHaveBeenCalledWith(`${ownPrefix}${invalidManifest.manifest.id}`);
+    expect(gitStub.deleteRef).not.toHaveBeenCalledWith(`${foreignPrefix}foreign-entry-id`);
+    expect(gitStub.deleteRef).not.toHaveBeenCalledWith("refs/sync-worktrees/trash/legacy-flat-id");
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("legacy flat trash pin refs"));
   });
 
   it("protects a pin ref behind any dirent name, even a non-directory — unpinning is irreversible, a ref is cheap", async () => {

--- a/src/services/__tests__/trash.service.test.ts
+++ b/src/services/__tests__/trash.service.test.ts
@@ -83,7 +83,7 @@ describe("TrashService", () => {
       expect(manifest.branch).toBe("feature-x");
       expect(manifest.reason).toBe("prune");
       expect(manifest.headOid).toBe("abc123");
-      expect(manifest.pinRef).toBe(`${GIT_CONSTANTS.TRASH_REF_PREFIX}${manifest.id}`);
+      expect(manifest.pinRef).toMatch(new RegExp(`^${GIT_CONSTANTS.TRASH_REF_PREFIX}[0-9a-f]{16}/${manifest.id}$`));
       expect(manifest.originalPath).toBe(source);
       expect(gitStub.updateRef).toHaveBeenCalledWith(manifest.pinRef, "abc123");
 

--- a/src/services/__tests__/worktree-metadata.service.test.ts
+++ b/src/services/__tests__/worktree-metadata.service.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import simpleGit from "simple-git";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createMockLogger } from "../../__tests__/test-utils";
 import { WorktreeMetadataService } from "../worktree-metadata.service";
 
 import type { SyncMetadata } from "../../types/sync-metadata";
@@ -30,6 +31,7 @@ describe("WorktreeMetadataService", () => {
     };
     (fs.open as Mock<any>).mockResolvedValue(mockFileHandle);
     (fs.rename as Mock<any>).mockResolvedValue(undefined);
+    (fs.readFile as Mock<any>).mockRejectedValue(new Error("ENOENT"));
   });
 
   describe("getMetadataPath", () => {
@@ -86,6 +88,28 @@ describe("WorktreeMetadataService", () => {
         ),
         "/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json",
       );
+    });
+
+    it("refuses to overwrite metadata for a different upstream branch", async () => {
+      const logger = createMockLogger();
+      service = new WorktreeMetadataService(logger);
+      const existing: SyncMetadata = {
+        lastSyncCommit: "abc123",
+        lastSyncDate: "2024-01-15T10:00:00Z",
+        upstreamBranch: "origin/feature-a",
+        createdFrom: { branch: "main", commit: "def456" },
+        syncHistory: [],
+      };
+      const incoming: SyncMetadata = {
+        ...existing,
+        upstreamBranch: "origin/feature-b",
+      };
+      (fs.readFile as Mock<any>).mockResolvedValue(JSON.stringify(existing));
+
+      await service.saveMetadata(mockBareRepoPath, mockWorktreeName, incoming);
+
+      expect(mockFileHandle.writeFile).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Refusing to overwrite metadata"));
     });
   });
 

--- a/src/services/__tests__/worktree-metadata.service.test.ts
+++ b/src/services/__tests__/worktree-metadata.service.test.ts
@@ -68,8 +68,9 @@ describe("WorktreeMetadataService", () => {
 
       (fs.mkdir as Mock<any>).mockResolvedValue(undefined);
 
-      await service.saveMetadata(mockBareRepoPath, mockWorktreeName, mockMetadata);
+      const saved = await service.saveMetadata(mockBareRepoPath, mockWorktreeName, mockMetadata);
 
+      expect(saved).toBe(true);
       expect(fs.mkdir).toHaveBeenCalledWith(
         path.dirname("/test/bare/repo/.git/worktrees/feature-branch/sync-metadata.json"),
         { recursive: true },
@@ -106,10 +107,34 @@ describe("WorktreeMetadataService", () => {
       };
       (fs.readFile as Mock<any>).mockResolvedValue(JSON.stringify(existing));
 
-      await service.saveMetadata(mockBareRepoPath, mockWorktreeName, incoming);
+      const saved = await service.saveMetadata(mockBareRepoPath, mockWorktreeName, incoming);
 
+      expect(saved).toBe(false);
       expect(mockFileHandle.writeFile).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Refusing to overwrite metadata"));
+    });
+
+    it("allows invalid existing metadata to be recreated with a different upstream branch", async () => {
+      const existing = {
+        lastSyncCommit: "not a sha",
+        lastSyncDate: "2024-01-15T10:00:00Z",
+        upstreamBranch: "origin/feature-a",
+        syncHistory: [],
+      };
+      const incoming: SyncMetadata = {
+        lastSyncCommit: "abc123",
+        lastSyncDate: "2024-01-15T10:00:00Z",
+        upstreamBranch: "origin/feature-b",
+        createdFrom: { branch: "main", commit: "def456" },
+        syncHistory: [],
+      };
+      (fs.readFile as Mock<any>).mockResolvedValue(JSON.stringify(existing));
+      (fs.mkdir as Mock<any>).mockResolvedValue(undefined);
+
+      const saved = await service.saveMetadata(mockBareRepoPath, mockWorktreeName, incoming);
+
+      expect(saved).toBe(true);
+      expect(mockFileHandle.writeFile).toHaveBeenCalledWith(JSON.stringify(incoming, null, 2), "utf-8");
     });
   });
 

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -76,6 +76,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
       deleteLocalBranch: vi.fn<any>().mockResolvedValue(undefined),
       createBundleFromRef: vi.fn<any>().mockResolvedValue(true),
       setStaleDirectoryTrasher: vi.fn(),
+      getBareRepoPath: vi.fn(() => "/test/.bare/repo.git"),
     } as any,
   };
 });
@@ -760,6 +761,7 @@ describe("WorktreeSyncService", () => {
       afterEach(() => {
         mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1", "feature-2"]);
         mockGitService.getWorktrees.mockResolvedValue([]);
+        mockGitService.getBareRepoPath.mockReturnValue("/test/.bare/repo.git");
         (fs.access as Mock<any>).mockReset();
       });
 
@@ -808,6 +810,26 @@ describe("WorktreeSyncService", () => {
         await service.sync();
 
         expect(fs.rm).toHaveBeenCalledWith(orphanPath, { recursive: true, force: true });
+      });
+
+      it("skips an orphaned directory that matches bareRepoDir", async () => {
+        const bareRepoPath = path.join("/test/worktrees", "repo-bare");
+        mockGitService.getBareRepoPath.mockReturnValue(bareRepoPath);
+        (fs.readdir as Mock<any>).mockImplementation(async (dirPath) => {
+          if ((dirPath as string).endsWith(".diverged")) {
+            throw errnoError("ENOENT");
+          }
+          return ["repo-bare"];
+        });
+        mockGitService.getWorktrees.mockResolvedValue([]);
+        mockGitService.getRemoteBranches.mockResolvedValue([]);
+        (fs.stat as Mock<any>).mockResolvedValue({ isDirectory: vi.fn().mockReturnValue(true) });
+
+        await service.sync();
+
+        expect(fs.rm).not.toHaveBeenCalledWith(bareRepoPath, expect.anything());
+        expect(fs.rename).not.toHaveBeenCalledWith(bareRepoPath, expect.anything());
+        expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("matches configured bareRepoDir"));
       });
     });
 
@@ -1358,6 +1380,7 @@ describe("WorktreeSyncService", () => {
       mockGitService.getWorktrees.mockResolvedValue([{ path: "/test/worktrees/feature-1", branch: "feature-1" }]);
       // The diverged-replace flow depends on these succeeding; re-stub them so
       // rejections configured by earlier suites cannot leak in.
+      mockGitService.hasStashedChanges.mockResolvedValue(false);
       mockGitService.updateRef.mockResolvedValue(undefined);
       mockGitService.deleteLocalBranch.mockResolvedValue(undefined);
     });
@@ -1422,6 +1445,24 @@ describe("WorktreeSyncService", () => {
       // force is safe: the directory was already moved to .diverged/
       expect(mockGitService.removeWorktree).toHaveBeenCalledWith("/test/worktrees/feature-1", { force: true });
       expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", "/test/worktrees/feature-1");
+    });
+
+    it("skips diverged replace when the worktree has stashed changes", async () => {
+      mockGitService.canFastForward.mockResolvedValue(false);
+      mockGitService.isLocalAheadOfRemote.mockResolvedValue(false);
+      mockGitService.checkWorktreeStatus.mockResolvedValue(true);
+      mockGitService.hasOperationInProgress.mockResolvedValue(false);
+      mockGitService.hasStashedChanges.mockResolvedValue(true);
+
+      await service.sync();
+
+      expect(mockGitService.compareTreeContent).not.toHaveBeenCalled();
+      expect(fs.rename).not.toHaveBeenCalled();
+      expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
+      expect(mockGitService.addWorktree).not.toHaveBeenCalledWith("feature-1", "/test/worktrees/feature-1");
+      expect(service.getLastOutcome()?.actions).toContainEqual(
+        expect.objectContaining({ kind: "skipped", reason: "stash_present", branch: "feature-1" }),
+      );
     });
 
     it("should use copy+remove fallback when rename fails with EXDEV", async () => {

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -142,7 +142,7 @@ export class ConfigLoaderService {
       }
 
       if (repoObj.runOnce !== undefined) {
-        throw new Error(`Repository '${repoObj.name}' cannot set 'runOnce'; use defaults.runOnce`);
+        throw new ConfigValidationError(`Repository '${repoObj.name}' runOnce`, "cannot be set; use defaults.runOnce");
       }
 
       if (repoObj.debug !== undefined && typeof repoObj.debug !== "boolean") {

--- a/src/services/config-loader.service.ts
+++ b/src/services/config-loader.service.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "module";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
@@ -14,6 +15,8 @@ import { REPOSITORY_MODES, isRepositoryMode } from "../utils/repo-mode";
 import { sanitizeNameForPath } from "../utils/sanitize-name";
 
 import type { Config, ConfigFile, RepositoryConfig, RepositoryMode } from "../types";
+
+const require = createRequire(import.meta.url);
 
 const CLONE_MODE_CONFLICTING_FIELDS = [
   "branchInclude",
@@ -51,10 +54,17 @@ export class ConfigLoaderService {
     }
 
     try {
-      const fileUrl = pathToFileURL(absolutePath);
-      fileUrl.searchParams.set("t", Date.now().toString());
-      const configModule = await import(fileUrl.href);
-      const config = configModule.default;
+      let config: unknown;
+      if (absolutePath.endsWith(".cjs")) {
+        this.clearRequireCacheSubtree(absolutePath);
+        const configModule = require(absolutePath) as { default?: unknown };
+        config = configModule.default ?? configModule;
+      } else {
+        const fileUrl = pathToFileURL(absolutePath);
+        fileUrl.searchParams.set("t", Date.now().toString());
+        const configModule = await import(fileUrl.href);
+        config = configModule.default;
+      }
 
       if (!config) {
         throw new Error("Config file must use 'export default' syntax");
@@ -131,13 +141,19 @@ export class ConfigLoaderService {
         throw new Error(`Repository '${repoObj.name}' has invalid cron expression: '${repoObj.cronSchedule}'`);
       }
 
-      if (repoObj.runOnce !== undefined && typeof repoObj.runOnce !== "boolean") {
-        throw new Error(`Repository '${repoObj.name}' has invalid 'runOnce' property`);
+      if (repoObj.runOnce !== undefined) {
+        throw new Error(`Repository '${repoObj.name}' cannot set 'runOnce'; use defaults.runOnce`);
       }
 
       if (repoObj.debug !== undefined && typeof repoObj.debug !== "boolean") {
         throw new Error(`Repository '${repoObj.name}' has invalid 'debug' property`);
       }
+
+      this.validateBranchPatternList(repoObj.branchInclude, `Repository '${repoObj.name}' branchInclude`);
+      this.validateBranchPatternList(repoObj.branchExclude, `Repository '${repoObj.name}' branchExclude`);
+      this.validateBranchMaxAge(repoObj.branchMaxAge, `Repository '${repoObj.name}' branchMaxAge`);
+      this.validateBoolean(repoObj.skipLfs, `Repository '${repoObj.name}' skipLfs`);
+      this.validateBoolean(repoObj.updateExistingWorktrees, `Repository '${repoObj.name}' updateExistingWorktrees`);
 
       if (repoObj.retry !== undefined) {
         this.validateRetryConfig(repoObj.retry, `Repository '${repoObj.name}' retry config`);
@@ -188,6 +204,11 @@ export class ConfigLoaderService {
       if (defaults.debug !== undefined && typeof defaults.debug !== "boolean") {
         throw new Error("Invalid 'debug' in defaults");
       }
+      this.validateBranchPatternList(defaults.branchInclude, "defaults.branchInclude");
+      this.validateBranchPatternList(defaults.branchExclude, "defaults.branchExclude");
+      this.validateBranchMaxAge(defaults.branchMaxAge, "defaults.branchMaxAge");
+      this.validateBoolean(defaults.skipLfs, "defaults.skipLfs");
+      this.validateBoolean(defaults.updateExistingWorktrees, "defaults.updateExistingWorktrees");
       if (defaults.retry !== undefined && typeof defaults.retry !== "object") {
         throw new Error("Invalid 'retry' in defaults");
       }
@@ -241,10 +262,55 @@ export class ConfigLoaderService {
     }
   }
 
+  private clearRequireCacheSubtree(configPath: string): void {
+    let resolved: string;
+    try {
+      resolved = require.resolve(configPath);
+    } catch {
+      resolved = configPath;
+    }
+
+    const seen = new Set<string>();
+    const visit = (modulePath: string): void => {
+      if (seen.has(modulePath)) return;
+      seen.add(modulePath);
+
+      const cached = require.cache[modulePath];
+      if (!cached) return;
+
+      for (const child of cached.children) {
+        visit(child.id);
+      }
+      delete require.cache[modulePath];
+    };
+
+    visit(resolved);
+  }
+
   private validateDepth(value: unknown, field: string): void {
     if (value === undefined) return;
     if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
       throw new ConfigValidationError(field, "must be a positive safe integer");
+    }
+  }
+
+  private validateBoolean(value: unknown, field: string): void {
+    if (value !== undefined && typeof value !== "boolean") {
+      throw new ConfigValidationError(field, "must be a boolean");
+    }
+  }
+
+  private validateBranchPatternList(value: unknown, field: string): void {
+    if (value === undefined) return;
+    if (!Array.isArray(value) || value.some((pattern) => typeof pattern !== "string")) {
+      throw new ConfigValidationError(field, "must be an array of strings");
+    }
+  }
+
+  private validateBranchMaxAge(value: unknown, field: string): void {
+    if (value === undefined) return;
+    if (typeof value !== "string" || parseDuration(value) === null) {
+      throw new ConfigValidationError(field, "must be a duration string like '14d', '12h', or '2w'");
     }
   }
 
@@ -362,8 +428,8 @@ export class ConfigLoaderService {
 
     for (const field of positiveIntFields) {
       const value = config[field];
-      if (value !== undefined && (typeof value !== "number" || value < 1)) {
-        throw new Error(`Invalid '${field}' in ${context} parallelism config. Must be a positive number`);
+      if (value !== undefined && (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1)) {
+        throw new ConfigValidationError(`${context} parallelism.${field}`, "must be a positive integer");
       }
     }
 
@@ -557,7 +623,7 @@ export class ConfigLoaderService {
       repoUrl: repo.repoUrl,
       worktreeDir: this.resolvePath(repo.worktreeDir, configDir),
       cronSchedule: repo.cronSchedule ?? defaults?.cronSchedule ?? DEFAULT_CONFIG.CRON_SCHEDULE,
-      runOnce: repo.runOnce ?? defaults?.runOnce ?? false,
+      runOnce: defaults?.runOnce ?? false,
       debug: repo.debug ?? defaults?.debug,
       mode,
     };
@@ -620,8 +686,9 @@ export class ConfigLoaderService {
     }
 
     if (repo.filesToCopyOnBranchCreate || defaults?.filesToCopyOnBranchCreate) {
-      const files = repo.filesToCopyOnBranchCreate ?? defaults?.filesToCopyOnBranchCreate;
-      resolved.filesToCopyOnBranchCreate = files?.map((f) => this.resolvePath(f, configDir));
+      resolved.filesToCopyOnBranchCreate = [
+        ...(repo.filesToCopyOnBranchCreate ?? defaults?.filesToCopyOnBranchCreate ?? []),
+      ];
     }
 
     if (repo.hooks || defaults?.hooks) {
@@ -650,7 +717,25 @@ export class ConfigLoaderService {
       };
     }
 
+    this.validateWorktreeBareRepoSeparation(resolved);
+
     return resolved;
+  }
+
+  private validateWorktreeBareRepoSeparation(repo: RepositoryConfig): void {
+    if (repo.mode === REPOSITORY_MODES.CLONE || !repo.bareRepoDir) return;
+
+    const worktreeDir = normalizePathForCompare(repo.worktreeDir);
+    const bareRepoDir = normalizePathForCompare(repo.bareRepoDir);
+    const worktreeContainsBare = bareRepoDir === worktreeDir || bareRepoDir.startsWith(worktreeDir + path.sep);
+    const bareContainsWorktree = worktreeDir.startsWith(bareRepoDir + path.sep);
+
+    if (worktreeContainsBare || bareContainsWorktree) {
+      throw new ConfigValidationError(
+        `Repository '${repo.name}' bareRepoDir/worktreeDir`,
+        `must not overlap (bareRepoDir: ${repo.bareRepoDir}, worktreeDir: ${repo.worktreeDir})`,
+      );
+    }
   }
 
   private isDuplicateRepoUrl(repo: RepositoryConfig, all: RepositoryConfig[], defaults?: Partial<Config>): boolean {

--- a/src/services/file-copy.service.ts
+++ b/src/services/file-copy.service.ts
@@ -37,9 +37,22 @@ export class FileCopyService {
       return result;
     }
 
-    const filesToCopy = await this.expandPatterns(sourceDir, patterns);
+    const safePatterns = patterns.filter((pattern) => {
+      if (!this.isSafeRelativePath(pattern)) {
+        result.errors.push({ file: pattern, error: "Pattern must be relative and stay inside source directory" });
+        return false;
+      }
+      return true;
+    });
+
+    const filesToCopy = await this.expandPatterns(sourceDir, safePatterns);
 
     for (const relativePath of filesToCopy) {
+      if (!this.isSafeRelativePath(relativePath)) {
+        result.errors.push({ file: relativePath, error: "Matched file must stay inside source directory" });
+        continue;
+      }
+
       const sourcePath = path.join(sourceDir, relativePath);
       const destPath = path.join(destDir, relativePath);
 
@@ -82,6 +95,10 @@ export class FileCopyService {
     }
 
     return Array.from(allFiles);
+  }
+
+  private isSafeRelativePath(filePath: string): boolean {
+    return !path.isAbsolute(filePath) && !filePath.split(/[\\/]+/).includes("..");
   }
 
   private async copyFile(sourcePath: string, destPath: string): Promise<boolean> {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -401,14 +401,15 @@ export class GitService {
       }
 
       const sampleSize = Math.min(5, lfsFileList.length);
-      const samplesToCheck = [];
+      const shuffled = [...lfsFileList];
       for (let i = 0; i < sampleSize; i++) {
-        const randomIndex = Math.floor(Math.random() * lfsFileList.length);
-        samplesToCheck.push(lfsFileList[randomIndex]);
+        const randomIndex = i + Math.floor(Math.random() * (shuffled.length - i));
+        [shuffled[i], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[i]];
       }
+      const samplesToCheck = shuffled.slice(0, sampleSize);
 
       let retries = 0;
-      const maxRetries = 30;
+      const maxRetries = DEFAULT_CONFIG.LFS_VERIFICATION_MAX_RETRIES;
       const retryDelay = 1000;
 
       while (retries < maxRetries) {
@@ -1031,11 +1032,13 @@ export class GitService {
   }
 
   private async detectDefaultBranch(bareGit: SimpleGit): Promise<string> {
+    const originHeadPrefix = "refs/remotes/origin/";
     try {
       // Try to get the symbolic ref for origin/HEAD
       const headRef = await bareGit.raw(["symbolic-ref", "refs/remotes/origin/HEAD"]);
       // Extract branch name from refs/remotes/origin/main or refs/remotes/origin/master
-      const branch = headRef.trim().split("/").pop();
+      const ref = headRef.trim();
+      const branch = ref.startsWith(originHeadPrefix) ? ref.slice(originHeadPrefix.length) : "";
       if (branch) {
         return branch;
       }
@@ -1044,7 +1047,8 @@ export class GitService {
       try {
         await bareGit.raw(["remote", "set-head", "origin", "-a"]);
         const headRef = await bareGit.raw(["symbolic-ref", "refs/remotes/origin/HEAD"]);
-        const branch = headRef.trim().split("/").pop();
+        const ref = headRef.trim();
+        const branch = ref.startsWith(originHeadPrefix) ? ref.slice(originHeadPrefix.length) : "";
         if (branch) {
           return branch;
         }

--- a/src/services/hook-execution.service.ts
+++ b/src/services/hook-execution.service.ts
@@ -52,17 +52,9 @@ export class HookExecutionService {
     this.killTimers.clear();
 
     for (const child of this.activeProcesses) {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // Process may have already exited
-      }
+      this.terminateChild(child, "SIGTERM");
       const killTimer = setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Process may have already exited
-        }
+        this.terminateChild(child, "SIGKILL");
         this.killTimers.delete(killTimer);
       }, 5000);
       this.killTimers.add(killTimer);
@@ -98,7 +90,7 @@ export class HookExecutionService {
   ): void {
     const child = spawn(command, {
       shell: true,
-      detached: false,
+      detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
       env,
       cwd,
@@ -111,18 +103,9 @@ export class HookExecutionService {
     const timer = setTimeout(() => {
       timedOut = true;
       this.timeoutTimers.delete(timer);
-      this.activeProcesses.delete(child);
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // Process may have already exited
-      }
+      this.terminateChild(child, "SIGTERM");
       const scheduledKillTimer = setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Process may have already exited
-        }
+        this.terminateChild(child, "SIGKILL");
         this.killTimers.delete(scheduledKillTimer);
       }, 5000);
       killTimer = scheduledKillTimer;
@@ -167,9 +150,21 @@ export class HookExecutionService {
         clearTimeout(killTimer);
         this.killTimers.delete(killTimer);
       }
-      if (timedOut) return;
       this.activeProcesses.delete(child);
+      if (timedOut) return;
       callbacks.onComplete?.(command, code);
     });
+  }
+
+  private terminateChild(child: ChildProcess, signal: NodeJS.Signals): void {
+    try {
+      if (process.platform !== "win32" && child.pid) {
+        process.kill(-child.pid, signal);
+        return;
+      }
+      child.kill(signal);
+    } catch {
+      // Process may have already exited.
+    }
   }
 }

--- a/src/services/hook-execution.service.ts
+++ b/src/services/hook-execution.service.ts
@@ -106,6 +106,7 @@ export class HookExecutionService {
 
     this.activeProcesses.add(child);
     let timedOut = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
 
     const timer = setTimeout(() => {
       timedOut = true;
@@ -116,14 +117,15 @@ export class HookExecutionService {
       } catch {
         // Process may have already exited
       }
-      const killTimer = setTimeout(() => {
+      const scheduledKillTimer = setTimeout(() => {
         try {
           child.kill("SIGKILL");
         } catch {
           // Process may have already exited
         }
-        this.killTimers.delete(killTimer);
+        this.killTimers.delete(scheduledKillTimer);
       }, 5000);
+      killTimer = scheduledKillTimer;
       this.killTimers.add(killTimer);
       callbacks.onError?.(command, new Error(`Hook timed out after ${this.timeoutMs}ms`));
     }, this.timeoutMs);
@@ -150,6 +152,10 @@ export class HookExecutionService {
     child.on("error", (error) => {
       clearTimeout(timer);
       this.timeoutTimers.delete(timer);
+      if (killTimer) {
+        clearTimeout(killTimer);
+        this.killTimers.delete(killTimer);
+      }
       this.activeProcesses.delete(child);
       callbacks.onError?.(command, error);
     });
@@ -157,6 +163,10 @@ export class HookExecutionService {
     child.on("close", (code) => {
       clearTimeout(timer);
       this.timeoutTimers.delete(timer);
+      if (killTimer) {
+        clearTimeout(killTimer);
+        this.killTimers.delete(killTimer);
+      }
       if (timedOut) return;
       this.activeProcesses.delete(child);
       callbacks.onComplete?.(command, code);

--- a/src/services/trash-reaper.service.ts
+++ b/src/services/trash-reaper.service.ts
@@ -1,10 +1,10 @@
-import { createHash } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
 import { GIT_CONSTANTS } from "../constants";
 import { formatBytes } from "../utils/disk-space";
 import { getErrorMessage } from "../utils/lfs-error";
+import { computeTrashRootHash } from "../utils/trash-root-hash";
 
 import { summarizeTrashEntries } from "./trash.service";
 
@@ -219,7 +219,7 @@ export class TrashReaperService {
   }
 
   private getTrashRootHash(): string {
-    return createHash("sha256").update(path.resolve(this.trashService.getTrashRoot())).digest("hex").slice(0, 16);
+    return computeTrashRootHash(this.trashService.getTrashRoot());
   }
 
   private warnIfOverThreshold(remaining: TrashEntry[]): void {

--- a/src/services/trash-reaper.service.ts
+++ b/src/services/trash-reaper.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -187,9 +188,21 @@ export class TrashReaperService {
       return;
     }
 
+    const ownPrefix = `${GIT_CONSTANTS.TRASH_REF_PREFIX}${this.getTrashRootHash()}/`;
+    let warnedLegacy = false;
+
     for (const ref of refs) {
       if (!ref.startsWith(GIT_CONSTANTS.TRASH_REF_PREFIX)) continue;
-      const id = ref.slice(GIT_CONSTANTS.TRASH_REF_PREFIX.length);
+      if (!ref.startsWith(ownPrefix)) {
+        const suffix = ref.slice(GIT_CONSTANTS.TRASH_REF_PREFIX.length);
+        if (suffix.length > 0 && !suffix.includes("/") && !warnedLegacy) {
+          this.logger.warn("⚠️ Trash reaper: leaving legacy flat trash pin refs alone");
+          warnedLegacy = true;
+        }
+        continue;
+      }
+
+      const id = ref.slice(ownPrefix.length);
       if (id.length === 0 || id.includes("/")) {
         this.logger.warn(`⚠️ Trash reaper: leaving unexpected ref '${ref}' alone`);
         continue;
@@ -203,6 +216,10 @@ export class TrashReaperService {
         this.logger.warn(`⚠️ Trash reaper: failed to delete orphaned pin ref '${ref}': ${getErrorMessage(error)}`);
       }
     }
+  }
+
+  private getTrashRootHash(): string {
+    return createHash("sha256").update(path.resolve(this.trashService.getTrashRoot())).digest("hex").slice(0, 16);
   }
 
   private warnIfOverThreshold(remaining: TrashEntry[]): void {

--- a/src/services/trash.service.ts
+++ b/src/services/trash.service.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "crypto";
+import { randomBytes } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -9,6 +9,7 @@ import { calculateDirectorySize } from "../utils/disk-space";
 import { probePathExists } from "../utils/file-exists";
 import { filenameTimestamp } from "../utils/filename-timestamp";
 import { getErrorMessage } from "../utils/lfs-error";
+import { computeTrashRootHash } from "../utils/trash-root-hash";
 
 import type { GitService } from "./git.service";
 import type { Logger } from "./logger.service";
@@ -539,6 +540,6 @@ export class TrashService {
   }
 
   private getTrashRootHash(): string {
-    return createHash("sha256").update(path.resolve(this.getTrashRoot())).digest("hex").slice(0, 16);
+    return computeTrashRootHash(this.getTrashRoot());
   }
 }

--- a/src/services/trash.service.ts
+++ b/src/services/trash.service.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import * as fs from "fs/promises";
 import * as path from "path";
 
@@ -467,7 +467,7 @@ export class TrashService {
   // Pin failure degrades to a files-only trash entry rather than blocking the
   // removal — the payload itself is still fully preserved either way.
   private async createPinRef(id: string, headOid: string): Promise<string | null> {
-    const refName = `${GIT_CONSTANTS.TRASH_REF_PREFIX}${id}`;
+    const refName = `${GIT_CONSTANTS.TRASH_REF_PREFIX}${this.getTrashRootHash()}/${id}`;
     try {
       await this.gitService.updateRef(refName, headOid);
       return refName;
@@ -528,7 +528,7 @@ export class TrashService {
     );
   }
 
-  // The id doubles as a refname component (refs/sync-worktrees/trash/<id>).
+  // The id becomes a refname component under the trash-root namespace.
   // The timestamp prefix and hex suffix rule out leading dots and ".lock"
   // endings, but ".." inside the name would still make the ref invalid and
   // silently degrade the entry to files-only.
@@ -536,5 +536,9 @@ export class TrashService {
     const timestamp = filenameTimestamp(deletedAt);
     const safeName = baseName.replace(/[^A-Za-z0-9._-]/g, "_").replace(/\.{2,}/g, "_");
     return `${timestamp}-${safeName}-${randomBytes(3).toString("hex")}`;
+  }
+
+  private getTrashRootHash(): string {
+    return createHash("sha256").update(path.resolve(this.getTrashRoot())).digest("hex").slice(0, 16);
   }
 }

--- a/src/services/worktree-metadata.service.ts
+++ b/src/services/worktree-metadata.service.ts
@@ -45,17 +45,18 @@ export class WorktreeMetadataService {
     return this.getMetadataPath(bareRepoPath, worktreeDirName);
   }
 
-  async saveMetadata(bareRepoPath: string, worktreeName: string, metadata: SyncMetadata): Promise<void> {
+  async saveMetadata(bareRepoPath: string, worktreeName: string, metadata: SyncMetadata): Promise<boolean> {
     const metadataPath = await this.getMetadataPath(bareRepoPath, worktreeName);
     const existing = await this.loadMetadata(bareRepoPath, worktreeName);
-    if (existing && existing.upstreamBranch !== metadata.upstreamBranch) {
+    if (existing && (await this.validateMetadata(existing)) && existing.upstreamBranch !== metadata.upstreamBranch) {
       this.logger.warn(
         `Refusing to overwrite metadata for ${worktreeName}: existing upstream ${existing.upstreamBranch} differs from ${metadata.upstreamBranch}`,
       );
-      return;
+      return false;
     }
     await fs.mkdir(path.dirname(metadataPath), { recursive: true });
     await atomicWriteFile(metadataPath, JSON.stringify(metadata, null, 2));
+    return true;
   }
 
   async loadMetadata(bareRepoPath: string, worktreeName: string): Promise<SyncMetadata | null> {
@@ -186,7 +187,7 @@ export class WorktreeMetadataService {
 
         const parentBranch = defaultBranch || GIT_CONSTANTS.DEFAULT_BRANCH;
 
-        await this.createInitialMetadataFromPath(
+        const created = await this.createInitialMetadataFromPath(
           bareRepoPath,
           worktreePath,
           currentCommit.trim(),
@@ -194,7 +195,11 @@ export class WorktreeMetadataService {
           parentBranch,
           currentCommit.trim(),
         );
-        this.logger.info(`  ✅ Created metadata for ${worktreeDirName}`);
+        if (created) {
+          this.logger.info(`  ✅ Created metadata for ${worktreeDirName}`);
+        } else {
+          this.logger.warn(`  ⚠️ Metadata for ${worktreeDirName} was not overwritten`);
+        }
         return;
       } catch (error) {
         this.logger.error(`  ❌ Failed to create metadata`, error);
@@ -252,7 +257,7 @@ export class WorktreeMetadataService {
     upstreamBranch: string,
     parentBranch: string,
     parentCommit: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const metadata: SyncMetadata = {
       lastSyncCommit: commit,
       lastSyncDate: new Date().toISOString(),
@@ -270,7 +275,7 @@ export class WorktreeMetadataService {
       ],
     };
 
-    await this.saveMetadata(bareRepoPath, worktreeName, metadata);
+    return this.saveMetadata(bareRepoPath, worktreeName, metadata);
   }
 
   async createInitialMetadataFromPath(
@@ -280,7 +285,7 @@ export class WorktreeMetadataService {
     upstreamBranch: string,
     parentBranch: string,
     parentCommit: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const worktreeDirName = this.getWorktreeDirectoryName(worktreePath);
     const metadata: SyncMetadata = {
       lastSyncCommit: commit,
@@ -299,7 +304,7 @@ export class WorktreeMetadataService {
       ],
     };
 
-    await this.saveMetadata(bareRepoPath, worktreeDirName, metadata);
+    return this.saveMetadata(bareRepoPath, worktreeDirName, metadata);
   }
 
   async validateMetadata(metadata: SyncMetadata): Promise<boolean> {

--- a/src/services/worktree-metadata.service.ts
+++ b/src/services/worktree-metadata.service.ts
@@ -18,9 +18,8 @@ export class WorktreeMetadataService {
   }
 
   /**
-   * Gets the internal worktree directory name from a worktree path.
-   * Git uses the basename of the worktree path as the internal directory name.
-   * For example: /worktrees/fix/test-branch -> test-branch (not fix/test-branch)
+   * Metadata is keyed by worktree path basename. Branch names are sanitized
+   * into unique basenames before worktrees are created.
    */
   private getWorktreeDirectoryName(worktreePath: string): string {
     return path.basename(worktreePath);
@@ -48,6 +47,13 @@ export class WorktreeMetadataService {
 
   async saveMetadata(bareRepoPath: string, worktreeName: string, metadata: SyncMetadata): Promise<void> {
     const metadataPath = await this.getMetadataPath(bareRepoPath, worktreeName);
+    const existing = await this.loadMetadata(bareRepoPath, worktreeName);
+    if (existing && existing.upstreamBranch !== metadata.upstreamBranch) {
+      this.logger.warn(
+        `Refusing to overwrite metadata for ${worktreeName}: existing upstream ${existing.upstreamBranch} differs from ${metadata.upstreamBranch}`,
+      );
+      return;
+    }
     await fs.mkdir(path.dirname(metadataPath), { recursive: true });
     await atomicWriteFile(metadataPath, JSON.stringify(metadata, null, 2));
   }

--- a/src/services/worktree-mode-sync-runner.ts
+++ b/src/services/worktree-mode-sync-runner.ts
@@ -10,6 +10,7 @@ import { filterBranchesByAge, formatDuration } from "../utils/date-filter";
 import { probePathExists } from "../utils/file-exists";
 import { getErrorMessage, isLfsError } from "../utils/lfs-error";
 import { getRemovalAuditLogPath } from "../utils/lock-path";
+import { normalizePathForCompare } from "../utils/path-compare";
 import { quarantineDirectory } from "../utils/quarantine";
 
 import { PathResolutionService } from "./path-resolution.service";
@@ -900,6 +901,11 @@ export class WorktreeModeSyncRunner {
         for (const dir of orphanedDirs) {
           const dirPath = path.join(this.config.worktreeDir, dir);
           try {
+            if (normalizePathForCompare(dirPath) === normalizePathForCompare(this.gitService.getBareRepoPath())) {
+              this.logger.warn(`  - ⚠️ Skipping orphaned directory ${dir}: matches configured bareRepoDir`);
+              continue;
+            }
+
             const stat = await fs.stat(dirPath);
             if (!stat.isDirectory()) {
               continue;
@@ -962,6 +968,18 @@ export class WorktreeModeSyncRunner {
     outcome: SyncOutcomeAccumulator,
   ): Promise<void> {
     this.logger.info(`⚠️  Branch '${worktree.branch}' has diverged from upstream. Analyzing...`);
+
+    if (await this.gitService.hasStashedChanges(worktree.path)) {
+      this.logger.warn(
+        `⚠️  Skipping diverged replace for '${worktree.branch}' because it has stashed changes. Pop/apply or drop the stash first.`,
+      );
+      outcome.recordSkipped("worktree", "stash_present", {
+        branch: worktree.branch,
+        path: worktree.path,
+        message: "stashed changes present",
+      });
+      return;
+    }
 
     const treesIdentical = await this.gitService.compareTreeContent(worktree.path, worktree.branch);
 

--- a/src/services/worktree-mode-sync-runner.ts
+++ b/src/services/worktree-mode-sync-runner.ts
@@ -251,9 +251,7 @@ export class WorktreeModeSyncRunner {
     phaseTimer: PhaseTimer,
     outcome: SyncOutcomeAccumulator,
   ): Promise<void> {
-    const maxConcurrent =
-      this.config.parallelism?.maxWorktreeCreation ?? DEFAULT_CONFIG.PARALLELISM.MAX_WORKTREE_CREATION;
-    phaseTimer.startPhase("Phase 2: Create", maxConcurrent);
+    phaseTimer.startPhase("Phase 2: Create");
     this.progressEmitter.emit({ phase: "create", message: "Creating worktrees for new branches" });
 
     await this.createNewWorktrees(syncPlan.create, outcome);
@@ -361,8 +359,7 @@ export class WorktreeModeSyncRunner {
     phaseTimer: PhaseTimer,
     outcome: SyncOutcomeAccumulator,
   ): Promise<void> {
-    const maxConcurrent = this.config.parallelism?.maxStatusChecks ?? DEFAULT_CONFIG.PARALLELISM.MAX_STATUS_CHECKS;
-    phaseTimer.startPhase("Phase 3: Prune", maxConcurrent);
+    phaseTimer.startPhase("Phase 3: Prune");
     this.progressEmitter.emit({ phase: "prune", message: "Pruning stale worktrees" });
 
     await this.pruneOldWorktrees(actions, outcome);
@@ -671,9 +668,7 @@ export class WorktreeModeSyncRunner {
     phaseTimer: PhaseTimer,
     outcome: SyncOutcomeAccumulator,
   ): Promise<void> {
-    const maxConcurrent =
-      this.config.parallelism?.maxWorktreeUpdates ?? DEFAULT_CONFIG.PARALLELISM.MAX_WORKTREE_UPDATES;
-    phaseTimer.startPhase("Phase 4: Update", maxConcurrent);
+    phaseTimer.startPhase("Phase 4: Update");
     this.progressEmitter.emit({ phase: "update", message: "Updating existing worktrees" });
 
     await this.updateExistingWorktrees(actions, outcome);

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -165,6 +165,13 @@ export class WorktreeSyncService {
     return this.gitService;
   }
 
+  async getDefaultBranch(): Promise<string> {
+    if (this.cloneSyncService) {
+      return this.cloneSyncService.resolveBranch();
+    }
+    return this.gitService.getDefaultBranch();
+  }
+
   // Restore must hold the repo lock: the reaper, prune, and gc all mutate the
   // same trash entries and refs at the tail of a sync. wait:true queues behind
   // an in-flight sync instead of failing fast — restores are explicit user

--- a/src/types/__tests__/public-config-types.test.ts
+++ b/src/types/__tests__/public-config-types.test.ts
@@ -16,7 +16,6 @@ type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ?
  */
 type CommonConfigKeys =
   | "cronSchedule"
-  | "runOnce"
   | "retry"
   | "parallelism"
   | "skipLfs"
@@ -33,6 +32,7 @@ type WorktreeOnlyConfigKeys =
   | "updateExistingWorktrees"
   | "trash";
 type CloneOnlyConfigKeys = "branch" | "depth";
+type DefaultsOnlyConfigKeys = "runOnce";
 type DiscriminantConfigKeys = "mode";
 type BaseIdentityConfigKeys = "repoUrl" | "worktreeDir";
 // Set internally or read only at runtime — intentionally absent from the public input surface.
@@ -42,6 +42,7 @@ type ClassifiedConfigKeys =
   | CommonConfigKeys
   | WorktreeOnlyConfigKeys
   | CloneOnlyConfigKeys
+  | DefaultsOnlyConfigKeys
   | DiscriminantConfigKeys
   | BaseIdentityConfigKeys
   | InternalOnlyConfigKeys;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -293,7 +293,6 @@ export type SyncWorktreesTrashConfig = TrashConfig;
 
 interface SyncWorktreesCommonConfigFields {
   cronSchedule?: string;
-  runOnce?: boolean;
   retry?: SyncWorktreesRetryConfig;
   parallelism?: SyncWorktreesParallelismConfig;
   skipLfs?: boolean;
@@ -336,7 +335,9 @@ export interface SyncWorktreesWorktreeRepository extends SyncWorktreesRepository
 
 export type SyncWorktreesRepository = SyncWorktreesCloneRepository | SyncWorktreesWorktreeRepository;
 
-type SyncWorktreesDefaultsBase = SyncWorktreesCommonConfigFields;
+interface SyncWorktreesDefaultsBase extends SyncWorktreesCommonConfigFields {
+  runOnce?: boolean;
+}
 
 export interface SyncWorktreesCloneDefaults extends SyncWorktreesDefaultsBase {
   mode: "clone";

--- a/src/utils/__tests__/config-generator.test.ts
+++ b/src/utils/__tests__/config-generator.test.ts
@@ -121,6 +121,22 @@ describe("Config Generator", () => {
       expect(content).toContain('mode: "clone"');
     });
 
+    it("deduplicates generated repository names", async () => {
+      const input = makeInput([
+        { repoUrl: "https://github.com/one/app.git", worktreeDir: "/path/one", mode: "worktree" },
+        { repoUrl: "https://github.com/two/app.git", worktreeDir: "/path/two", mode: "worktree" },
+        { repoUrl: "https://github.com/three/app.git", worktreeDir: "/path/three", mode: "clone" },
+      ]);
+
+      const configPath = path.join(tempDir, "test.config.js");
+      await generateConfigFile(input, configPath);
+
+      const content = await fs.readFile(configPath, "utf-8");
+      expect(content).toContain('name: "app"');
+      expect(content).toContain('name: "app-2"');
+      expect(content).toContain('name: "app-3"');
+    });
+
     it("appends a commented cheatsheet of advanced options", async () => {
       const input = makeInput([
         { repoUrl: "https://github.com/user/repo.git", worktreeDir: "/path/to/worktrees", mode: "worktree" },

--- a/src/utils/__tests__/config-generator.test.ts
+++ b/src/utils/__tests__/config-generator.test.ts
@@ -137,6 +137,21 @@ describe("Config Generator", () => {
       expect(content).toContain('name: "app-3"');
     });
 
+    it("deduplicates generated names against already-emitted suffixed names", async () => {
+      const input = makeInput([
+        { repoUrl: "https://github.com/one/app.git", worktreeDir: "/path/one", mode: "worktree" },
+        { repoUrl: "https://github.com/two/app.git", worktreeDir: "/path/two", mode: "worktree" },
+        { repoUrl: "https://github.com/three/app-2.git", worktreeDir: "/path/three", mode: "clone" },
+      ]);
+
+      const configPath = path.join(tempDir, "test.config.js");
+      await generateConfigFile(input, configPath);
+
+      const config = await new ConfigLoaderService().loadConfigFile(configPath);
+      const names = config.repositories.map((repo) => repo.name);
+      expect(names).toEqual(["app", "app-2", "app-2-2"]);
+    });
+
     it("appends a commented cheatsheet of advanced options", async () => {
       const input = makeInput([
         { repoUrl: "https://github.com/user/repo.git", worktreeDir: "/path/to/worktrees", mode: "worktree" },

--- a/src/utils/__tests__/git-url.test.ts
+++ b/src/utils/__tests__/git-url.test.ts
@@ -30,6 +30,12 @@ describe("git-url utilities", () => {
       expect(extractRepoNameFromUrl("file:///home/user/repos/my-project")).toBe("my-project");
     });
 
+    it("should handle absolute local paths", () => {
+      expect(extractRepoNameFromUrl("/srv/git/repo.git")).toBe("repo");
+      expect(extractRepoNameFromUrl("/srv/git/repo.git/")).toBe("repo");
+      expect(extractRepoNameFromUrl("C:\\srv\\git\\repo.git\\")).toBe("repo");
+    });
+
     it("should handle URLs with different domains", () => {
       expect(extractRepoNameFromUrl("https://bitbucket.org/user/repo.git")).toBe("repo");
       expect(extractRepoNameFromUrl("git@bitbucket.org:user/repo.git")).toBe("repo");
@@ -51,7 +57,7 @@ describe("git-url utilities", () => {
     it("should throw error for invalid URLs", () => {
       expect(() => extractRepoNameFromUrl("not-a-url")).toThrow("Invalid Git URL format");
       expect(() => extractRepoNameFromUrl("")).toThrow("Invalid Git URL format");
-      expect(() => extractRepoNameFromUrl("/local/path")).toThrow("Invalid Git URL format");
+      expect(() => extractRepoNameFromUrl("relative/path")).toThrow("Invalid Git URL format");
     });
   });
 

--- a/src/utils/__tests__/interactive.test.ts
+++ b/src/utils/__tests__/interactive.test.ts
@@ -232,4 +232,24 @@ describe("promptForInitConfig", () => {
       expect(depthValidate("1.5")).toBe("Depth must be a positive integer");
     }
   });
+
+  it("validates cron schedules with node-cron", async () => {
+    mockInput
+      .mockResolvedValueOnce("https://github.com/user/repo.git")
+      .mockResolvedValueOnce("/path/to/worktrees")
+      .mockResolvedValueOnce("0 * * * *");
+    mockSelect.mockResolvedValueOnce("worktree");
+    mockConfirm.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+    await promptForInitConfig();
+
+    const cronValidate = mockInput.mock.calls.find((call) => call[0].message?.includes("cron schedule"))?.[0].validate;
+
+    expect(cronValidate).toBeDefined();
+    if (cronValidate) {
+      expect(cronValidate("a b c d e")).toBe("Invalid cron pattern. Expected format: '* * * * *'");
+      expect(cronValidate("")).toBe("Cron schedule is required");
+      expect(cronValidate("0 * * * *")).toBe(true);
+    }
+  });
 });

--- a/src/utils/__tests__/mcp-registration.test.ts
+++ b/src/utils/__tests__/mcp-registration.test.ts
@@ -24,9 +24,10 @@ function enoent(): NodeJS.ErrnoException {
   return err;
 }
 
-function exitFailure(): NodeJS.ErrnoException {
+function exitFailure(stderr = "sync-worktrees MCP server not found"): NodeJS.ErrnoException {
   const err = new Error("command failed") as NodeJS.ErrnoException;
-  err.code = 1 as unknown as string; // `mcp get` exits 1 = definitely not registered
+  err.code = 1 as unknown as string;
+  (err as NodeJS.ErrnoException & { stderr: string }).stderr = stderr;
   return err;
 }
 
@@ -40,7 +41,7 @@ function ambiguousFailure(): NodeJS.ErrnoException {
 function routeExecFile(handler: (tool: string, verb: string) => NodeJS.ErrnoException | null): void {
   mockExecFile.mockImplementation((tool, args, _opts, cb) => {
     const result = handler(tool, args[1]);
-    cb(result, "", "");
+    cb(result, "", result ? ((result as NodeJS.ErrnoException & { stderr?: string }).stderr ?? "") : "");
   });
 }
 
@@ -92,6 +93,16 @@ describe("maybeRegisterMcpClients", () => {
 
   it("does not prompt when the probe fails ambiguously (only ask when we know it's missing)", async () => {
     routeExecFile(() => ambiguousFailure()); // e.g. timeout / unexpected exit / no `mcp get`
+
+    await maybeRegisterMcpClients();
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+    const addCalls = mockExecFile.mock.calls.filter((call) => call[1][1] === "add");
+    expect(addCalls).toHaveLength(0);
+  });
+
+  it("does not prompt or register on unrelated exit-1 probe errors", async () => {
+    routeExecFile(() => exitFailure("failed to read corrupt config"));
 
     await maybeRegisterMcpClients();
 

--- a/src/utils/__tests__/signal-handlers.test.ts
+++ b/src/utils/__tests__/signal-handlers.test.ts
@@ -44,6 +44,18 @@ describe("setupSignalHandlers", () => {
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
+  it("uses the configured cleanup exit code after first signal cleanup", async () => {
+    const handle = setupSignalHandlers({ process: proc, exit, log, exitAfterCleanupCode: 130 });
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    handle.register(cleanup);
+
+    proc.emit("SIGINT");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(cleanup).toHaveBeenCalledWith(true);
+    expect(exitMock).toHaveBeenCalledWith(130);
+  });
+
   it("force-exits 130 if cleanup exceeds watchdog window", async () => {
     const handle = setupSignalHandlers({ process: proc, exit, log, forceExitMs: 3000 });
     handle.register(() => new Promise(() => {}));

--- a/src/utils/__tests__/timing.test.ts
+++ b/src/utils/__tests__/timing.test.ts
@@ -93,7 +93,7 @@ describe("PhaseTimer", () => {
   it("should not calculate efficiency for parallel operations without per-item timings", () => {
     const phaseTimer = new PhaseTimer();
 
-    phaseTimer.startPhase("Create", 3);
+    phaseTimer.startPhase("Create");
     vi.advanceTimersByTime(3000);
     phaseTimer.setPhaseCount("Create", 9);
     phaseTimer.endPhase();
@@ -106,7 +106,7 @@ describe("PhaseTimer", () => {
   it("should not calculate efficiency for sequential operations", () => {
     const phaseTimer = new PhaseTimer();
 
-    phaseTimer.startPhase("Fetch", 1);
+    phaseTimer.startPhase("Fetch");
     vi.advanceTimersByTime(1000);
     phaseTimer.setPhaseCount("Fetch", 1);
     phaseTimer.endPhase();

--- a/src/utils/__tests__/timing.test.ts
+++ b/src/utils/__tests__/timing.test.ts
@@ -90,7 +90,7 @@ describe("PhaseTimer", () => {
     expect(results[0].count).toBe(15);
   });
 
-  it("should calculate efficiency for parallel operations", () => {
+  it("should not calculate efficiency for parallel operations without per-item timings", () => {
     const phaseTimer = new PhaseTimer();
 
     phaseTimer.startPhase("Create", 3);
@@ -100,7 +100,7 @@ describe("PhaseTimer", () => {
 
     const results = phaseTimer.getResults();
 
-    expect(results[0].efficiency).toBe(300);
+    expect(results[0]).not.toHaveProperty("efficiency");
   });
 
   it("should not calculate efficiency for sequential operations", () => {
@@ -113,7 +113,7 @@ describe("PhaseTimer", () => {
 
     const results = phaseTimer.getResults();
 
-    expect(results[0].efficiency).toBeUndefined();
+    expect(results[0]).not.toHaveProperty("efficiency");
   });
 
   it("should handle zero count", () => {
@@ -127,7 +127,7 @@ describe("PhaseTimer", () => {
     const results = phaseTimer.getResults();
 
     expect(results[0].count).toBe(0);
-    expect(results[0].efficiency).toBeUndefined();
+    expect(results[0]).not.toHaveProperty("efficiency");
   });
 });
 
@@ -154,9 +154,9 @@ describe("formatTimingTable", () => {
   it("should format timing table with all phases", () => {
     const phaseResults = [
       { name: "Phase 1: Fetch", duration: 45000 },
-      { name: "Phase 2: Create", duration: 30000, count: 15, efficiency: 100 },
-      { name: "Phase 3: Prune", duration: 20000, count: 3, efficiency: 300 },
-      { name: "Phase 4: Update", duration: 50000, count: 12, efficiency: 240 },
+      { name: "Phase 2: Create", duration: 30000, count: 15 },
+      { name: "Phase 3: Prune", duration: 20000, count: 3 },
+      { name: "Phase 4: Update", duration: 50000, count: 12 },
       { name: "Phase 5: Cleanup", duration: 5000 },
     ];
 
@@ -168,9 +168,9 @@ describe("formatTimingTable", () => {
     expect(table).toContain("Phase 1: Fetch");
     expect(table).toContain("45.0s");
     expect(table).toContain("Phase 2: Create (15)");
-    expect(table).toContain("100%");
     expect(table).toContain("Phase 3: Prune (3)");
-    expect(table).toContain("300%");
+    expect(table).not.toContain("Efficiency");
+    expect(table).not.toContain("%");
   });
 
   it("should handle phases without count or efficiency", () => {

--- a/src/utils/config-generator.ts
+++ b/src/utils/config-generator.ts
@@ -81,9 +81,9 @@ function toConfigRelativePath(configDir: string, target: string): string {
   return segments[0] === ".." ? relative : `./${relative}`;
 }
 
-function buildRepository(repo: InitRepositoryInput, configDir: string): SerializableObject {
+function buildRepository(repo: InitRepositoryInput, configDir: string, name: string): SerializableObject {
   const result: SerializableObject = {
-    name: extractRepoNameFromUrl(repo.repoUrl),
+    name,
     repoUrl: repo.repoUrl,
     worktreeDir: toConfigRelativePath(configDir, repo.worktreeDir),
   };
@@ -103,6 +103,17 @@ function buildRepository(repo: InitRepositoryInput, configDir: string): Serializ
   return result;
 }
 
+function uniqueRepositoryNames(repositories: InitRepositoryInput[]): string[] {
+  const counts = new Map<string, number>();
+
+  return repositories.map((repo) => {
+    const baseName = extractRepoNameFromUrl(repo.repoUrl);
+    const count = (counts.get(baseName) ?? 0) + 1;
+    counts.set(baseName, count);
+    return count === 1 ? baseName : `${baseName}-${count}`;
+  });
+}
+
 export async function generateConfigFile(
   input: InitConfigInput,
   configPath: string,
@@ -111,11 +122,12 @@ export async function generateConfigFile(
   const configDir = path.dirname(configPath);
   await fs.mkdir(configDir, { recursive: true });
 
+  const names = uniqueRepositoryNames(input.repositories);
   const configObject: SerializableObject = {
     defaults: {
       cronSchedule: input.cronSchedule,
     },
-    repositories: input.repositories.map((repo) => buildRepository(repo, configDir)),
+    repositories: input.repositories.map((repo, index) => buildRepository(repo, configDir, names[index])),
   };
 
   const configContent = `// @ts-check

--- a/src/utils/config-generator.ts
+++ b/src/utils/config-generator.ts
@@ -104,13 +104,18 @@ function buildRepository(repo: InitRepositoryInput, configDir: string, name: str
 }
 
 function uniqueRepositoryNames(repositories: InitRepositoryInput[]): string[] {
-  const counts = new Map<string, number>();
+  const usedNames = new Set<string>();
 
   return repositories.map((repo) => {
     const baseName = extractRepoNameFromUrl(repo.repoUrl);
-    const count = (counts.get(baseName) ?? 0) + 1;
-    counts.set(baseName, count);
-    return count === 1 ? baseName : `${baseName}-${count}`;
+    let candidate = baseName;
+    let suffix = 2;
+    while (usedNames.has(candidate)) {
+      candidate = `${baseName}-${suffix}`;
+      suffix++;
+    }
+    usedNames.add(candidate);
+    return candidate;
   });
 }
 

--- a/src/utils/git-url.ts
+++ b/src/utils/git-url.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 /**
  * Extracts the repository name from a Git URL
  * @param gitUrl - The Git URL (HTTPS or SSH format)
@@ -7,6 +9,12 @@
 export function extractRepoNameFromUrl(gitUrl: string): string {
   // Remove trailing spaces
   const url = gitUrl.trim();
+
+  if (/^(\/|[A-Za-z]:\\)/.test(url)) {
+    const trimmedPath = url.replace(/[\\/]+$/, "");
+    const repoName = /^[A-Za-z]:\\/.test(trimmedPath) ? path.win32.basename(trimmedPath) : path.basename(trimmedPath);
+    if (repoName) return repoName.replace(/\.git$/, "");
+  }
 
   // Handle SSH format: git@github.com:user/repo.git or ssh://git@domain/path/repo.git
   const sshMatch = url.match(/^git@[^:]+:(?:.+\/)?([^/]+?)(?:\.git)?$/);

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 
 import { confirm, input, select } from "@inquirer/prompts";
+import * as cron from "node-cron";
 
 import { extractRepoNameFromUrl } from "./git-url";
 
@@ -131,7 +132,7 @@ export async function promptForInitConfig(): Promise<InitConfigInput> {
       if (!value.trim()) {
         return "Cron schedule is required";
       }
-      if (value.trim().split(/\s+/).length < 5) {
+      if (!cron.validate(value.trim())) {
         return "Invalid cron pattern. Expected format: '* * * * *'";
       }
       return true;

--- a/src/utils/mcp-registration.ts
+++ b/src/utils/mcp-registration.ts
@@ -23,6 +23,10 @@ const MCP_CLIENTS: McpClient[] = [
 
 type ClientStatus = "absent" | "registered" | "unregistered" | "unknown";
 
+function isMissingServerOutput(output: string): boolean {
+  return /(not found|not registered|does not exist|unknown server|no MCP server)/i.test(output);
+}
+
 async function probeClient(tool: string): Promise<ClientStatus> {
   try {
     await execFileAsync(tool, ["mcp", "get", MCP_SERVER_NAME], { timeout: 15_000 });
@@ -34,7 +38,10 @@ async function probeClient(tool: string): Promise<ClientStatus> {
       return "absent"; // CLI not installed
     }
     if (code === 1) {
-      return "unregistered"; // `mcp get` exits 1 only when the server isn't there
+      const output = `${(error as { stdout?: string }).stdout ?? ""}\n${(error as { stderr?: string }).stderr ?? ""}`;
+      if (isMissingServerOutput(output)) {
+        return "unregistered";
+      }
     }
     // Timeout, unexpected exit code, or an older CLI without `mcp get` — we don't
     // actually know it's missing, so don't offer to add it.

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -51,7 +51,11 @@ const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "maxAttempts">> & { maxAttemp
       return true;
     }
 
-    if (err.code === "EBUSY" || err.code === "ENOENT" || err.code === "EACCES") {
+    if (err.code === "EACCES" || err.code === "EPERM" || err.code === "EROFS" || err.code === "ENOSPC") {
+      return false;
+    }
+
+    if (err.code === "EBUSY") {
       return true;
     }
 
@@ -71,6 +75,10 @@ const DEFAULT_OPTIONS: Required<Omit<RetryOptions, "maxAttempts">> & { maxAttemp
 
 export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
+  if (opts.maxAttempts !== "unlimited" && (!Number.isFinite(opts.maxAttempts) || opts.maxAttempts < 1)) {
+    throw new Error("maxAttempts must be 'unlimited' or a finite positive number");
+  }
+
   let attempt = 1;
   let lfsAttempt = 0;
   const lfsContext: LfsErrorContext = { isLfsError: false };

--- a/src/utils/signal-handlers.ts
+++ b/src/utils/signal-handlers.ts
@@ -2,6 +2,7 @@ export type CleanupFn = (fast: boolean) => void | Promise<void>;
 
 export interface SignalHandlerOptions {
   forceExitMs?: number;
+  exitAfterCleanupCode?: number;
   log?: (message: string) => void;
   exit?: (code: number) => void;
   process?: NodeJS.EventEmitter;
@@ -16,6 +17,7 @@ export const DEFAULT_FORCE_EXIT_MS = 3000;
 
 export function setupSignalHandlers(options: SignalHandlerOptions = {}): SignalHandlerHandle {
   const forceExitMs = options.forceExitMs ?? DEFAULT_FORCE_EXIT_MS;
+  const exitAfterCleanupCode = options.exitAfterCleanupCode ?? 0;
   const log = options.log ?? ((msg: string): void => console.log(msg));
   const exit = options.exit ?? ((code: number): void => process.exit(code));
   const target = options.process ?? process;
@@ -42,7 +44,7 @@ export function setupSignalHandlers(options: SignalHandlerOptions = {}): SignalH
 
     void Promise.allSettled(cleanupFns.map((fn) => Promise.resolve().then(() => fn(true)))).then(() => {
       clearTimeout(watchdog);
-      exit(0);
+      exit(exitAfterCleanupCode);
     });
   };
 

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -26,15 +26,15 @@ export class Timer {
 }
 
 export class PhaseTimer {
-  private phases: Map<string, { timer: Timer; count?: number; parallelism?: number }> = new Map();
+  private phases: Map<string, { timer: Timer; count?: number }> = new Map();
   private currentPhase?: string;
 
-  startPhase(name: string, parallelism?: number): void {
+  startPhase(name: string): void {
     if (this.currentPhase) {
       this.endPhase();
     }
     this.currentPhase = name;
-    this.phases.set(name, { timer: new Timer(), parallelism });
+    this.phases.set(name, { timer: new Timer() });
   }
 
   endPhase(): void {

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -4,7 +4,6 @@ export interface TimingResult {
   name: string;
   duration: number;
   count?: number;
-  efficiency?: number;
 }
 
 export class Timer {
@@ -62,21 +61,13 @@ export class PhaseTimer {
 
     const results: TimingResult[] = [];
 
-    for (const [name, { timer, count, parallelism }] of this.phases.entries()) {
+    for (const [name, { timer, count }] of this.phases.entries()) {
       const duration = timer.getDuration();
       const result: TimingResult = {
         name,
         duration,
         count,
       };
-
-      if (count && count > 0 && parallelism && parallelism > 1) {
-        const batches = Math.ceil(count / parallelism);
-        const avgTimePerBatch = duration / batches;
-        const theoreticalSequentialTime = count * avgTimePerBatch;
-        result.efficiency =
-          theoreticalSequentialTime > 0 ? Math.round((theoreticalSequentialTime / duration) * 100) : 100;
-      }
 
       results.push(result);
     }
@@ -101,17 +92,17 @@ export function formatTimingTable(totalDuration: number, phaseResults: TimingRes
   const header = repoName ? `Performance Summary - [${repoName}]` : "Performance Summary";
 
   const table = new Table({
-    head: ["Operation", "Duration", "Efficiency"],
-    colWidths: [35, 12, 12],
+    head: ["Operation", "Duration"],
+    colWidths: [35, 12],
     style: {
       head: ["cyan", "bold"],
       border: ["gray"],
     },
   });
 
-  table.push([{ colSpan: 3, content: header, hAlign: "center" }]);
+  table.push([{ colSpan: 2, content: header, hAlign: "center" }]);
 
-  table.push(["Total Sync", formatDuration(totalDuration), ""]);
+  table.push(["Total Sync", formatDuration(totalDuration)]);
 
   for (let i = 0; i < phaseResults.length; i++) {
     const result = phaseResults[i];
@@ -119,9 +110,8 @@ export function formatTimingTable(totalDuration: number, phaseResults: TimingRes
     const countStr = result.count ? ` (${result.count})` : "";
     const prefix = isLast ? "└─" : "├─";
     const name = `  ${prefix} ${result.name}${countStr}`;
-    const efficiency = result.efficiency ? `${result.efficiency}%` : "";
 
-    table.push([name, formatDuration(result.duration), efficiency]);
+    table.push([name, formatDuration(result.duration)]);
   }
 
   return table.toString();

--- a/src/utils/trash-root-hash.ts
+++ b/src/utils/trash-root-hash.ts
@@ -1,0 +1,6 @@
+import { createHash } from "crypto";
+import * as path from "path";
+
+export function computeTrashRootHash(trashRoot: string): string {
+  return createHash("sha256").update(path.resolve(trashRoot)).digest("hex").slice(0, 16);
+}


### PR DESCRIPTION
## Summary

Implements all 20 findings from a full-codebase review. The findings live in `REVIEW_FINDINGS.md` (included in this PR) as self-contained specs with per-finding acceptance criteria and status checkboxes — all now marked done. Two design items (D1 hash-suffix naming, D2 GitService decomposition) are deliberately left open pending a maintainer decision.

Implementation was done by Codex CLI in five batches, each independently reviewed against the spec and verified with `pnpm lint && pnpm typecheck && pnpm test` before proceeding.

## Changelog

### High severity
- **F1** — Config validation rejects `bareRepoDir` nested in `worktreeDir` (and vice versa, case-folded); orphan cleanup additionally skips any directory matching the bare repo path. Prevents `fs.rm -rf` of the shared object database.
- **F2** — `filesToCopyOnBranchCreate` was functionally broken (loader resolved patterns to absolute paths, mangling the glob + join). Patterns now stay relative end-to-end; absolute and `..`-escaping patterns are rejected into `result.errors`.
- **F3** — MCP `update_worktree` fetches the worktree's branch before the ff-merge (no more stale "success"); `create_worktree` runs `fetchAll` before the branch-existence matrix (no more divergent duplicate branches).
- **F4** — Worktree-mode default-branch detection strips only the `refs/remotes/origin/` prefix, so defaults like `release/2024` initialize correctly.

### Medium severity
- **F5** — Diverged-replace skips worktrees with stashed changes (recorded as `stash_present` skip) instead of deleting the admin dir and losing the stash.
- **F6** — A rejected sync always sets exit code 1 (soft skips no longer mask hard failures); SIGINT/SIGTERM during runOnce exits 130; per-repo `runOnce` is rejected at validation in favor of `defaults.runOnce` (option b from the spec).
- **F7** — Trash pin refs are namespaced `refs/sync-worktrees/trash/<rootHash>/<id>` so a reaper can no longer delete another config's live pins when sharing a bare repo; legacy flat refs are left untouched with a one-time warning.
- **F8** — MCP repo-selection fixes: auto-detected pseudo-repo is reselected to the matching configured repo after `load_config`; no silent `repositories[0]` pin for multi-repo configs; `invalidateDiscovered()` clears per-entry discovery state.
- **F9** — Load-time validation for `branchInclude`/`branchExclude` (arrays of strings), `branchMaxAge` (duration grammar), `skipLfs`/`updateExistingWorktrees` (booleans), parallelism (positive integers); `.cjs` configs hot-reload via require-cache subtree purge; local-path `repoUrl` now resolves a default `bareRepoDir` instead of throwing.
- **F10** — MCP `initialize` reports the clone's actual resolved branch, not the constructor constant `"main"`.

### Low severity
- **F11** — Retry util: `EACCES`/`EPERM`/`EROFS`/`ENOSPC`/`ENOENT` non-retryable by default; non-finite `maxAttempts` rejected.
- **F12** — Removed the fake "Efficiency" column (it was a pure function of count/parallelism, not measured time).
- **F13** — `create_worktree` reports structured partial success (`created: true, pushed: false, pushError`) when the push fails.
- **F14** — Worktree-membership verification failures surface as infrastructure errors instead of blaming the caller's path.
- **F15** — Init wizard validates cron with `node-cron` and de-duplicates generated repo names (`-2`, `-3`, …).
- **F16** — Deleted the loose `isLfsError` (matched any message containing `LFS`); single strict implementation re-exported for API compatibility.
- **F17** — Hook execution clears the 5s SIGKILL timer on child exit in all paths.
- **F18** — LFS verification samples files without replacement; the 30-retry budget moved to `DEFAULT_CONFIG`.
- **F19** — Metadata save guard refuses to overwrite an entry whose `upstreamBranch` refers to a different branch; corrected the misleading keying comment.
- **F20** — MCP registration matches "not found"-style CLI output before treating exit-1 as "unregistered"; unknown failures no longer trigger a registration prompt.

## Verification

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` (full suite **including E2E**) — 68/68 files, 1468 passed, 5 skipped
- `pnpm build` — succeeds
- Every batch was additionally verified in isolation before the next batch started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CommonJS config files and improved config reloading.
  * Generated repository names are now automatically deduplicated when needed.

* **Bug Fixes**
  * Improved worktree and repo selection during sync, including safer cleanup and better default-branch handling.
  * Fixed several failure cases in multi-repo runs so errors are reported more accurately.
  * Tightened path safety for file copying and trash cleanup to avoid unintended deletions or copies.
  * Updated retry behavior and LFS verification for more reliable syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->