### PR TITLE
Fix sync, removal and trash regressions in cleanup hardening

### DIFF
--- a/.changeset/fix-sync-delete-trash-review.md
+++ b/.changeset/fix-sync-delete-trash-review.md
@@ -1,0 +1,13 @@
+---
+"sync-worktrees": patch
+---
+
+Fix sync, removal and trash regressions found reviewing the cleanup-hardening work:
+
+- Rebuild worktrees whose registration points at a directory that was deleted out-of-band. Without the start-of-sync `worktree prune`, git still reported the branch as checked out, so sync silently stopped restoring it.
+- Recreating a worktree for a stale registration no longer fails permanently: the recovery path handed the already-missing directory to the trasher, which failed with `ENOENT`.
+- A diverged branch is only held back from syncing while its trashed replacement was genuinely never created. Previously any later removal of the replacement re-armed the reservation, and `.diverged/` copies (which nothing restores from) or an unverifiable path check could hold a branch back for good.
+- `resetToUpstream` indexes the upstream tree instead of comparing every ignored path against every tracked path, and lets git collapse wholly-ignored directories. The old scan blocked the event loop for minutes on a large ignored tree while holding the repo lock.
+- Relocating `worktreeDir` no longer strands every existing trash entry as unrecognized content that is never reaped and never releases its pin ref. The restore destination is still confined to `worktreeDir`, checked where it is used.
+- Force clean keeps recovery refs that a `.diverged/` directory still depends on, so it can no longer leave preserved files whose commits `git gc --prune=now` has already collected. It reports trash deletions from the reaper's own count and only purges repositories whose preview was shown in the confirmation.
+- The fast-forward gate honours the repository's own `submodule.<name>.ignore` settings again. Overriding them there marked worktrees with vendored build output permanently dirty, so those branches silently stopped updating; removal checks keep the stricter view.

--- a/.changeset/safe-trash-cleanup.md
+++ b/.changeset/safe-trash-cleanup.md
@@ -2,4 +2,4 @@
 "sync-worktrees": minor
 ---
 
-Add reversible worktree trash and restore workflows, an explicit TUI force-clean action, and hardened cleanup for detached or external worktrees, stale registrations, unsafe manifests, and interrupted diverged-branch replacement. Worktree status now uses `--ignore-submodules=none`, recursively inspecting every submodule and overriding `submodule.<name>.ignore` and `diff.ignoreSubmodules`; this may increase sync and pruning costs.
+Add reversible worktree trash and restore workflows, an explicit TUI force-clean action, and hardened cleanup for detached or external worktrees, stale registrations, unsafe manifests, and interrupted diverged-branch replacement. Removal safety checks now use `--ignore-submodules=none`, recursively inspecting every submodule and overriding `submodule.<name>.ignore` and `diff.ignoreSubmodules`; this may increase pruning costs. The fast-forward gate still honours the repository's own submodule ignore settings.

--- a/src/__tests__/e2e/diverged-branch-reservation.test.ts
+++ b/src/__tests__/e2e/diverged-branch-reservation.test.ts
@@ -1,0 +1,116 @@
+import { execSync } from "child_process";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import simpleGit from "simple-git";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// A diverged worktree leaves a preserved copy behind. That copy reserves the
+// branch so a later restore can put it back at its original path — but the
+// reservation must lift once the original path is genuinely free again,
+// otherwise the branch can never be synced anymore.
+describe("Diverged branch reservation E2E test", () => {
+  let tempDir: string;
+  let bareRepo: string;
+  let worktreeDir: string;
+  let bareRepoDir: string;
+  let configPath: string;
+  let seedDir: string;
+  const binaryPath = path.join(__dirname, "../../../dist/index.js");
+
+  const run = (): string => execSync(`node "${binaryPath}" --config "${configPath}"`, { encoding: "utf8" });
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "sync-worktrees-diverged-res-"));
+    bareRepo = path.join(tempDir, "test-repo.git");
+    worktreeDir = path.join(tempDir, "worktrees");
+    bareRepoDir = path.join(tempDir, ".bare");
+    seedDir = path.join(tempDir, "seed");
+
+    await simpleGit().init(["--bare", bareRepo]);
+
+    await fs.mkdir(seedDir);
+    const seed = simpleGit(seedDir);
+    await seed.init();
+    await seed.addConfig("user.name", "Test User");
+    await seed.addConfig("user.email", "test@example.com");
+    await fs.writeFile(path.join(seedDir, "README.md"), "# Test Repository");
+    await seed.add(".");
+    await seed.commit("Initial commit");
+    await seed.branch(["-M", "main"]);
+    await seed.addRemote("origin", bareRepo);
+    await seed.push("origin", "main");
+
+    await seed.checkoutLocalBranch("feature-1");
+    await fs.writeFile(path.join(seedDir, "feature-1.txt"), "upstream v1");
+    await seed.add(".");
+    await seed.commit("Add feature-1");
+    await seed.push("origin", "feature-1");
+
+    await simpleGit(bareRepo).raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    configPath = path.join(tempDir, "sync-worktrees.config.js");
+    await fs.writeFile(
+      configPath,
+      `export default {
+  defaults: { runOnce: true },
+  repositories: [
+    {
+      name: "test-repo",
+      repoUrl: "file://${bareRepo}",
+      worktreeDir: "${worktreeDir}",
+      bareRepoDir: "${bareRepoDir}",
+      trash: { enabled: false },
+    }
+  ]
+};
+`,
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("re-creates a branch worktree after its diverged copy stops occupying the path", async () => {
+    run();
+
+    const featureDir = (await fs.readdir(worktreeDir)).find((d) => d.startsWith("feature-1-"));
+    expect(featureDir).toBeDefined();
+    const featurePath = path.join(worktreeDir, featureDir!);
+
+    // Diverge: an unpushed local commit here, a rewritten history upstream.
+    const wt = simpleGit(featurePath);
+    await wt.addConfig("user.name", "Test User");
+    await wt.addConfig("user.email", "test@example.com");
+    await fs.writeFile(path.join(featurePath, "local-only.txt"), "never pushed");
+    await wt.add(".");
+    await wt.commit("local only work");
+
+    const seed = simpleGit(seedDir);
+    await seed.checkout("feature-1");
+    await fs.writeFile(path.join(seedDir, "feature-1.txt"), "upstream v2");
+    await seed.add(".");
+    await seed.commit("upstream rewrite");
+    await seed.push(["--force", "origin", "feature-1"]);
+
+    const divergeRun = run();
+    expect(divergeRun).toContain("Moving to diverged");
+    const divergedEntries = await fs.readdir(path.join(worktreeDir, ".diverged"));
+    expect(divergedEntries).toHaveLength(1);
+    // A fresh worktree took the original path back.
+    await expect(fs.readFile(path.join(featurePath, "feature-1.txt"), "utf8")).resolves.toBe("upstream v2");
+
+    // The user drops the fresh worktree themselves — cleanly, so git keeps no
+    // stale registration and the original path is genuinely free again.
+    await simpleGit(bareRepoDir).raw(["worktree", "remove", "--force", featurePath]);
+    await expect(fs.access(featurePath)).rejects.toThrow();
+
+    // feature-1 is still a remote branch, so sync must rebuild its worktree.
+    const finalRun = run();
+    expect(finalRun).toContain("Synchronization finished");
+
+    await expect(fs.readFile(path.join(featurePath, "feature-1.txt"), "utf8")).resolves.toBe("upstream v2");
+  }, 90000);
+});

--- a/src/__tests__/e2e/stale-registration.test.ts
+++ b/src/__tests__/e2e/stale-registration.test.ts
@@ -1,0 +1,98 @@
+import { execSync } from "child_process";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import simpleGit from "simple-git";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// A worktree directory deleted out-of-band (rm -rf, a failed backup restore, a
+// wiped external volume) leaves git's registration behind. Sync must notice the
+// registration is stale and rebuild the worktree instead of treating the branch
+// as already present.
+describe("Stale worktree registration E2E test", () => {
+  let tempDir: string;
+  let bareRepo: string;
+  let worktreeDir: string;
+  let bareRepoDir: string;
+  let configPath: string;
+  const binaryPath = path.join(__dirname, "../../../dist/index.js");
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "sync-worktrees-stale-reg-"));
+    bareRepo = path.join(tempDir, "test-repo.git");
+    worktreeDir = path.join(tempDir, "worktrees");
+    bareRepoDir = path.join(tempDir, ".bare");
+
+    const git = simpleGit();
+    await git.init(["--bare", bareRepo]);
+
+    const initDir = path.join(tempDir, "init");
+    await fs.mkdir(initDir);
+    const initGit = simpleGit(initDir);
+    await initGit.init();
+    await initGit.addConfig("user.name", "Test User");
+    await initGit.addConfig("user.email", "test@example.com");
+    await fs.writeFile(path.join(initDir, "README.md"), "# Test Repository");
+    await initGit.add(".");
+    await initGit.commit("Initial commit");
+    await initGit.branch(["-M", "main"]);
+    await initGit.addRemote("origin", bareRepo);
+    await initGit.push("origin", "main");
+
+    await initGit.checkoutLocalBranch("feature-1");
+    await fs.writeFile(path.join(initDir, "feature-1.txt"), "Content for feature-1");
+    await initGit.add(".");
+    await initGit.commit("Add feature-1");
+    await initGit.push("origin", "feature-1");
+
+    const bareGit = simpleGit(bareRepo);
+    await bareGit.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    await fs.rm(initDir, { recursive: true });
+
+    configPath = path.join(tempDir, "sync-worktrees.config.js");
+    await fs.writeFile(
+      configPath,
+      `export default {
+  defaults: { runOnce: true },
+  repositories: [
+    {
+      name: "test-repo",
+      repoUrl: "file://${bareRepo}",
+      worktreeDir: "${worktreeDir}",
+      bareRepoDir: "${bareRepoDir}",
+    }
+  ]
+};
+`,
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("recreates a worktree whose directory was deleted out-of-band", async () => {
+    const command = `node "${binaryPath}" --config "${configPath}"`;
+
+    execSync(command, { encoding: "utf8" });
+
+    const dirs = await fs.readdir(worktreeDir);
+    const featureDir = dirs.find((d) => d.startsWith("feature-1-"));
+    expect(featureDir).toBeDefined();
+    const featurePath = path.join(worktreeDir, featureDir!);
+    await expect(fs.readFile(path.join(featurePath, "feature-1.txt"), "utf8")).resolves.toBe("Content for feature-1");
+
+    // The user deletes the checkout by hand. Git still has the registration.
+    await fs.rm(featurePath, { recursive: true, force: true });
+    const bareGit = simpleGit(bareRepoDir);
+    const listing = await bareGit.raw(["worktree", "list", "--porcelain"]);
+    expect(listing).toContain("prunable");
+
+    const secondRun = execSync(command, { encoding: "utf8" });
+    expect(secondRun).toContain("Synchronization finished");
+
+    await expect(fs.readFile(path.join(featurePath, "feature-1.txt"), "utf8")).resolves.toBe("Content for feature-1");
+  }, 60000);
+});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -53,7 +53,7 @@ export interface AppProps {
   getDivergedDirectoriesForRepo?: (index: number) => Promise<DivergedDirectoryInfo[]>;
   deleteDivergedDirectory?: (repoIndex: number, name: string) => Promise<void>;
   getForceCleanPreview?: () => Promise<ForceCleanRepositoryPreview[]>;
-  forceClean?: () => Promise<ForceCleanRepositoryResult[]>;
+  forceClean?: (repoIndexes: number[]) => Promise<ForceCleanRepositoryResult[]>;
 }
 
 export interface LogEntry {

--- a/src/components/ForceCleanModal.tsx
+++ b/src/components/ForceCleanModal.tsx
@@ -7,7 +7,7 @@ import type { ForceCleanRepositoryPreview, ForceCleanRepositoryResult } from "..
 
 export interface ForceCleanModalProps {
   getPreview: () => Promise<ForceCleanRepositoryPreview[]>;
-  forceClean: () => Promise<ForceCleanRepositoryResult[]>;
+  forceClean: (repoIndexes: number[]) => Promise<ForceCleanRepositoryResult[]>;
   onClose: () => void;
 }
 
@@ -59,7 +59,9 @@ const ForceCleanModal: React.FC<ForceCleanModalProps> = ({ getPreview, forceClea
       onClose();
     } else if ((input === "y" || input === "Y") && !loading && !error) {
       setCleaning(true);
-      forceClean()
+      // Only the repos whose counts are on screen — a repo whose preview failed
+      // was never shown a number, so it must not be purged on this confirmation.
+      forceClean(previews.filter((row) => row.preview).map((row) => row.repoIndex))
         .then(setResults)
         .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)))
         .finally(() => setCleaning(false));
@@ -106,6 +108,9 @@ const ForceCleanModal: React.FC<ForceCleanModalProps> = ({ getPreview, forceClea
               <Text key={row.repoIndex} color={row.result.errors.length > 0 ? "yellow" : "green"}>
                 {row.repoName}: deleted {row.result.trashDeleted} trash and {row.result.keepRefsDeleted} refs; GC{" "}
                 {row.result.gcSucceeded ? "complete" : "failed"}
+                {row.result.keepRefsRetained > 0
+                  ? `; kept ${row.result.keepRefsRetained} ref(s) still backing a .diverged copy`
+                  : ""}
                 {row.result.errors.length > 0 ? ` (${row.result.errors.join("; ")})` : ""}
               </Text>
             ) : (

--- a/src/services/InteractiveUIService.tsx
+++ b/src/services/InteractiveUIService.tsx
@@ -223,7 +223,7 @@ export class InteractiveUIService {
         getDivergedDirectoriesForRepo={(index: number) => this.getDivergedDirectoriesForRepo(index)}
         deleteDivergedDirectory={(repoIndex: number, name: string) => this.deleteDivergedDirectory(repoIndex, name)}
         getForceCleanPreview={() => this.getForceCleanPreview()}
-        forceClean={() => this.forceClean()}
+        forceClean={(repoIndexes?: number[]) => this.forceClean(repoIndexes)}
         openEditorInWorktree={(path: string) => this.openEditorInWorktree(path)}
         openTerminalInWorktree={(repoIndex: number, path: string, branchName: string) =>
           this.openTerminalInWorktree(repoIndex, path, branchName)
@@ -740,11 +740,18 @@ export class InteractiveUIService {
     );
   }
 
-  public async forceClean(): Promise<ForceCleanRepositoryResult[]> {
+  // `repoIndexes` is what the confirmation actually showed. A repo whose preview
+  // failed is not in that list and is skipped: purging it would destroy content
+  // the user was never shown a count for.
+  public async forceClean(repoIndexes?: number[]): Promise<ForceCleanRepositoryResult[]> {
+    const selected = repoIndexes ? new Set(repoIndexes) : null;
     const results = await Promise.all(
       this.syncServices.map((service, repoIndex) =>
         this.limit(async () => {
           const repoName = this.getRepoName(repoIndex);
+          if (selected && !selected.has(repoIndex)) {
+            return { repoIndex, repoName, error: "skipped: cleanup preview was unavailable" };
+          }
           try {
             const result = await service.forceClean();
             const level = result.errors.length > 0 ? "warn" : "info";

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -686,6 +686,7 @@ describe("GitService", () => {
     it("should clean up orphaned directory before creating worktree", async () => {
       (fs.access as Mock<any>)
         .mockResolvedValueOnce(undefined) // directory exists
+        .mockResolvedValueOnce(undefined) // still there when clearing
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" })); // no .git inside
 
       mockGit.raw.mockReset();
@@ -733,6 +734,7 @@ describe("GitService", () => {
       (fs.access as Mock<any>)
         .mockRejectedValueOnce(new Error("Not found")) // First check - directory doesn't exist
         .mockResolvedValueOnce(undefined) // Second check in fallback - directory exists
+        .mockResolvedValueOnce(undefined) // still there when clearing
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" })); // no .git inside
 
       mockGit.raw.mockReset();
@@ -772,11 +774,42 @@ describe("GitService", () => {
       expect(mockMetadataService.createInitialMetadataFromPath).toHaveBeenCalled();
     });
 
+    // The whole point of this recovery is a registration whose directory is
+    // gone. Handing that missing path to the trasher fails with ENOENT and turns
+    // a self-healing case into a worktree that can never be rebuilt.
+    it("recreates a worktree for a stale registration whose directory is already gone", async () => {
+      const worktreePath = "/test/worktrees/feature-1";
+      const trasher = vi.fn<any>().mockRejectedValue(new Error("ENOENT: no such file or directory"));
+      gitService.setStaleDirectoryTrasher(trasher as unknown as (dirPath: string) => Promise<string>);
+
+      (fs.access as Mock<any>).mockRejectedValue(
+        Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" }),
+      );
+
+      mockGit.raw.mockReset();
+      mockGit.raw
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing
+        .mockResolvedValueOnce("") // refs/remotes/origin exists
+        .mockRejectedValueOnce(new Error("fatal: 'feature-1' is already registered worktree"))
+        .mockResolvedValueOnce(`worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/feature-1\nprunable\n\n`)
+        .mockResolvedValueOnce("") // targeted registration removal succeeds
+        .mockRejectedValueOnce(new Error("show-ref: not found")) // refs/heads missing on retry
+        .mockResolvedValueOnce("") // refs/remotes/origin exists on retry
+        .mockResolvedValueOnce("") // retry add succeeds
+        .mockResolvedValueOnce(""); // LFS ls-files
+
+      await expect(gitService.addWorktree("feature-1", worktreePath)).resolves.toBeUndefined();
+
+      expect(trasher).not.toHaveBeenCalled();
+      expect(mockGit.raw).toHaveBeenCalledWith(["worktree", "remove", "--force", worktreePath]);
+    });
+
     it("clears the stale target directory and retries when targeted registration removal fails", async () => {
       const worktreePath = "/test/worktrees/feature-1";
 
       (fs.access as Mock<any>)
         .mockRejectedValueOnce(new Error("Not found")) // Directory doesn't exist initially
+        .mockResolvedValueOnce(undefined) // a leftover directory now sits at the target
         .mockRejectedValueOnce(Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" })); // no .git inside stale dir
 
       mockGit.raw.mockReset();
@@ -2179,6 +2212,53 @@ prunable
       await expect(gitService.resetToUpstream("/test/worktrees/feature-1", "feature-1")).resolves.toBe(false);
 
       expect(mockGit.reset).not.toHaveBeenCalled();
+    });
+
+    it("refuses reset when an upstream file sits inside a wholly-ignored directory", async () => {
+      (mockGit.raw as Mock).mockImplementation(async (args: unknown) => {
+        const command = args as string[];
+        // `--directory` collapses the ignored tree to a single entry.
+        if (command[0] === "ls-files") return "node_modules/\0";
+        if (command[0] === "ls-tree") return "node_modules/vendored/index.js\0src/index.ts\0";
+        return "";
+      });
+
+      await expect(gitService.resetToUpstream("/test/worktrees/feature-1", "feature-1")).resolves.toBe(false);
+    });
+
+    it("collapses ignored directories instead of enumerating every ignored file", async () => {
+      const lsFilesCalls: string[][] = [];
+      (mockGit.raw as Mock).mockImplementation(async (args: unknown) => {
+        const command = args as string[];
+        if (command[0] === "ls-files") {
+          lsFilesCalls.push(command);
+          return "node_modules/\0dist/\0";
+        }
+        if (command[0] === "ls-tree") return "src/index.ts\0";
+        return "";
+      });
+
+      await expect(gitService.resetToUpstream("/test/worktrees/feature-1", "feature-1")).resolves.toBe(true);
+      expect(lsFilesCalls[0]).toContain("--directory");
+      expect(lsFilesCalls[0]).toContain("--no-empty-directory");
+    });
+
+    // The check used to compare every ignored path against every upstream path.
+    // At monorepo scale that blocks the event loop for minutes while the repo
+    // lock is held, so the shape of the algorithm is worth pinning.
+    it("answers the ignored-path check in linear time on a monorepo-sized tree", async () => {
+      const ignored = Array.from({ length: 60_000 }, (_, i) => `node_modules/pkg${i}/index.js`).join("\0");
+      const upstream = Array.from({ length: 20_000 }, (_, i) => `src/module${i}/index.ts`).join("\0");
+      (mockGit.raw as Mock).mockImplementation(async (args: unknown) => {
+        const command = args as string[];
+        if (command[0] === "ls-files") return ignored;
+        if (command[0] === "ls-tree") return upstream;
+        return "";
+      });
+
+      const startedAt = Date.now();
+      await expect(gitService.resetToUpstream("/test/worktrees/feature-1", "feature-1")).resolves.toBe(true);
+      expect(Date.now() - startedAt).toBeLessThan(5000);
     });
 
     it("rechecks cleanliness immediately before a destructive reset", async () => {

--- a/src/services/__tests__/trash.service.test.ts
+++ b/src/services/__tests__/trash.service.test.ts
@@ -298,19 +298,49 @@ describe("TrashService", () => {
       await expect(service.listEntries()).resolves.toEqual({ entries: [], invalid: [entry.containerPath] });
     });
 
+    // Restore is the only writer of originalPath, so that is where an escaping
+    // destination has to be refused. The entry itself stays listable and
+    // reapable — marking it invalid would leak its payload and pin forever.
     it("rejects restore destinations that escape worktreeDir through a symlinked parent", async () => {
       const source = await makeSourceDir("escaped-restore");
       const entry = await service.trashDirectory({ dirPath: source, reason: "manual" });
       const outsideDir = await createTempDirectory();
       const linkedParent = path.join(worktreeDir, "outside-link");
       await fs.symlink(outsideDir, linkedParent);
+      const escapedPath = path.join(linkedParent, "restored");
       const manifestPath = path.join(entry.containerPath, TRASH_CONSTANTS.MANIFEST_FILENAME);
-      await fs.writeFile(
-        manifestPath,
-        JSON.stringify({ ...entry.manifest, originalPath: path.join(linkedParent, "restored") }),
+      await fs.writeFile(manifestPath, JSON.stringify({ ...entry.manifest, originalPath: escapedPath }));
+
+      await expect(service.restore(entry.manifest.id)).rejects.toThrow(/outside worktreeDir/);
+      await expect(fs.access(escapedPath)).rejects.toThrow();
+
+      const listed = await service.listEntries();
+      expect(listed.invalid).toEqual([]);
+      expect(listed.entries.map((e) => e.manifest.id)).toEqual([entry.manifest.id]);
+    });
+
+    // Relocating worktreeDir moves .trash with it. The entries inside are still
+    // ours and must keep ageing out — an entry that reads as "invalid" is never
+    // reaped and its pin ref is never released, so the disk and the object store
+    // both leak permanently.
+    it("keeps recognizing its own entries after worktreeDir is relocated", async () => {
+      const source = await makeSourceDir("relocated");
+      const entry = await service.trashDirectory({ dirPath: source, branch: "relocated", reason: "prune" });
+
+      const movedDir = `${worktreeDir}-moved`;
+      await fs.rename(worktreeDir, movedDir);
+      const movedService = new TrashService(
+        { ...config, worktreeDir: movedDir },
+        gitStub as unknown as GitService,
+        logger,
+        audit as unknown as RemovalAuditService,
       );
 
-      await expect(service.listEntries()).resolves.toEqual({ entries: [], invalid: [entry.containerPath] });
+      const listed = await movedService.listEntries();
+
+      expect(listed.invalid).toEqual([]);
+      expect(listed.entries.map((e) => e.manifest.id)).toEqual([entry.manifest.id]);
+      await fs.rename(movedDir, worktreeDir);
     });
 
     it("returns empty results when no trash root exists yet", async () => {

--- a/src/services/__tests__/worktree-status.service.test.ts
+++ b/src/services/__tests__/worktree-status.service.test.ts
@@ -54,7 +54,18 @@ describe("WorktreeStatusService", () => {
 
       expect(result).toBe(true);
       expect(simpleGit).toHaveBeenCalledWith("/test/worktree");
-      expect(mockGit.status).toHaveBeenCalledWith(["--ignore-submodules=none"]);
+    });
+
+    // This gate only decides whether to fast-forward, which never touches a
+    // submodule's working tree. Forcing --ignore-submodules=none here would
+    // override a repo's own `submodule.<name>.ignore` — the standard way to keep
+    // vendored build output from dirtying the superproject — and silently stop
+    // that branch from ever updating again. Removal gating is where the
+    // override belongs, and getFullWorktreeStatus keeps it.
+    it("honours the repository's own submodule ignore settings", async () => {
+      await service.checkWorktreeStatus("/test/worktree");
+
+      expect(mockGit.status).toHaveBeenCalledWith();
     });
 
     it.each([

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -248,8 +248,8 @@ describe("WorktreeSyncService", () => {
       vi.spyOn(GitMaintenanceService.prototype, "runNowUnlocked").mockResolvedValue(true);
       mockGitService.listRefs
         .mockResolvedValueOnce(["refs/sync-worktrees/keep/preserved-entry"])
-        .mockResolvedValueOnce(["refs/sync-worktrees/keep/preserved-entry"])
         .mockResolvedValueOnce([]);
+      (fs.readdir as Mock<any>).mockResolvedValue([]);
 
       const result = await service.forceClean();
 
@@ -261,6 +261,35 @@ describe("WorktreeSyncService", () => {
         gcSucceeded: true,
         errors: [],
       });
+    });
+
+    // A `.diverged/<name>` directory and `keep/<name>` are two halves of one
+    // preserved worktree: the files on disk and the commits behind them. Force
+    // clean deletes neither or both — dropping only the ref and then running
+    // `gc --prune=now` would leave a directory whose own instructions
+    // ("git push --force-with-lease") no longer work, with nothing said about it.
+    it("keeps a keep ref whose .diverged directory is still on disk", async () => {
+      const divergedName = "2026-01-01-feature-1-abc";
+      vi.spyOn(TrashService.prototype, "listEntries").mockResolvedValue({ entries: [], invalid: [] });
+      vi.spyOn(TrashReaperService.prototype, "purgeAllUnlocked").mockResolvedValue({
+        deleted: 0,
+        orphanedRefsDeleted: 0,
+        errors: [],
+      });
+      vi.spyOn(GitMaintenanceService.prototype, "runNowUnlocked").mockResolvedValue(true);
+      mockGitService.listRefs.mockResolvedValue([
+        `refs/sync-worktrees/keep/${divergedName}`,
+        "refs/sync-worktrees/keep/orphaned-entry",
+      ]);
+      (fs.readdir as Mock<any>).mockImplementation(async (dirPath: unknown) =>
+        String(dirPath).endsWith(".diverged") ? [divergedName] : [],
+      );
+
+      const result = await service.forceClean();
+
+      expect(mockGitService.deleteRef).toHaveBeenCalledWith("refs/sync-worktrees/keep/orphaned-entry");
+      expect(mockGitService.deleteRef).not.toHaveBeenCalledWith(`refs/sync-worktrees/keep/${divergedName}`);
+      expect(result).toMatchObject({ keepRefsDeleted: 1, keepRefsRetained: 1 });
     });
   });
 
@@ -382,45 +411,187 @@ describe("WorktreeSyncService", () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Skipping external worktree"));
     });
 
-    it("does not recreate a branch while a preserved replacement path cannot be verified", async () => {
+    // A trash entry keeps its original path free so `trash --restore` can put the
+    // payload back there. The reservation is what stops sync from recreating a
+    // worktree over that path in the meantime.
+    // The default mock config has trash off; reservations only exist for repos
+    // whose trash pipeline can eventually release them.
+    async function useTrashEnabledService(): Promise<void> {
+      service = new WorktreeSyncService({ ...mockConfig, trash: { enabled: true } });
+      service["gitService"] = mockGitService;
+      await service.initialize();
+    }
+
+    function reserveTrashEntry(): ReturnType<typeof vi.spyOn> {
+      return vi.spyOn(TrashService.prototype, "listEntries").mockResolvedValue({
+        entries: [
+          {
+            manifest: {
+              id: "trash-id",
+              reason: "diverged-replace",
+              branch: "feature-1",
+              originalPath: wtPath("/test/worktrees", "feature-1"),
+              expiresAt: "2099-01-01T00:00:00.000Z",
+            },
+          } as any,
+        ],
+        invalid: [],
+      });
+    }
+
+    it("does not recreate a branch reserved by a diverged trash entry whose path is free", async () => {
+      await useTrashEnabledService();
+      mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
+      mockGitService.getWorktrees.mockResolvedValue([]);
+      const listSpy = reserveTrashEntry();
+      (fs.access as Mock<any>).mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
+      );
+
+      try {
+        await service.sync();
+        expect(mockGitService.addWorktree).not.toHaveBeenCalledWith(
+          "feature-1",
+          wtPath("/test/worktrees", "feature-1"),
+        );
+      } finally {
+        listSpy.mockRestore();
+      }
+    });
+
+    // An unverifiable probe is not proof the path is free. Reserving on it would
+    // stop the branch from ever syncing again; a restore that fails with a clear
+    // message is the better failure.
+    it("still syncs a reserved branch when its original path cannot be verified", async () => {
+      await useTrashEnabledService();
+      mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
+      mockGitService.getWorktrees.mockResolvedValue([]);
+      const listSpy = reserveTrashEntry();
+      (fs.access as Mock<any>).mockRejectedValue(Object.assign(new Error("unavailable"), { code: "EACCES" }));
+
+      try {
+        await service.sync();
+        expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", wtPath("/test/worktrees", "feature-1"));
+      } finally {
+        listSpy.mockRestore();
+      }
+    });
+
+    // Once the replacement worktree exists the reserve is spent. Without this,
+    // removing that replacement for any unrelated reason (branch deleted then
+    // re-pushed) re-arms the reservation and strands the branch until expiry.
+    it("syncs a branch again once its diverged replacement has been recreated", async () => {
+      await useTrashEnabledService();
+      mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
+      mockGitService.getWorktrees.mockResolvedValue([]);
+      const listSpy = vi.spyOn(TrashService.prototype, "listEntries").mockResolvedValue({
+        entries: [
+          {
+            manifest: {
+              id: "trash-id",
+              reason: "diverged-replace",
+              branch: "feature-1",
+              originalPath: wtPath("/test/worktrees", "feature-1"),
+              expiresAt: "2099-01-01T00:00:00.000Z",
+              replacedAt: "2026-01-01T00:00:00.000Z",
+            },
+          } as any,
+        ],
+        invalid: [],
+      });
+      (fs.access as Mock<any>).mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
+      );
+
+      try {
+        await service.sync();
+        expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", wtPath("/test/worktrees", "feature-1"));
+      } finally {
+        listSpy.mockRestore();
+      }
+    });
+
+    // With trash off the reaper never touches existing entries, so a reservation
+    // taken here could never expire — the branch would stop syncing for good.
+    it("does not reserve a branch from trash entries when trash is disabled", async () => {
+      mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
+      mockGitService.getWorktrees.mockResolvedValue([]);
+      const listSpy = reserveTrashEntry();
+      (fs.access as Mock<any>).mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
+      );
+
+      try {
+        await service.sync();
+        expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", wtPath("/test/worktrees", "feature-1"));
+      } finally {
+        listSpy.mockRestore();
+      }
+    });
+
+    // Nothing restores from `.diverged/`, so a copy left there must never
+    // reserve its branch — those directories are never cleaned up, and the
+    // reservation would block the branch forever.
+    it("keeps syncing a branch that only has a leftover .diverged copy", async () => {
       mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
       mockGitService.getWorktrees.mockResolvedValue([]);
       (fs.readdir as Mock<any>).mockImplementation(async (dirPath) =>
         String(dirPath).endsWith(".diverged") ? ["pending-feature"] : [],
       );
       (fs.readFile as Mock<any>).mockResolvedValue(
-        JSON.stringify({ originalBranch: "feature-1", originalPath: "/test/worktrees/feature-1" }),
+        JSON.stringify({
+          originalBranch: "feature-1",
+          originalPath: wtPath("/test/worktrees", "feature-1"),
+        }),
       );
-      (fs.access as Mock<any>).mockRejectedValueOnce(Object.assign(new Error("unavailable"), { code: "EACCES" }));
+      (fs.access as Mock<any>).mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" }),
+      );
 
       await service.sync();
 
-      expect(mockGitService.addWorktree).not.toHaveBeenCalledWith("feature-1", "/test/worktrees/feature-1");
+      expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", wtPath("/test/worktrees", "feature-1"));
     });
 
-    it("does not recreate a trashed replacement when its original path cannot be verified", async () => {
+    // A registration whose directory is gone must not read as "branch already
+    // checked out" — the worktree has to be rebuilt on this same run. The
+    // registration itself is cleared by addWorktree's recovery, which re-asks
+    // git whether the entry is prunable, so a directory that reappeared in the
+    // meantime is never force-removed on the strength of a stale probe.
+    it("rebuilds a worktree whose registration points at a missing directory", async () => {
+      const featurePath = wtPath("/test/worktrees", "feature-1");
       mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
-      mockGitService.getWorktrees.mockResolvedValue([]);
-      const listSpy = vi.spyOn(TrashService.prototype, "listEntries").mockResolvedValueOnce({
-        entries: [
-          {
-            manifest: {
-              reason: "diverged-replace",
-              branch: "feature-1",
-              originalPath: "/test/worktrees/feature-1",
-            },
-          } as any,
-        ],
-        invalid: [],
+      mockGitService.getWorktrees.mockResolvedValue([{ path: featurePath, branch: "feature-1" }]);
+      (fs.access as Mock<any>).mockImplementation(async (target: unknown) => {
+        if (target === featurePath) {
+          throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+        }
+        return undefined;
       });
-      (fs.access as Mock<any>).mockRejectedValueOnce(Object.assign(new Error("unavailable"), { code: "EACCES" }));
 
-      try {
-        await service.sync();
-        expect(mockGitService.addWorktree).not.toHaveBeenCalledWith("feature-1", "/test/worktrees/feature-1");
-      } finally {
-        listSpy.mockRestore();
-      }
+      await service.sync();
+
+      expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", featurePath);
+      expect(mockGitService.removeWorktree).not.toHaveBeenCalled();
+    });
+
+    // Same registration, unverifiable directory: an unavailable mount must keep
+    // its registration rather than have a second worktree built over it.
+    it("keeps a registration whose directory cannot be verified", async () => {
+      const featurePath = wtPath("/test/worktrees", "feature-1");
+      mockGitService.getRemoteBranches.mockResolvedValue(["main", "feature-1"]);
+      mockGitService.getWorktrees.mockResolvedValue([{ path: featurePath, branch: "feature-1" }]);
+      (fs.access as Mock<any>).mockImplementation(async (target: unknown) => {
+        if (target === featurePath) {
+          throw Object.assign(new Error("EIO: i/o error"), { code: "EIO" });
+        }
+        return undefined;
+      });
+
+      await service.sync();
+
+      expect(mockGitService.removeWorktree).not.toHaveBeenCalledWith(featurePath, { force: true });
+      expect(mockGitService.addWorktree).not.toHaveBeenCalledWith("feature-1", featurePath);
     });
 
     it.each([
@@ -1699,6 +1870,8 @@ describe("WorktreeSyncService", () => {
         expect.stringContaining("refs/sync-worktrees/trash/"),
       );
       expect(mockGitService.addWorktree).toHaveBeenCalledWith("feature-1", "/test/worktrees/feature-1");
+      // The replacement exists now, so the entry must stop reserving the branch.
+      expect(JSON.parse(manifestWrite!.content).replacedAt).toEqual(expect.any(String));
     });
 
     it("should skip diverged branch handling when local is ahead of remote", async () => {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -933,6 +933,20 @@ export class GitService {
   // A stale directory that contains a .git may be a live checkout that git
   // failed to report; quarantine it instead of deleting.
   private async clearStaleWorktreeDirectory(absoluteWorktreePath: string): Promise<void> {
+    // Nothing at the path means nothing to clear. Falling through would hand a
+    // missing directory to the trasher, which fails with ENOENT and turns a
+    // recoverable stale registration into a permanent creation failure.
+    const dirProbe = await probePathExists(absoluteWorktreePath);
+    if (dirProbe === "missing") {
+      return;
+    }
+    if (dirProbe === "unknown") {
+      throw new GitOperationError(
+        "clear-stale-directory",
+        `Cannot verify whether '${absoluteWorktreePath}' still exists; refusing to clear it`,
+      );
+    }
+
     const gitProbe = await probePathExists(path.join(absoluteWorktreePath, PATH_CONSTANTS.GIT_DIR));
 
     if (gitProbe === "unknown") {
@@ -1271,26 +1285,60 @@ export class GitService {
     }
   }
 
+  // Would checking out `origin/<branch>` write over something git is currently
+  // ignoring? Comparing every ignored path against every upstream path is
+  // O(ignored x upstream) and runs synchronously with the repo lock held, which
+  // is minutes of a blocked event loop on a monorepo. Index the upstream tree
+  // once instead, then answer each ignored path in constant time per segment.
+  private wouldOverwriteIgnoredPaths(ignoredRaw: string, upstreamRaw: string): boolean {
+    const upstreamFiles = new Set<string>();
+    // Files plus every ancestor directory: membership then means "upstream has
+    // content at this path or somewhere beneath it".
+    const upstreamPaths = new Set<string>();
+    for (const upstreamPath of upstreamRaw.split("\0")) {
+      if (!upstreamPath) continue;
+      upstreamFiles.add(upstreamPath);
+      upstreamPaths.add(upstreamPath);
+      for (let slash = upstreamPath.indexOf("/"); slash !== -1; slash = upstreamPath.indexOf("/", slash + 1)) {
+        upstreamPaths.add(upstreamPath.slice(0, slash));
+      }
+    }
+
+    for (const entry of ignoredRaw.split("\0")) {
+      if (!entry) continue;
+      // `--directory` reports collapsed directories with a trailing slash.
+      const localPath = entry.endsWith("/") ? entry.slice(0, -1) : entry;
+      if (upstreamPaths.has(localPath)) return true;
+      // The reverse shadowing case: upstream has a file (or submodule) exactly
+      // where this ignored path sits inside a directory.
+      for (let slash = localPath.indexOf("/"); slash !== -1; slash = localPath.indexOf("/", slash + 1)) {
+        if (upstreamFiles.has(localPath.slice(0, slash))) return true;
+      }
+    }
+    return false;
+  }
+
   async resetToUpstream(worktreePath: string, branch: string, expectedHead?: string): Promise<boolean> {
     const worktreeGit = this.getCachedGit(worktreePath, this.isLfsSkipEnabled());
     const status = await worktreeGit.status(["--ignore-submodules=none"]);
     if (!status.isClean()) return false;
 
+    // `--directory` collapses a wholly-ignored directory to one entry, so a
+    // node_modules with 150k files costs one path instead of 150k. Directories
+    // that also hold tracked files are still expanded, so nothing is missed.
     const [ignoredRaw, upstreamRaw] = await Promise.all([
-      worktreeGit.raw(["ls-files", "-z", "--others", "--ignored", "--exclude-standard"]),
+      worktreeGit.raw([
+        "ls-files",
+        "-z",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+        "--no-empty-directory",
+      ]),
       worktreeGit.raw(["ls-tree", "-rz", "--name-only", `origin/${branch}`]),
     ]);
-    const ignored = ignoredRaw.split("\0").filter(Boolean);
-    const upstreamPaths = upstreamRaw.split("\0").filter(Boolean);
-    const wouldOverwriteIgnored = ignored.some((localPath) =>
-      upstreamPaths.some(
-        (upstreamPath) =>
-          localPath === upstreamPath ||
-          localPath.startsWith(`${upstreamPath}/`) ||
-          upstreamPath.startsWith(`${localPath}/`),
-      ),
-    );
-    if (wouldOverwriteIgnored) return false;
+    if (this.wouldOverwriteIgnoredPaths(ignoredRaw, upstreamRaw)) return false;
 
     if (expectedHead) {
       const currentHead = (await worktreeGit.revparse(["HEAD"])).trim();

--- a/src/services/trash.service.ts
+++ b/src/services/trash.service.ts
@@ -42,6 +42,10 @@ export interface TrashManifest {
   // upstream deletion" proof — the remote may have deleted an unmerged
   // branch, so the commits must never become gc-eligible silently.
   keepPinOnReap?: boolean;
+  /** When a diverged-replace entry's replacement worktree was successfully
+   * created. Until then the entry reserves `originalPath` so restore can put
+   * the payload back; afterwards the branch syncs normally again. */
+  replacedAt?: string | null;
 }
 
 export interface TrashEntry {
@@ -301,6 +305,21 @@ export class TrashService {
       try {
         await fs.rename(entry.payloadPath, options.dirPath);
         await this.undoPartialTrash(entry.containerPath, entry.manifest.pinRef);
+        // trashDirectory already logged a `trash_create: success` for a
+        // container that no longer exists; without this the audit trail claims
+        // the directory is in trash when it is back at its original path.
+        await this.removalAudit
+          .record({
+            action: "trash_create",
+            result: "failure",
+            path: entry.manifest.originalPath,
+            branch: entry.manifest.branch ?? undefined,
+            trashId: entry.manifest.id,
+            error: `rolled back: ${getErrorMessage(error)}`,
+          })
+          .catch((auditError: unknown) =>
+            this.logger.warn(`⚠️ Failed to write trash rollback audit record: ${getErrorMessage(auditError)}`),
+          );
       } catch (rollbackError) {
         throw new TrashOperationError(
           "unregister-worktree",
@@ -326,6 +345,16 @@ export class TrashService {
     return { entry, branchRefError };
   }
 
+  // A diverged-replace entry holds `originalPath` in reserve so restore can put
+  // the payload back there. Once the replacement worktree exists that reserve is
+  // spent — restore would collide with it anyway — so record it and let the
+  // branch sync normally again instead of staying blocked until expiry.
+  async markReplacementCreated(entry: TrashEntry, now: Date = new Date()): Promise<void> {
+    const manifest: TrashManifest = { ...entry.manifest, replacedAt: now.toISOString() };
+    await this.writeManifest(entry.containerPath, manifest);
+    entry.manifest.replacedAt = manifest.replacedAt;
+  }
+
   async restore(id: string): Promise<TrashManifest> {
     const { entries } = await this.listEntries();
     const entry = entries.find((candidate) => candidate.manifest.id === id);
@@ -334,6 +363,17 @@ export class TrashService {
     }
 
     const { manifest, containerPath, payloadPath } = entry;
+
+    // Restore is the only operation that writes to originalPath, so this is
+    // where a manifest pointing outside the workspace has to be refused — and
+    // it is checked against the CURRENT worktreeDir, which is what a relocated
+    // workspace needs. Listing and reaping deliberately stay unaffected.
+    if (!this.pathResolution.isPathInsideBaseDir(manifest.originalPath, this.config.worktreeDir)) {
+      throw new TrashOperationError(
+        "restore",
+        `destination '${manifest.originalPath}' is outside worktreeDir '${this.config.worktreeDir}'; copy the files you need out of '${payloadPath}' manually`,
+      );
+    }
 
     if ((await probePathExists(payloadPath)) !== "exists") {
       throw new TrashOperationError("restore", `payload missing or unverifiable for '${id}' at '${payloadPath}'`);
@@ -511,7 +551,6 @@ export class TrashService {
       const raw = await fs.readFile(path.join(containerPath, TRASH_CONSTANTS.MANIFEST_FILENAME), "utf-8");
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       const id = path.basename(containerPath);
-      const expectedPinRef = `${GIT_CONSTANTS.TRASH_REF_PREFIX}${this.getTrashRootHash()}/${id}`;
       if (
         parsed.schemaVersion !== TRASH_CONSTANTS.SCHEMA_VERSION ||
         parsed.id !== id ||
@@ -521,13 +560,12 @@ export class TrashService {
         !Number.isFinite(Date.parse(parsed.expiresAt)) ||
         typeof parsed.originalPath !== "string" ||
         !path.isAbsolute(parsed.originalPath) ||
-        !this.pathResolution.isPathInsideBaseDir(parsed.originalPath, this.config.worktreeDir) ||
         !(typeof parsed.branch === "string" || parsed.branch === null) ||
         !["prune", "orphan", "diverged-replace", "manual", "legacy-adopt"].includes(parsed.reason as string) ||
         !(typeof parsed.sizeBytes === "number" || parsed.sizeBytes === null) ||
         (typeof parsed.sizeBytes === "number" && (!Number.isFinite(parsed.sizeBytes) || parsed.sizeBytes < 0)) ||
         !(typeof parsed.headOid === "string" || parsed.headOid === null) ||
-        !(parsed.pinRef === null || parsed.pinRef === expectedPinRef) ||
+        !this.isOwnPinRef(parsed.pinRef, id) ||
         (parsed.pinRef !== null && parsed.headOid === null) ||
         !(
           parsed.bundleFile === undefined ||
@@ -542,7 +580,12 @@ export class TrashService {
           (typeof parsed.legacyQuarantinedAt === "string" && Number.isFinite(Date.parse(parsed.legacyQuarantinedAt)))
         ) ||
         !(parsed.keepPinOnReap === undefined || typeof parsed.keepPinOnReap === "boolean") ||
-        (parsed.keepPinOnReap === true && (parsed.headOid === null || parsed.pinRef === null))
+        (parsed.keepPinOnReap === true && (parsed.headOid === null || parsed.pinRef === null)) ||
+        !(
+          parsed.replacedAt === undefined ||
+          parsed.replacedAt === null ||
+          (typeof parsed.replacedAt === "string" && Number.isFinite(Date.parse(parsed.replacedAt)))
+        )
       ) {
         return null;
       }
@@ -550,6 +593,20 @@ export class TrashService {
     } catch {
       return null;
     }
+  }
+
+  // A pin ref must belong to this entry, so a hand-edited manifest can never
+  // aim the reaper's deleteRef at something like refs/heads/main. The root-hash
+  // segment is checked for shape only, not for equality with the current trash
+  // root: relocating worktreeDir must not turn every existing entry into
+  // unrecognized content that is never reaped and never releases its pin.
+  private isOwnPinRef(pinRef: unknown, id: string): boolean {
+    if (pinRef === null) return true;
+    if (typeof pinRef !== "string") return false;
+    const suffix = `/${id}`;
+    if (!pinRef.startsWith(GIT_CONSTANTS.TRASH_REF_PREFIX) || !pinRef.endsWith(suffix)) return false;
+    const rootHash = pinRef.slice(GIT_CONSTANTS.TRASH_REF_PREFIX.length, pinRef.length - suffix.length);
+    return /^[0-9a-f]{16}$/.test(rootHash);
   }
 
   private async undoPartialTrash(containerPath: string, pinRef: string | null): Promise<void> {

--- a/src/services/worktree-mode-sync-runner.ts
+++ b/src/services/worktree-mode-sync-runner.ts
@@ -21,6 +21,7 @@ import type { Logger } from "./logger.service";
 import type { ProgressEmitter } from "./progress-emitter";
 import type { SyncOutcomeAccumulator } from "./sync-outcome";
 import type { SyncRetryContext } from "./sync-retry-policy";
+import type { TrashEntry } from "./trash.service";
 import type { WorktreeStatusDetails, WorktreeStatusResult } from "./worktree-status.service";
 import type { CreateAction, PruneAction, SparseAction, SyncPlan, UpdateAction } from "./worktree-sync-planner";
 import type { Config } from "../types";
@@ -70,6 +71,10 @@ export class WorktreeModeSyncRunner {
       }
     }
     const externalBranches = new Set(externalWorktrees.map((worktree) => worktree.branch));
+    const plannedBranches = remoteBranches.filter(
+      (branch) => !externalBranches.has(branch) && !pendingDivergedBranches.has(branch),
+    );
+    await this.dropStaleRegistrations(worktrees, new Set(plannedBranches));
     this.logger.info(`Found ${worktrees.length} managed Git worktrees.`);
     for (const worktree of externalWorktrees) {
       this.logger.warn(`  - Skipping external worktree outside worktreeDir: ${worktree.path}`);
@@ -77,9 +82,7 @@ export class WorktreeModeSyncRunner {
 
     const syncPlan = createWorktreeSyncPlan(
       {
-        remoteBranches: remoteBranches.filter(
-          (branch) => !externalBranches.has(branch) && !pendingDivergedBranches.has(branch),
-        ),
+        remoteBranches: plannedBranches,
         defaultBranch,
         existingWorktrees: worktrees,
         worktreeDir: this.config.worktreeDir,
@@ -165,38 +168,72 @@ export class WorktreeModeSyncRunner {
     );
   }
 
+  // A registration whose directory is definitively gone (rm -rf, a wiped volume)
+  // still makes the planner believe the branch is checked out: no create action,
+  // and an update action against a path that no longer exists, so the worktree is
+  // never rebuilt. Dropping it from the inventory turns it back into a create.
+  //
+  // Deliberately only bookkeeping — nothing is removed here. `addWorktree`'s
+  // "already registered worktree" recovery clears the registration, and it asks
+  // git whether the entry is still prunable first, so a directory that came back
+  // between this probe and that moment is left alone instead of force-removed.
+  //
+  // Two narrowings: only branches the plan still wants (a branch gone upstream
+  // stays with the prune pipeline, which owns removals and their audit records),
+  // and only a definitive "missing" (an unverifiable path keeps its registration
+  // so no second worktree is ever built over one that still exists).
+  private async dropStaleRegistrations(
+    worktrees: { path: string; branch: string }[],
+    plannedBranches: Set<string>,
+  ): Promise<void> {
+    const stale: { path: string; branch: string }[] = [];
+    for (const worktree of worktrees) {
+      if (plannedBranches.has(worktree.branch) && (await probePathExists(worktree.path)) === "missing") {
+        stale.push(worktree);
+      }
+    }
+
+    for (const worktree of stale) {
+      this.logger.info(
+        `  - Registration for '${worktree.branch}' points at a missing directory (${worktree.path}); rebuilding it.`,
+      );
+      worktrees.splice(worktrees.indexOf(worktree), 1);
+    }
+  }
+
+  // A diverged replace whose replacement worktree was never created leaves the
+  // trashed payload as the only copy of that branch's work. Reserving the branch
+  // keeps sync from taking `originalPath` before the user can `trash --restore`.
+  //
+  // Three deliberate narrowings, each of which was a way to strand a branch:
+  //  - `replacedAt` set means the replacement exists, so the reserve is spent.
+  //    Without this, any later removal of the replacement (branch deleted then
+  //    re-pushed, worktree removed by hand) re-arms the reservation and the
+  //    branch stops syncing until the entry expires.
+  //  - only a definitive "missing" reserves; an unverifiable probe lets the
+  //    branch keep syncing, because a silently unsynced branch is worse than a
+  //    restore that fails with a clear message.
+  //  - `.diverged/` copies never reserve: nothing restores from them, and those
+  //    directories are never cleaned up, so the block would be permanent.
   private async getPendingDivergedBranches(): Promise<Set<string>> {
     const pending = new Set<string>();
+    // With trash off the reaper leaves existing entries alone, so nothing would
+    // ever release the reserve. An expiring reservation is a delay; one that
+    // cannot expire is a branch that stops syncing for good.
+    if (!this.trashService.isEnabled()) return pending;
 
     const { entries } = await this.trashService.listEntries().catch(() => ({ entries: [], invalid: [] }));
     for (const { manifest } of entries) {
       if (
         manifest.reason === "diverged-replace" &&
         manifest.branch &&
-        (await probePathExists(manifest.originalPath)) !== "exists"
+        !manifest.replacedAt &&
+        (await probePathExists(manifest.originalPath)) === "missing"
       ) {
         pending.add(manifest.branch);
-      }
-    }
-
-    const divergedDir = path.join(this.config.worktreeDir, GIT_CONSTANTS.DIVERGED_DIR_NAME);
-    let names: string[] = [];
-    try {
-      names = (await fs.readdir(divergedDir)) ?? [];
-    } catch {}
-    for (const name of names) {
-      try {
-        const raw = await fs.readFile(path.join(divergedDir, name, METADATA_CONSTANTS.DIVERGED_INFO_FILE), "utf-8");
-        const info = JSON.parse(raw) as { originalBranch?: unknown; originalPath?: unknown };
-        if (
-          typeof info.originalBranch === "string" &&
-          typeof info.originalPath === "string" &&
-          (await probePathExists(info.originalPath)) !== "exists"
-        ) {
-          pending.add(info.originalBranch);
-        }
-      } catch {
-        // Invalid legacy entries stay preserved but cannot safely reserve a branch.
+        this.logger.info(
+          `  - Reserving '${manifest.originalPath}' for trash entry '${manifest.id}'; '${manifest.branch}' stays unsynced until it is restored or expires (${manifest.expiresAt}).`,
+        );
       }
     }
 
@@ -963,7 +1000,10 @@ export class WorktreeModeSyncRunner {
     }
     this.logger.info(`🔒 Branch '${worktree.branch}' has diverged with local changes. Moving to diverged...`);
 
-    const { divergedPath, keepRef, unregistered } = await this.divergeWorktree(worktree.path, worktree.branch);
+    const { divergedPath, keepRef, unregistered, trashEntry } = await this.divergeWorktree(
+      worktree.path,
+      worktree.branch,
+    );
     const relativePath = path.relative(process.cwd(), divergedPath);
     outcome.recordPreservedDiverged(worktree.branch, worktree.path, divergedPath);
 
@@ -996,6 +1036,17 @@ export class WorktreeModeSyncRunner {
       );
     await this.gitService.addWorktree(worktree.branch, worktree.path);
     this.logger.info(`   Created fresh worktree from upstream at: ${worktree.path}`);
+    if (trashEntry) {
+      // Best effort: if this does not land, the entry keeps reserving the branch
+      // until it expires, which is visible in the reservation log line.
+      await this.trashService
+        .markReplacementCreated(trashEntry)
+        .catch((error: unknown) =>
+          this.logger.warn(
+            `⚠️ Could not record the replacement for trash entry '${trashEntry.manifest.id}'; '${worktree.branch}' stays reserved until the entry expires: ${getErrorMessage(error)}`,
+          ),
+        );
+    }
     return true;
   }
 
@@ -1020,6 +1071,7 @@ export class WorktreeModeSyncRunner {
     divergedPath: string;
     keepRef: string | null;
     unregistered: boolean;
+    trashEntry: TrashEntry | null;
   }> {
     if (this.trashService.isEnabled()) {
       // keepPinOnReap: diverged-replace trashes the only copy of never-pushed
@@ -1042,7 +1094,7 @@ export class WorktreeModeSyncRunner {
             `⚠️ Could not write diverged metadata for trash entry '${entry.manifest.id}': ${getErrorMessage(error)}`,
           ),
       );
-      return { divergedPath: entry.payloadPath, keepRef: null, unregistered: true };
+      return { divergedPath: entry.payloadPath, keepRef: null, unregistered: true, trashEntry: entry };
     }
 
     const divergedBaseDir = path.join(this.config.worktreeDir, GIT_CONSTANTS.DIVERGED_DIR_NAME);
@@ -1099,7 +1151,7 @@ export class WorktreeModeSyncRunner {
       throw error;
     }
 
-    return { divergedPath, keepRef, unregistered: false };
+    return { divergedPath, keepRef, unregistered: false, trashEntry: null };
   }
 
   private async writeDivergedInfoFile(

--- a/src/services/worktree-status.service.ts
+++ b/src/services/worktree-status.service.ts
@@ -90,9 +90,15 @@ export class WorktreeStatusService {
     this.logger = logger ?? Logger.createDefault();
   }
 
+  // Only gates fast-forwards, which never touch a submodule's working tree, so
+  // the repository's own `submodule.<name>.ignore` is respected here. Forcing
+  // `--ignore-submodules=none` would override the standard way repos keep
+  // vendored build output from dirtying the superproject, and a worktree that
+  // reads as permanently dirty silently stops updating. Removal is the decision
+  // that must not be fooled by a quiet submodule — see getFullWorktreeStatus.
   async checkWorktreeStatus(worktreePath: string): Promise<boolean> {
     const worktreeGit = this.createGitInstance(worktreePath);
-    const status = await worktreeGit.status(["--ignore-submodules=none"]);
+    const status = await worktreeGit.status();
 
     const hasTrackedChanges =
       status.modified.length > 0 ||

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -227,15 +227,25 @@ export class WorktreeSyncService {
     await this.requireForceCleanTarget();
     const result = await this.runExclusiveRepoOperation(
       async () => {
-        const before = await this.getForceCleanPreview();
         const reap = this.cloneSyncService
           ? { deleted: 0, orphanedRefsDeleted: 0, errors: [] }
           : await this.trashReaper.purgeAllUnlocked();
         const errors = [...reap.errors];
         const keepRefs = this.cloneSyncService ? [] : await this.listKeepRefs();
+        // A `.diverged/<name>` directory and `keep/<name>` are the two halves of
+        // one preserved worktree — the files, and the commits they were made on.
+        // Dropping the ref and then running `gc --prune=now` would leave the
+        // directory intact but its own recovery instructions dead, so refs whose
+        // directory is still there are retained and reported instead.
+        const reservedNames = this.cloneSyncService ? new Set<string>() : await this.getDivergedDirectoryNames();
         let keepRefsDeleted = 0;
+        let keepRefsRetained = 0;
 
         for (const ref of keepRefs) {
+          if (reservedNames.has(ref.slice(GIT_CONSTANTS.KEEP_REF_PREFIX.length))) {
+            keepRefsRetained++;
+            continue;
+          }
           try {
             await this.removalAudit.record({ action: "keep_ref_delete", result: "attempt", path: ref });
             await this.gitService.deleteRef(ref);
@@ -255,8 +265,11 @@ export class WorktreeSyncService {
         const after = await this.getForceCleanPreview();
         return {
           ...after,
-          trashDeleted: before.trashEntries - after.trashEntries,
+          // The reaper's own count, not a before/after difference: a re-scan
+          // cannot tell a deletion from an entry that failed and stayed put.
+          trashDeleted: reap.deleted,
           keepRefsDeleted,
+          keepRefsRetained,
           gcSucceeded,
           errors,
         };
@@ -265,6 +278,23 @@ export class WorktreeSyncService {
     );
     if (!result.started) throw new Error("Cannot force clean while another process holds the repository lock");
     return result.value;
+  }
+
+  // Entry names under `.diverged/`, which are exactly the keep-ref names the
+  // non-trash diverge flow mints. Any name counts, files and symlinks included
+  // (same reasoning as the reaper's pin sweep): retaining a ref costs disk,
+  // dropping one can cost commits. An unreadable directory means the same —
+  // refuse to delete rather than guess.
+  private async getDivergedDirectoryNames(): Promise<Set<string>> {
+    const divergedRoot = path.join(this.config.worktreeDir, GIT_CONSTANTS.DIVERGED_DIR_NAME);
+    try {
+      return new Set((await fs.readdir(divergedRoot)) ?? []);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Set();
+      throw new Error(
+        `cannot scan '${divergedRoot}' to protect preserved commits; refusing to delete recovery refs: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   private async requireForceCleanTarget(): Promise<void> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -294,6 +294,8 @@ export interface ForceCleanPreview {
 export interface ForceCleanResult extends ForceCleanPreview {
   trashDeleted: number;
   keepRefsDeleted: number;
+  /** Recovery refs left alone because a `.diverged/` directory still relies on them. */
+  keepRefsRetained: number;
   gcSucceeded: boolean;
   errors: string[];
 }


### PR DESCRIPTION
## Summary

This PR fixes several regressions discovered while reviewing the cleanup-hardening work, focusing on stale worktree registrations, diverged branch reservations, and trash restoration safety.

## Key Changes

### Stale Worktree Registration Recovery
- **Rebuild missing worktrees**: Added `dropStaleRegistrations()` to detect and remove git registrations pointing to directories that have been deleted out-of-band (rm -rf, wiped volumes, etc.). This allows sync to rebuild the worktree instead of silently treating the branch as already checked out.
- **Safe stale directory clearing**: Modified `clearStaleWorktreeDirectory()` to skip clearing when the directory is already missing, preventing ENOENT failures that would permanently block worktree recreation.
- **Graceful recovery**: The recovery only removes stale registrations for branches still in the sync plan and only when the path is definitively missing (not unverifiable), ensuring no second worktree is built over one that still exists.

### Diverged Branch Reservation Refinement
- **Replacement tracking**: Added `replacedAt` field to `TrashManifest` to track when a diverged-replace entry's replacement worktree was successfully created. Once set, the branch is no longer reserved and can sync normally again.
- **Smarter reservation logic**: Updated `getPendingDivergedBranches()` to only reserve branches when:
  - The trash entry has `reason: "diverged-replace"`
  - The replacement hasn't been created yet (`!manifest.replacedAt`)
  - The original path is definitively missing (not just unverifiable)
  - Trash is enabled (otherwise the reservation could never expire)
- **Removed `.diverged/` directory reservations**: Stopped reserving branches based on leftover `.diverged/` directories since nothing restores from them and they're never cleaned up, which would create permanent blocks.

### Trash Restoration Safety
- **Path escape validation**: Added check in `restore()` to reject destinations that escape `worktreeDir`, preventing symlink-based attacks while keeping invalid entries listable and reapable.
- **Audit trail integrity**: When a restore fails and is rolled back, now records a `trash_create: failure` audit entry to correct the misleading success record from the initial trash operation.
- **Relocation support**: Ensured trash entries remain valid after `worktreeDir` is relocated, preventing permanent leaks of disk space and object store pins.

### Force Clean Improvements
- **Diverged directory preservation**: Modified force-clean to retain `keep/` refs whose corresponding `.diverged/` directories still exist on disk, preventing orphaned directories with dead recovery instructions.
- **Accurate reporting**: Added `keepRefsRetained` to track refs kept due to diverged directory reservations, separate from deleted refs.

### Performance and Correctness
- **Ignored path optimization**: Optimized `resetToUpstream()` to use `--directory` flag when listing ignored files, collapsing wholly-ignored directories (like `node_modules/`) to single entries instead of enumerating thousands of files.
- **Conflict detection**: Implemented `wouldOverwriteIgnoredPaths()` to properly detect when checking out would overwrite ignored content, handling both direct conflicts and reverse shadowing cases.

## Testing

Added comprehensive E2E tests:
- `stale-registration.test.ts`: Verifies worktrees are rebuilt when their directories are deleted out-of-band
- `diverged-branch-reservation.test.ts`: Confirms branches can be re-synced once their diverged copies are cleaned up

Updated unit tests to cover new recovery paths and edge cases around path verification and trash operations.

## Notable Implementation Details

- Path existence probing uses three states: "exists", "missing", and "unknown" (unverifiable), allowing safe decisions about when to act vs. when to preserve existing state
- Stale registration cleanup happens at the start of sync, before the planner runs, ensuring the inventory is accurate
- Trash entry validation is deferred to restore time (the only writer of `originalPath`) rather than invalidating entries, preventing permanent leaks

https://claude.ai/code/session_011zEhNngSr7Kb6uGASoL3oS