### PR TITLE
Upgrade MCP server to 2026-07-28

### DIFF
--- a/.changeset/modern-mice-connect.md
+++ b/.changeset/modern-mice-connect.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": major
+---
+
+Require MCP 2026-07-28 clients for the stdio server and reject legacy protocol handshakes.

--- a/.changeset/modern-mice-connect.md
+++ b/.changeset/modern-mice-connect.md
@@ -1,5 +1,7 @@
 ---
-"sync-worktrees": major
+"sync-worktrees": minor
 ---
 
-Require MCP 2026-07-28 clients for the stdio server and reject legacy protocol handshakes.
+Upgrade the MCP server to the 2026-07-28 protocol revision (`@modelcontextprotocol/server` v2). The stdio server now serves the 2026-07-28 revision and keeps serving 2025-era clients from the same tool registry, so existing MCP clients continue to work unchanged.
+
+Tools now advertise `outputSchema` and return `structuredContent` alongside the existing JSON text block, and `tools/list` / `resources/list` carry cache hints so clients can avoid re-fetching a static tool registry.

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ demo-recording/*.gif
 # Astro site build artifacts
 site/.astro/
 site/public/demo.gif
+
+# MCP stdio integration-test build dirs (bundled inside the repo so the spawned
+# server resolves node_modules; removed in the test's finally block)
+.mcp-stdio-test-*

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,4 +1,8 @@
+import { readFileSync } from "node:fs";
+
 import * as esbuild from "esbuild";
+
+const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
 const commonConfig = {
   bundle: true,
@@ -7,6 +11,9 @@ const commonConfig = {
   target: "node22",
   sourcemap: true,
   packages: "external",
+  define: {
+    __SYNC_WORKTREES_VERSION__: JSON.stringify(version),
+  },
 };
 
 try {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://github.com/yordan-kanchelov/sync-worktrees#readme",
   "dependencies": {
     "@inquirer/prompts": "^8.5.2",
-    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "cli-table3": "^0.6.5",
     "cron-parser": "^5.6.2",
     "fast-folder-size": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^8.5.2
         version: 8.5.2(@types/node@26.1.2)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
@@ -404,12 +404,6 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@2.0.12':
-    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      hono: ^4
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -598,15 +592,13 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/sdk@1.30.0':
-    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.2.0':
     resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
@@ -963,10 +955,6 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -985,19 +973,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1061,10 +1038,6 @@ packages:
   bl@1.2.3:
     resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
 
-  body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
-    engines: {node: '>=18'}
-
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 20 || >=22}
@@ -1091,10 +1064,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1150,18 +1119,6 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1169,20 +1126,8 @@ packages:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1234,10 +1179,6 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1258,18 +1199,11 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1312,9 +1246,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -1374,31 +1305,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
-
-  express-rate-limit@8.6.1:
-    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1425,9 +1334,6 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -1470,10 +1376,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1492,14 +1394,6 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1590,16 +1484,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
-    engines: {node: '>=16.9.0'}
-
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1653,14 +1539,6 @@ packages:
       react-devtools-core:
         optional: true
 
-  ip-address@10.3.1:
-    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
-    engines: {node: '>= 12'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -1692,9 +1570,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
@@ -1733,9 +1608,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jose@6.2.4:
-    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
-
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1752,12 +1624,6 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1886,14 +1752,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  media-typer@1.1.1:
-    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
-    engines: {node: '>= 0.8'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1901,14 +1759,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1945,10 +1795,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
   node-cron@4.6.0:
     resolution: {integrity: sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==}
     engines: {node: '>=20'}
@@ -1957,17 +1803,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2018,10 +1856,6 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2037,9 +1871,6 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2082,10 +1913,6 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
-  pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -2109,31 +1936,15 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
-    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  range-parser@1.3.0:
-    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   react-devtools-core@7.0.1:
     resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
@@ -2155,10 +1966,6 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2179,10 +1986,6 @@ packages:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2208,20 +2011,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
-
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2233,22 +2025,6 @@ packages:
 
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2292,10 +2068,6 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -2376,10 +2148,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2409,10 +2177,6 @@ packages:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
 
-  type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
-    engines: {node: '>= 18'}
-
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2432,10 +2196,6 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2444,10 +2204,6 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -2627,11 +2383,6 @@ packages:
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
-
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2938,10 +2689,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
-    dependencies:
-      hono: 4.12.32
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3122,27 +2869,14 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+  '@modelcontextprotocol/core@2.0.0':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.6.1(express@5.2.1)
-      hono: 4.12.32
-      jose: 6.2.4
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -3408,11 +3142,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -3425,23 +3154,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -3492,20 +3210,6 @@ snapshots:
       readable-stream: 2.3.8
       safe-buffer: 5.2.1
 
-  body-parser@2.3.0:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 2.0.0
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.3
-      on-finished: 2.4.1
-      qs: 6.15.3
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
@@ -3533,8 +3237,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3590,26 +3292,11 @@ snapshots:
 
   commander@2.20.3: {}
 
-  content-disposition@1.1.0: {}
-
-  content-type@1.0.5: {}
-
-  content-type@2.0.0: {}
-
   convert-source-map@2.0.0: {}
 
   convert-to-spaces@2.0.1: {}
 
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
-
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -3675,8 +3362,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  depd@2.0.0: {}
-
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -3693,13 +3378,9 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  ee-first@1.1.1: {}
-
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3756,8 +3437,6 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
-
-  escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -3833,56 +3512,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1: {}
-
-  eventsource-parser@3.1.0: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.1.0
-
   expect-type@1.4.0: {}
-
-  express-rate-limit@8.6.1(express@5.2.1):
-    dependencies:
-      debug: 4.4.3
-      express: 5.2.1
-      ip-address: 10.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.3.0
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.3
-      range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   extendable-error@0.1.7: {}
 
@@ -3912,8 +3542,6 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-
-  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -3947,17 +3575,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -3978,10 +3595,6 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  forwarded@0.2.0: {}
-
-  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -4087,17 +3700,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.32: {}
-
   html-escaper@2.0.2: {}
-
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -4161,10 +3764,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ip-address@10.3.1: {}
-
-  ipaddr.js@1.9.1: {}
-
   is-callable@1.2.7: {}
 
   is-extglob@2.1.1: {}
@@ -4184,8 +3783,6 @@ snapshots:
   is-natural-number@4.0.1: {}
 
   is-number@7.0.0: {}
-
-  is-promise@4.0.0: {}
 
   is-stream@1.1.0: {}
 
@@ -4218,8 +3815,6 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jose@6.2.4: {}
-
   js-tokens@10.0.0: {}
 
   js-yaml@3.15.0:
@@ -4234,10 +3829,6 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4339,22 +3930,12 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  media-typer@1.1.1: {}
-
-  merge-descriptors@2.0.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
-
-  mime-db@1.54.0: {}
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -4376,19 +3957,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@1.0.0: {}
-
   node-cron@4.6.0: {}
 
   object-assign@4.1.1: {}
 
-  object-inspect@1.13.4: {}
-
   obug@2.1.4: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -4441,8 +4014,6 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  parseurl@1.3.3: {}
-
   patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
@@ -4453,8 +4024,6 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
-
-  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -4480,8 +4049,6 @@ snapshots:
 
   pinkie@2.0.4: {}
 
-  pkce-challenge@5.0.1: {}
-
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.24:
@@ -4502,30 +4069,11 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   punycode@2.3.1: {}
-
-  qs@6.15.3:
-    dependencies:
-      es-define-property: 1.0.1
-      side-channel: 1.1.1
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
-
-  range-parser@1.3.0: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.3
-      unpipe: 1.0.0
 
   react-devtools-core@7.0.1:
     dependencies:
@@ -4559,8 +4107,6 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
-  require-from-string@2.0.2: {}
-
   resolve-from@5.0.0: {}
 
   restore-cursor@4.0.0:
@@ -4593,16 +4139,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4621,31 +4157,6 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.3.0
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -4655,8 +4166,6 @@ snapshots:
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
-  setprototypeof@1.2.0: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -4664,34 +4173,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.10.0: {}
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4736,8 +4217,6 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
-
-  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -4819,8 +4298,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toidentifier@1.0.1: {}
-
   totalist@3.0.1: {}
 
   ts-node@10.9.2(@types/node@26.1.2)(typescript@7.0.2):
@@ -4851,12 +4328,6 @@ snapshots:
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
-
-  type-is@2.1.0:
-    dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.1
-      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -4896,8 +4367,6 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unpipe@1.0.0: {}
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -4905,8 +4374,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
-
-  vary@1.1.2: {}
 
   vite@8.0.10(@types/node@26.1.2)(esbuild@0.28.1):
     dependencies:
@@ -5022,9 +4489,5 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoga-layout@3.2.1: {}
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -199,7 +199,13 @@ function makeCtx(opts: {
 }
 
 function parseResponse(result: any): any {
-  return JSON.parse(result.content[0].text);
+  const parsed = JSON.parse(result.content[0].text);
+  // Every tool advertises an outputSchema, so a success result must also carry
+  // structuredContent — the SDK turns a result that omits it into an error.
+  if (result.isError !== true) {
+    expect(result.structuredContent).toEqual(parsed);
+  }
+  return parsed;
 }
 
 describe("handleListWorktrees", () => {

--- a/src/mcp/__tests__/handlers.test.ts
+++ b/src/mcp/__tests__/handlers.test.ts
@@ -14,10 +14,10 @@ import {
 import { formatErrorResponse } from "../utils";
 
 import type { Capabilities, DiscoveredRepoContext, RepositoryContext } from "../context";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/server";
 
 async function invoke<T>(
-  handler: (ctx: RepositoryContext, params: T, extra?: any) => Promise<CallToolResult>,
+  handler: (ctx: RepositoryContext, params: T, handlerContext?: any) => Promise<CallToolResult>,
   ctx: RepositoryContext,
   params: T,
 ): Promise<CallToolResult> {
@@ -753,15 +753,19 @@ describe("handleSync", () => {
       return { started: true };
     });
 
-    const sendNotification = vi.fn<any>().mockResolvedValue(undefined);
-    const extra = { _meta: { progressToken: "tok-1" }, sendNotification };
-    await handleSync(ctx, {}, extra as any);
+    const notify = vi.fn<any>().mockResolvedValue(undefined);
+    const handlerContext = { mcpReq: { _meta: { progressToken: "tok-1" }, notify } };
+    await handleSync(ctx, {}, handlerContext as any);
 
-    expect(sendNotification).toHaveBeenCalledTimes(2);
-    const firstCall = sendNotification.mock.calls[0][0] as { params: { message: string } };
-    const secondCall = sendNotification.mock.calls[1][0] as { params: { message: string } };
-    expect(firstCall.params.message).toContain("[fetch]");
-    expect(secondCall.params.message).toContain("[create]");
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenNthCalledWith(1, {
+      method: "notifications/progress",
+      params: { progressToken: "tok-1", progress: 1, message: "[fetch] Fetching" },
+    });
+    expect(notify).toHaveBeenNthCalledWith(2, {
+      method: "notifications/progress",
+      params: { progressToken: "tok-1", progress: 2, message: "[create] Creating" },
+    });
   });
 
   it("unsubscribes progress listener even when sync throws", async () => {
@@ -770,9 +774,10 @@ describe("handleSync", () => {
     service.onProgress = vi.fn<any>().mockReturnValue(unsubscribe);
     service.sync.mockRejectedValue(new Error("boom"));
 
-    const sendNotification = vi.fn<any>().mockResolvedValue(undefined);
-    const extra = { _meta: { progressToken: "tok-1" }, sendNotification };
-    await expect(handleSync(ctx, {}, extra as any)).rejects.toThrow("boom");
+    const handlerContext = {
+      mcpReq: { _meta: { progressToken: "tok-1" }, notify: vi.fn<any>().mockResolvedValue(undefined) },
+    };
+    await expect(handleSync(ctx, {}, handlerContext as any)).rejects.toThrow("boom");
     expect(unsubscribe).toHaveBeenCalled();
   });
 });
@@ -808,13 +813,14 @@ describe("handleInitialize", () => {
       for (const l of progressListeners) l({ phase: "initialize", message: "Initializing repository" });
     });
 
-    const sendNotification = vi.fn<any>().mockResolvedValue(undefined);
-    const extra = { _meta: { progressToken: "init-1" }, sendNotification };
-    await handleInitialize(ctx, {}, extra as any);
+    const notify = vi.fn<any>().mockResolvedValue(undefined);
+    const handlerContext = { mcpReq: { _meta: { progressToken: "init-1" }, notify } };
+    await handleInitialize(ctx, {}, handlerContext as any);
 
-    expect(sendNotification).toHaveBeenCalled();
-    const call = sendNotification.mock.calls[0][0] as { params: { message: string } };
-    expect(call.params.message).toContain("[initialize]");
+    expect(notify).toHaveBeenCalledWith({
+      method: "notifications/progress",
+      params: { progressToken: "init-1", progress: 1, message: "[initialize] Initializing repository" },
+    });
   });
 });
 

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -1,9 +1,18 @@
+import { spawn } from "node:child_process";
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
+import * as readline from "node:readline";
 
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  SERVER_INFO_META_KEY,
+} from "@modelcontextprotocol/server";
+import { build } from "esbuild";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import packageJson from "../../../package.json" with { type: "json" };
 import { RepositoryContext } from "../context";
 import { buildInstructions, createServer } from "../server";
 
@@ -166,6 +175,135 @@ describe("createServer", () => {
       { name: "ui", mode: "clone", checkoutPath: "/ws/ui", isCurrent: false },
       { name: "frontend", mode: "worktree", worktreeDir: "/ws/frontend", isCurrent: true },
     ]);
+  });
+});
+
+describe("stdio protocol", () => {
+  it("serves MCP 2026-07-28 and rejects a legacy handshake", async () => {
+    const buildDir = await fs.mkdtemp(path.join(process.cwd(), ".mcp-stdio-test-"));
+    const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-stdio-runtime-"));
+    const entry = path.join(buildDir, "mcp-server.mjs");
+    const children: ReturnType<typeof spawn>[] = [];
+
+    try {
+      await build({
+        entryPoints: [path.join(process.cwd(), "src/mcp/index.ts")],
+        outfile: entry,
+        bundle: true,
+        platform: "node",
+        format: "esm",
+        target: "node22",
+        packages: "external",
+      });
+
+      const startServer = () => {
+        const child = spawn(process.execPath, [entry], {
+          cwd: runtimeDir,
+          env: { ...process.env, SYNC_WORKTREES_CONFIG: "" },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        children.push(child);
+        const lines = readline.createInterface({ input: child.stdout });
+        let stderr = "";
+        child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+
+        const request = (message: Record<string, unknown>): Promise<any> =>
+          new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+              cleanup();
+              reject(new Error(`MCP response timed out. stderr: ${stderr}`));
+            }, 5_000);
+            const onLine = (line: string) => {
+              const response = JSON.parse(line);
+              if (response.id !== message.id) return;
+              cleanup();
+              resolve(response);
+            };
+            const onExit = () => {
+              cleanup();
+              reject(new Error(`MCP server exited before responding. stderr: ${stderr}`));
+            };
+            const cleanup = () => {
+              clearTimeout(timeout);
+              lines.off("line", onLine);
+              child.off("exit", onExit);
+            };
+
+            lines.on("line", onLine);
+            child.once("exit", onExit);
+            child.stdin.write(`${JSON.stringify(message)}\n`);
+          });
+
+        return { child, request };
+      };
+
+      const modern = startServer();
+      const envelope = {
+        [PROTOCOL_VERSION_META_KEY]: "2026-07-28",
+        [CLIENT_CAPABILITIES_META_KEY]: {},
+      };
+      const discover = await modern.request({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "server/discover",
+        params: { _meta: envelope },
+      });
+      expect(discover.result).toMatchObject({
+        supportedVersions: ["2026-07-28"],
+        ttlMs: 0,
+        cacheScope: "private",
+      });
+      expect(discover.result._meta[SERVER_INFO_META_KEY]).toEqual({
+        name: "sync-worktrees",
+        version: packageJson.version,
+      });
+
+      const tools = await modern.request({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: { _meta: envelope },
+      });
+      expect(tools.result).toMatchObject({ ttlMs: 0, cacheScope: "private" });
+      expect(tools.result.tools.map((tool: { name: string }) => tool.name)).toEqual([
+        "detect_context",
+        "list_worktrees",
+        "get_worktree_status",
+        "create_worktree",
+        "sync",
+        "update_worktree",
+        "initialize",
+        "load_config",
+        "set_current_repository",
+      ]);
+
+      const toolCall = await modern.request({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "detect_context", arguments: { path: runtimeDir }, _meta: envelope },
+      });
+      expect(toolCall.error).toBeUndefined();
+      expect(toolCall.result.isError).not.toBe(true);
+      expect(JSON.parse(toolCall.result.content[0].text)).toMatchObject({ isWorktree: false });
+
+      const legacy = startServer();
+      const initialize = await legacy.request({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "legacy-test", version: "1.0.0" },
+        },
+      });
+      expect(initialize.error.code).toBe(-32022);
+    } finally {
+      for (const child of children) child.kill();
+      await fs.rm(buildDir, { recursive: true, force: true });
+      await fs.rm(runtimeDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/mcp/__tests__/server.test.ts
+++ b/src/mcp/__tests__/server.test.ts
@@ -194,6 +194,9 @@ describe("stdio protocol", () => {
         format: "esm",
         target: "node22",
         packages: "external",
+        // Mirrors esbuild.config.js — the bundled entry reads the version from
+        // this define, not from an import of package.json.
+        define: { __SYNC_WORKTREES_VERSION__: JSON.stringify(packageJson.version) },
       });
 
       const startServer = () => {
@@ -250,7 +253,8 @@ describe("stdio protocol", () => {
       });
       expect(discover.result).toMatchObject({
         supportedVersions: ["2026-07-28"],
-        ttlMs: 0,
+        // Cacheable, but private: the instructions embed connect-time workspace paths.
+        ttlMs: 3_600_000,
         cacheScope: "private",
       });
       expect(discover.result._meta[SERVER_INFO_META_KEY]).toEqual({
@@ -264,7 +268,8 @@ describe("stdio protocol", () => {
         method: "tools/list",
         params: { _meta: envelope },
       });
-      expect(tools.result).toMatchObject({ ttlMs: 0, cacheScope: "private" });
+      // The registry is fixed at construction, so it is publicly cacheable.
+      expect(tools.result).toMatchObject({ ttlMs: 3_600_000, cacheScope: "public" });
       expect(tools.result.tools.map((tool: { name: string }) => tool.name)).toEqual([
         "detect_context",
         "list_worktrees",
@@ -276,6 +281,10 @@ describe("stdio protocol", () => {
         "load_config",
         "set_current_repository",
       ]);
+      // Every tool advertises an output schema (SEP-2106).
+      for (const tool of tools.result.tools) {
+        expect(tool.outputSchema, `${tool.name} outputSchema`).toMatchObject({ type: "object" });
+      }
 
       const toolCall = await modern.request({
         jsonrpc: "2.0",
@@ -286,6 +295,8 @@ describe("stdio protocol", () => {
       expect(toolCall.error).toBeUndefined();
       expect(toolCall.result.isError).not.toBe(true);
       expect(JSON.parse(toolCall.result.content[0].text)).toMatchObject({ isWorktree: false });
+      // Results validate against the advertised schema and ship structuredContent.
+      expect(toolCall.result.structuredContent).toMatchObject({ isWorktree: false });
 
       const legacy = startServer();
       const initialize = await legacy.request({
@@ -298,7 +309,27 @@ describe("stdio protocol", () => {
           clientInfo: { name: "legacy-test", version: "1.0.0" },
         },
       });
-      expect(initialize.error.code).toBe(-32022);
+      // 2025-era clients are still served, from the same tool registry.
+      expect(initialize.error).toBeUndefined();
+      expect(initialize.result).toMatchObject({
+        protocolVersion: "2025-11-25",
+        serverInfo: { name: "sync-worktrees", version: packageJson.version },
+      });
+
+      const legacyTools = await legacy.request({ jsonrpc: "2.0", id: 5, method: "tools/list", params: {} });
+      expect(legacyTools.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
+        tools.result.tools.map((tool: { name: string }) => tool.name),
+      );
+
+      const legacyCall = await legacy.request({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: { name: "detect_context", arguments: { path: runtimeDir } },
+      });
+      expect(legacyCall.error).toBeUndefined();
+      expect(legacyCall.result.isError).not.toBe(true);
+      expect(legacyCall.result.structuredContent).toMatchObject({ isWorktree: false });
     } finally {
       for (const child of children) child.kill();
       await fs.rm(buildDir, { recursive: true, force: true });

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -15,10 +15,10 @@ import { CapabilityUnavailableError, SyncInProgressError, formatToolResponse } f
 import { deriveLabel, deriveSafeToRemove, getDivergence } from "./worktree-summary";
 
 import type { Capabilities, DiscoveredRepoContext, DiscoveredWorktree, RepositoryContext } from "./context";
-import type { HandlerExtra } from "./utils";
+import type { HandlerContext } from "./utils";
 import type { WorktreeLabel } from "./worktree-summary";
 import type { ProgressEvent } from "../services/worktree-sync.service";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/server";
 
 type CapabilityKey = keyof Capabilities;
 type RepoScopedParams = { repoName?: string };
@@ -156,7 +156,7 @@ async function getWorktreesFromService(
 export async function handleDetectContext(
   ctx: RepositoryContext,
   params: { path?: string; includeStatus?: boolean; includeAllWorktrees?: boolean; detailed?: boolean },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const target = params.path ?? process.cwd();
   const discovered = await ctx.detectFromPath(target);
@@ -229,7 +229,7 @@ async function enrichDetectedWorktrees(
 export async function handleListWorktrees(
   ctx: RepositoryContext,
   params: { repoName?: string; includeSize?: boolean },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const configuredRepoNames = params.repoName ? [] : ctx.getConfiguredRepositoryNames();
   if (configuredRepoNames.length > 0) {
@@ -319,7 +319,7 @@ async function listWorktreesForRepo(
 export async function handleGetWorktreeStatus(
   ctx: RepositoryContext,
   params: { path: string; repoName?: string; includeDetails?: boolean },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const { service, git } = await getReadyService(ctx, params.repoName, {
     capability: "getStatus",
@@ -341,7 +341,7 @@ export async function handleGetWorktreeStatus(
 export async function handleCreateWorktree(
   ctx: RepositoryContext,
   params: { branchName: string; baseBranch?: string; push?: boolean; repoName?: string },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const { branchName, baseBranch } = params;
   const push = params.push ?? true;
@@ -417,14 +417,14 @@ export async function handleCreateWorktree(
 export async function handleSync(
   ctx: RepositoryContext,
   params: { repoName?: string },
-  extra?: HandlerExtra,
+  handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const { service } = await getReadyService(ctx, params.repoName, {
     capability: "sync",
     toolName: "sync",
   });
 
-  const dispose = attachProgressReporter(service, extra);
+  const dispose = attachProgressReporter(service, handlerContext);
   try {
     const start = Date.now();
     const result = await service.sync();
@@ -461,7 +461,7 @@ export async function handleSync(
 export async function handleUpdateWorktree(
   ctx: RepositoryContext,
   params: { path: string; repoName?: string },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const { service, git } = await getReadyService(ctx, params.repoName, {
     capability: "updateWorktree",
@@ -489,13 +489,13 @@ export async function handleUpdateWorktree(
 export async function handleInitialize(
   ctx: RepositoryContext,
   params: { repoName?: string },
-  extra?: HandlerExtra,
+  handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const { service } = await getReadyService(ctx, params.repoName, {
     capability: "initialize",
     toolName: "initialize",
   });
-  const dispose = attachProgressReporter(service, extra);
+  const dispose = attachProgressReporter(service, handlerContext);
   try {
     return await runExclusiveRepoOperation(ctx, params.repoName, service, async () => {
       await service.initializeUnlocked();
@@ -518,7 +518,7 @@ export async function handleInitialize(
 export async function handleLoadConfig(
   ctx: RepositoryContext,
   params: { configPath?: string },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   const configPath =
     params.configPath ??
@@ -555,7 +555,7 @@ async function detectConfigFromLaunchCwd(ctx: RepositoryContext): Promise<string
 export async function handleSetCurrentRepository(
   ctx: RepositoryContext,
   params: { repoName: string },
-  _extra?: HandlerExtra,
+  _handlerContext?: HandlerContext,
 ): Promise<CallToolResult> {
   ctx.setCurrentRepo(params.repoName);
   return formatToolResponse({
@@ -568,17 +568,17 @@ function attachProgressReporter(
   service: {
     onProgress?: (listener: (event: ProgressEvent) => void) => () => void;
   },
-  extra: HandlerExtra | undefined,
+  handlerContext: HandlerContext | undefined,
 ): () => void {
-  const token = extra?._meta?.progressToken;
-  if (token === undefined || !extra) return () => {};
+  const token = handlerContext?.mcpReq._meta?.progressToken;
+  if (token === undefined || !handlerContext) return () => {};
   if (!service.onProgress) return () => {};
 
   let progressCounter = 0;
   const unsubscribe = service.onProgress((event) => {
     progressCounter++;
-    void extra
-      .sendNotification({
+    void handlerContext.mcpReq
+      .notify({
         method: "notifications/progress",
         params: {
           progressToken: token,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -30,14 +30,29 @@ async function main(): Promise<void> {
     process.stderr.write(`[sync-worktrees-mcp] Auto-detect failed: ${(err as Error).message}\n`);
   }
 
-  serveStdio(
+  const handle = serveStdio(
     () =>
       createServer(context, {
         discovered,
         configuredRepoCount: context.getConfiguredRepositoryNames().length,
       }),
-    { legacy: "reject" },
+    {
+      // 2025-era clients are served from the same factory, with the same tools
+      // and instructions. The 2026-07-28 revision keeps older revisions alive
+      // for at least twelve months, and most MCP clients have not shipped
+      // 2026-07-28 support yet, so rejecting them would strand every install.
+      legacy: "serve",
+      onerror: (err) => {
+        process.stderr.write(`[sync-worktrees-mcp] Transport error: ${err.message}\n`);
+      },
+    },
   );
+
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      void handle.close().finally(() => process.exit(0));
+    });
+  }
 }
 
 main().catch((err) => {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,4 +1,4 @@
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 
 import { RepositoryContext } from "./context";
 import { createServer } from "./server";
@@ -30,12 +30,14 @@ async function main(): Promise<void> {
     process.stderr.write(`[sync-worktrees-mcp] Auto-detect failed: ${(err as Error).message}\n`);
   }
 
-  const server = createServer(context, {
-    discovered,
-    configuredRepoCount: context.getConfiguredRepositoryNames().length,
-  });
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  serveStdio(
+    () =>
+      createServer(context, {
+        discovered,
+        configuredRepoCount: context.getConfiguredRepositoryNames().length,
+      }),
+    { legacy: "reject" },
+  );
 }
 
 main().catch((err) => {

--- a/src/mcp/output-schemas.ts
+++ b/src/mcp/output-schemas.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+
+/**
+ * Output schemas advertised on `tools/list` and enforced on `tools/call`
+ * (SEP-2106, protocol revision 2026-07-28).
+ *
+ * The SDK validates every result whose tool advertises a schema: a missing or
+ * mismatched `structuredContent` is turned into an `isError` result. Two rules
+ * keep that safe as the handlers evolve:
+ *
+ * 1. A field is `required` here only when the handler's TypeScript return type
+ *    guarantees it. Anything optional or conditional is `.optional()`.
+ * 2. Every object is loose, so adding a field to a response is never a
+ *    breaking wire change.
+ *
+ * Error results (`isError: true`) carry no `structuredContent` and are exempt
+ * from validation, so `formatErrorResponse` stays schema-free.
+ */
+
+const worktreeLabelSchema = z.enum(["current", "dirty", "stale", "clean", "unknown"]);
+
+const divergenceSchema = z
+  .looseObject({
+    ahead: z.number().describe("Commits on this branch not on its upstream."),
+    behind: z.number().describe("Commits on the upstream not on this branch."),
+  })
+  .nullable()
+  .describe("null when the worktree has no upstream or rev-list failed.");
+
+const capabilityStateSchema = z.looseObject({
+  available: z.boolean(),
+  reason: z.string().optional().describe("Why the capability is unavailable. Absent when available."),
+});
+
+const capabilitiesSchema = z.looseObject({
+  listWorktrees: capabilityStateSchema,
+  getStatus: capabilityStateSchema,
+  createWorktree: capabilityStateSchema,
+  updateWorktree: capabilityStateSchema,
+  sync: capabilityStateSchema,
+  initialize: capabilityStateSchema,
+});
+
+const discoveredWorktreeSchema = z.looseObject({
+  path: z.string(),
+  branch: z.string(),
+  isCurrent: z.boolean(),
+  label: worktreeLabelSchema.optional().describe("Only present when includeStatus=true."),
+  divergence: divergenceSchema.optional(),
+  staleHint: z.boolean().optional().describe("Upstream ref is gone. Only present when includeStatus=true."),
+});
+
+const siblingRepositorySchema = z.looseObject({
+  name: z.string(),
+  bareRepoPath: z.string(),
+  worktreeDir: z.string().nullable(),
+  repoUrl: z.string().nullable(),
+  sparseCheckout: z.unknown().optional(),
+  present: z.boolean(),
+  configMatched: z.boolean(),
+});
+
+const configuredRepositorySummarySchema = z.looseObject({
+  name: z.string(),
+  isCurrent: z.boolean(),
+  mode: z.enum(["clone", "worktree"]),
+  checkoutPath: z.string().optional().describe("clone mode only."),
+  worktreeDir: z.string().optional().describe("worktree mode only."),
+  bareRepoDir: z.string().optional().describe("worktree mode, detailed=true only."),
+  repoUrl: z.string().optional().describe("detailed=true only."),
+  branch: z.string().optional().describe("detailed=true only."),
+  sparseCheckout: z.unknown().optional().describe("detailed=true only."),
+  localReady: z.boolean().optional().describe("detailed=true only."),
+});
+
+/** Shared between the `status` member of a listed worktree and the flattened `get_worktree_status` result. */
+const worktreeStatusShape = {
+  isClean: z.boolean(),
+  hasUnpushedCommits: z.boolean(),
+  hasStashedChanges: z.boolean(),
+  hasOperationInProgress: z.boolean(),
+  hasModifiedSubmodules: z.boolean(),
+  upstreamGone: z.boolean(),
+  fullyPushedUpstreamDeleted: z
+    .boolean()
+    .describe("Commits look unpushed only because the upstream ref was deleted after they landed."),
+  canRemove: z.boolean(),
+  reasons: z.array(z.string()),
+  details: z
+    .looseObject({})
+    .optional()
+    .describe("File-level lists (modified, untracked, staged). Only present when includeDetails=true."),
+};
+
+const worktreeStatusSchema = z.looseObject(worktreeStatusShape);
+
+const safeToRemoveSchema = z.looseObject({
+  safe: z.boolean(),
+  reason: z.string(),
+});
+
+const listedWorktreeSchema = z.looseObject({
+  path: z.string(),
+  branch: z.string(),
+  isCurrent: z.boolean(),
+  label: worktreeLabelSchema,
+  status: worktreeStatusSchema.nullable().describe("null when the status probe failed."),
+  divergence: divergenceSchema,
+  safeToRemove: safeToRemoveSchema,
+  lastSyncAt: z.string().nullable(),
+  sizeBytes: z.number().nullable().describe("null unless includeSize=true."),
+});
+
+const repositoryListEntrySchema = z.looseObject({
+  name: z.string(),
+  repoUrl: z.string(),
+  worktreeDir: z.string(),
+  source: z.enum(["config", "detected"]),
+});
+
+export const detectContextOutputSchema = z.looseObject({
+  isWorktree: z.boolean(),
+  kind: z.enum(["managed", "unmanaged", "unsupported"]),
+  currentBranch: z.string().nullable(),
+  currentWorktreePath: z.string().nullable(),
+  bareRepoPath: z.string().nullable(),
+  repoUrl: z.string().nullable(),
+  worktreeDir: z.string().nullable(),
+  allWorktrees: z.array(discoveredWorktreeSchema),
+  allWorktreesByRepo: z
+    .record(z.string(), z.array(discoveredWorktreeSchema))
+    .optional()
+    .describe("Only present when includeAllWorktrees=true."),
+  allWorktreeErrorsByRepo: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Per-repo enumeration errors. Only present when includeAllWorktrees=true and something failed."),
+  siblingRepositories: z.array(siblingRepositorySchema),
+  configPath: z.string().nullable(),
+  repoName: z.string().nullable(),
+  capabilities: capabilitiesSchema,
+  notes: z.array(z.string()),
+  configuredRepositories: z
+    .array(configuredRepositorySummarySchema)
+    .describe("Server-wide loaded-config inventory, independent of params.path."),
+});
+
+export const listWorktreesOutputSchema = z.looseObject({
+  worktrees: z
+    .array(listedWorktreeSchema)
+    .optional()
+    .describe("Present for a single repo (repoName given, or no config)."),
+  repositories: z
+    .record(
+      z.string(),
+      z.looseObject({
+        worktrees: z.array(listedWorktreeSchema),
+        error: z.string().optional().describe("Present instead of results when this repo failed to enumerate."),
+      }),
+    )
+    .optional()
+    .describe("Present when listing all configured repos (no repoName)."),
+});
+
+export const getWorktreeStatusOutputSchema = z.looseObject({
+  path: z.string().describe("Resolved absolute worktree path."),
+  ...worktreeStatusShape,
+  divergence: divergenceSchema,
+});
+
+export const createWorktreeOutputSchema = z.looseObject({
+  success: z.boolean().describe("false when the worktree was created but pushing the new branch failed."),
+  branchName: z.string(),
+  worktreePath: z.string(),
+  created: z.boolean().describe("The branch was newly created (vs. an existing local/remote branch checked out)."),
+  pushed: z.boolean(),
+  pushError: z.string().optional().describe("Present only when success=false."),
+});
+
+export const syncOutputSchema = z.looseObject({
+  success: z.boolean(),
+  duration: z.number().describe("Wall-clock milliseconds."),
+  outcome: z.looseObject({
+    repoName: z.string().optional(),
+    mode: z.enum(["clone", "worktree"]),
+    started: z.literal(true),
+    counts: z.looseObject({
+      created: z.number(),
+      removed: z.number(),
+      updated: z.number(),
+      skipped: z.number(),
+      preserved: z.number(),
+      failed: z.number(),
+      noop: z.number(),
+    }),
+    actions: z.array(
+      z.looseObject({
+        kind: z.enum(["created", "removed", "updated", "noop", "skipped", "preserved-diverged", "failed"]),
+        branch: z.string().optional(),
+        path: z.string().optional(),
+        scope: z.enum(["repo", "branch", "worktree", "sparse-checkout"]).optional(),
+        reason: z.string().optional(),
+        message: z.string().optional(),
+        warning: z.string().optional(),
+        error: z.string().optional(),
+        preservedPath: z.string().optional(),
+      }),
+    ),
+    durationMs: z.number().optional(),
+  }),
+  skips: z.array(
+    z.looseObject({
+      kind: z.string(),
+      message: z.string().describe("Human-readable rendering of the skip reason."),
+    }),
+  ),
+});
+
+export const updateWorktreeOutputSchema = z.looseObject({
+  success: z.boolean(),
+  worktreePath: z.string(),
+});
+
+export const initializeOutputSchema = z.looseObject({
+  success: z.boolean(),
+  defaultBranch: z.string(),
+  worktreeDir: z.string(),
+});
+
+export const loadConfigOutputSchema = z.looseObject({
+  configPath: z.string().describe("Resolved absolute path of the config that was loaded."),
+  currentRepository: z.string().nullable(),
+  repositories: z.array(repositoryListEntrySchema),
+});
+
+export const setCurrentRepositoryOutputSchema = z.looseObject({
+  currentRepository: z.string().nullable(),
+  repositories: z.array(repositoryListEntrySchema),
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,7 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
+
+import packageJson from "../../package.json" with { type: "json" };
 
 import { buildUnsupportedContext } from "./context";
 import {
@@ -53,7 +55,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
   const server = new McpServer(
     {
       name: "sync-worktrees",
-      version: "1.0.0",
+      version: packageJson.version,
     },
     {
       instructions: buildInstructions(snapshot),
@@ -95,7 +97,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Detect sync-worktrees structure from path (default: CWD). Reads .git, resolves bare repo, walks up to auto-load sync-worktrees.config.{js,mjs,cjs,ts}. Returns: configuredRepositories (server-wide loaded-config inventory; independent of params.path), bareRepoPath, allWorktrees, siblingRepositories, currentWorktreePath, configPath, capabilities {available,reason}, notes. Lean configuredRepositories entries are mode-discriminated: clone → {name, mode:'clone', checkoutPath, isCurrent}; worktree → {name, mode:'worktree', worktreeDir, isCurrent}. detailed=true adds repoUrl, branch?, sparseCheckout?, localReady, plus bareRepoDir for worktree mode. Use at session start or to bootstrap from unknown checkout.",
-      inputSchema: {
+      inputSchema: z.object({
         path: z.string().optional().describe("Directory to inspect. Default: server CWD."),
         detailed: z
           .boolean()
@@ -112,7 +114,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
           .describe(
             "Enrich entries with label, divergence, staleHint. Adds 1 git status + rev-list per worktree. Labels here are metadata-blind (no sync metadata is loaded), so a fully-pushed branch whose remote was deleted shows 'dirty'; list_worktrees gives the authoritative label/safeToRemove. Default: false.",
           ),
-      },
+      }),
       annotations: {
         title: "Detect sync-worktrees context",
         readOnlyHint: true,
@@ -128,7 +130,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "List worktrees with status. No repoName + config loaded = all configured repos grouped by repoName. With repoName = single repo. Entries: {path, branch, isCurrent, label (clean|dirty|stale|current|unknown), status, divergence, safeToRemove, lastSyncAt, sizeBytes}.",
-      inputSchema: {
+      inputSchema: z.object({
         repoName: z.string().optional().describe("Repo name. Omit + config loaded = list all configured repos."),
         includeSize: z
           .boolean()
@@ -136,7 +138,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
           .describe(
             "Compute on-disk size per worktree (bytes). Slow on large worktrees. Default: false (sizeBytes=null).",
           ),
-      },
+      }),
       annotations: {
         title: "List worktrees with status",
         readOnlyHint: true,
@@ -152,14 +154,14 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Detailed status for one worktree: dirty files, unpushed commits, stashes, upstream gone, ops in progress. Returns: status + divergence {ahead,behind} + resolved path.",
-      inputSchema: {
+      inputSchema: z.object({
         path: z.string().describe(`Worktree path. ${PATH_DESCRIBE_SUFFIX}`),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
         includeDetails: z
           .boolean()
           .optional()
           .describe("Include file-level lists (modified, untracked, staged). Default: false (counts only)."),
-      },
+      }),
       annotations: {
         title: "Get worktree status",
         readOnlyHint: true,
@@ -175,7 +177,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Worktree-mode only; clone-mode repos error here. Create worktree for a branch. Existing branch (local/remote) = checkout. New branch = create from baseBranch + push to origin (default). baseBranch required only for new branches — pass defensively if unsure. push=false opts out. Preconditions: repo initialized (auto-runs). Returns: {success, branchName, worktreePath, created, pushed}.",
-      inputSchema: {
+      inputSchema: z.object({
         branchName: z.string().describe("Branch name. Slashes/special chars sanitized for dir name."),
         baseBranch: z
           .string()
@@ -185,7 +187,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
           ),
         push: z.boolean().optional().describe("Push new branch to origin. Default: true. Ignored if branch existed."),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
-      },
+      }),
       annotations: {
         title: "Create worktree",
         readOnlyHint: false,
@@ -202,9 +204,9 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Repo-wide sync: fetch, create worktrees for new remote branches, remove pruned (clean only), fast-forward existing. Emits progress. In worktree mode: single worktree? Use update_worktree. Single create? Use create_worktree. Preconditions: config loaded + repo initialized (auto-runs). Returns: {success, duration, skips}.",
-      inputSchema: {
+      inputSchema: z.object({
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
-      },
+      }),
       annotations: {
         title: "Sync repository worktrees",
         readOnlyHint: false,
@@ -221,10 +223,10 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Worktree-mode only; clone-mode repos error here; use sync to update the checkout. Fast-forward one worktree to upstream. No merge, no rebase, aborts if not fast-forwardable. Whole repo? Use sync.",
-      inputSchema: {
+      inputSchema: z.object({
         path: z.string().describe(`Worktree path to fast-forward. ${PATH_DESCRIBE_SUFFIX}`),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
-      },
+      }),
       annotations: {
         title: "Fast-forward one worktree",
         readOnlyHint: false,
@@ -241,9 +243,9 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     {
       description:
         "Initialize repo: clone as bare if missing, create main worktree. Idempotent. Emits progress. Preconditions: config loaded. Returns: {success, defaultBranch, worktreeDir}.",
-      inputSchema: {
+      inputSchema: z.object({
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
-      },
+      }),
       annotations: {
         title: "Initialize repository",
         readOnlyHint: false,
@@ -259,15 +261,15 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "load_config",
     {
       description:
-        "Load/reload sync-worktrees JS config into session. Replaces previously loaded repos. Uses configPath, SYNC_WORKTREES_CONFIG, an already detected config, or a launch-CWD auto-detect fallback. For first discovery from an arbitrary project path, call detect_context with path. Returns: {configPath, currentRepository, repositories: [{name, repoUrl, worktreeDir, source}]}.",
-      inputSchema: {
+        "Load/reload sync-worktrees JS config for this server process. Replaces previously loaded repos. Uses configPath, SYNC_WORKTREES_CONFIG, an already detected config, or a launch-CWD auto-detect fallback. For first discovery from an arbitrary project path, call detect_context with path. Returns: {configPath, currentRepository, repositories: [{name, repoUrl, worktreeDir, source}]}.",
+      inputSchema: z.object({
         configPath: z
           .string()
           .optional()
           .describe(
             "Config file path. Falls back to SYNC_WORKTREES_CONFIG, an already detected config, or launch-CWD auto-detect.",
           ),
-      },
+      }),
       annotations: {
         title: "Load sync-worktrees config",
         readOnlyHint: false,
@@ -283,10 +285,10 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
     "set_current_repository",
     {
       description:
-        "Set current repo for tool calls that omit repoName. Session-scoped. Preconditions: load_config called.",
-      inputSchema: {
+        "Set current repo for tool calls that omit repoName. Applies to this server process. Preconditions: load_config called.",
+      inputSchema: z.object({
         repoName: z.string().describe("Repo name from loaded config repositories[].name."),
-      },
+      }),
       annotations: {
         title: "Set current repository",
         readOnlyHint: false,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,8 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 
-import packageJson from "../../package.json" with { type: "json" };
-
 import { buildUnsupportedContext } from "./context";
 import {
   handleCreateWorktree,
@@ -15,6 +13,17 @@ import {
   handleSync,
   handleUpdateWorktree,
 } from "./handlers";
+import {
+  createWorktreeOutputSchema,
+  detectContextOutputSchema,
+  getWorktreeStatusOutputSchema,
+  initializeOutputSchema,
+  listWorktreesOutputSchema,
+  loadConfigOutputSchema,
+  setCurrentRepositoryOutputSchema,
+  syncOutputSchema,
+  updateWorktreeOutputSchema,
+} from "./output-schemas";
 import { wrapHandler } from "./utils";
 
 import type { DiscoveredRepoContext, RepositoryContext } from "./context";
@@ -23,6 +32,9 @@ const REPO_NAME_DESCRIBE =
   "Repo name from loaded config. Omit to use current (set via set_current_repository) or the only loaded repo.";
 
 const PATH_DESCRIBE_SUFFIX = "Absolute preferred; relative resolves from server CWD.";
+
+/** The tool/resource registry is fixed at construction, so clients may cache the listings for an hour. */
+const TOOL_REGISTRY_TTL_MS = 3_600_000;
 
 const SERVER_INSTRUCTIONS =
   "Call `detect_context` for the project map and live worktree state; `configuredRepositories` in its response is the server-wide loaded-config inventory. Use `set_current_repository` to switch repos. Auto-loads sync-worktrees.config.{js,mjs,cjs,ts} via walk-up. Repos run in one of two modes. worktree (default): a bare repo plus branch worktrees, with new worktrees created under worktreeDir. clone: one standalone checkout where worktreeDir is the repo root. create_worktree and update_worktree are worktree-mode only; in clone mode, use sync to update the checkout.";
@@ -55,10 +67,19 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
   const server = new McpServer(
     {
       name: "sync-worktrees",
-      version: packageJson.version,
+      version: __SYNC_WORKTREES_VERSION__,
     },
     {
       instructions: buildInstructions(snapshot),
+      // The tool and resource registries are built once at construction and
+      // never mutated, so they are safe to cache for a long time and carry no
+      // user-specific data. `server/discover` is kept private because its
+      // instructions embed connect-time workspace and config paths.
+      cacheHints: {
+        "tools/list": { ttlMs: TOOL_REGISTRY_TTL_MS, cacheScope: "public" },
+        "resources/list": { ttlMs: TOOL_REGISTRY_TTL_MS, cacheScope: "public" },
+        "server/discover": { ttlMs: TOOL_REGISTRY_TTL_MS, cacheScope: "private" },
+      },
     },
   );
 
@@ -70,6 +91,9 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
       description:
         "Workspace context: isWorktree, kind, currentWorktreePath, currentBranch, allWorktrees, siblingRepositories, configPath, capabilities {available,reason}, configuredRepositories (server-wide loaded-config inventory). {isWorktree:false} when outside any workspace.",
       mimeType: "application/json",
+      // Live git state, re-probed on every read: never cache, and never share
+      // between clients (the payload carries local filesystem paths).
+      cacheHint: { ttlMs: 0, cacheScope: "private" },
     },
     async (uri) => {
       let payload: unknown;
@@ -115,6 +139,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
             "Enrich entries with label, divergence, staleHint. Adds 1 git status + rev-list per worktree. Labels here are metadata-blind (no sync metadata is loaded), so a fully-pushed branch whose remote was deleted shows 'dirty'; list_worktrees gives the authoritative label/safeToRemove. Default: false.",
           ),
       }),
+      outputSchema: detectContextOutputSchema,
       annotations: {
         title: "Detect sync-worktrees context",
         readOnlyHint: true,
@@ -139,6 +164,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
             "Compute on-disk size per worktree (bytes). Slow on large worktrees. Default: false (sizeBytes=null).",
           ),
       }),
+      outputSchema: listWorktreesOutputSchema,
       annotations: {
         title: "List worktrees with status",
         readOnlyHint: true,
@@ -162,6 +188,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
           .optional()
           .describe("Include file-level lists (modified, untracked, staged). Default: false (counts only)."),
       }),
+      outputSchema: getWorktreeStatusOutputSchema,
       annotations: {
         title: "Get worktree status",
         readOnlyHint: true,
@@ -188,6 +215,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
         push: z.boolean().optional().describe("Push new branch to origin. Default: true. Ignored if branch existed."),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       }),
+      outputSchema: createWorktreeOutputSchema,
       annotations: {
         title: "Create worktree",
         readOnlyHint: false,
@@ -207,6 +235,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
       inputSchema: z.object({
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       }),
+      outputSchema: syncOutputSchema,
       annotations: {
         title: "Sync repository worktrees",
         readOnlyHint: false,
@@ -227,6 +256,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
         path: z.string().describe(`Worktree path to fast-forward. ${PATH_DESCRIBE_SUFFIX}`),
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       }),
+      outputSchema: updateWorktreeOutputSchema,
       annotations: {
         title: "Fast-forward one worktree",
         readOnlyHint: false,
@@ -246,6 +276,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
       inputSchema: z.object({
         repoName: z.string().optional().describe(REPO_NAME_DESCRIBE),
       }),
+      outputSchema: initializeOutputSchema,
       annotations: {
         title: "Initialize repository",
         readOnlyHint: false,
@@ -270,6 +301,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
             "Config file path. Falls back to SYNC_WORKTREES_CONFIG, an already detected config, or launch-CWD auto-detect.",
           ),
       }),
+      outputSchema: loadConfigOutputSchema,
       annotations: {
         title: "Load sync-worktrees config",
         readOnlyHint: false,
@@ -289,6 +321,7 @@ export function createServer(context: RepositoryContext, snapshot?: ServerSnapsh
       inputSchema: z.object({
         repoName: z.string().describe("Repo name from loaded config repositories[].name."),
       }),
+      outputSchema: setCurrentRepositoryOutputSchema,
       annotations: {
         title: "Set current repository",
         readOnlyHint: false,

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,9 +1,8 @@
 import { SyncWorktreesError } from "../errors";
 
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type { CallToolResult, ServerNotification, ServerRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ServerContext } from "@modelcontextprotocol/server";
 
-export type HandlerExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+export type HandlerContext = ServerContext;
 
 export function formatToolResponse(data: unknown): CallToolResult {
   return {
@@ -62,11 +61,11 @@ export class SyncInProgressError extends SyncWorktreesError {
 }
 
 export function wrapHandler<P>(
-  fn: (params: P, extra: HandlerExtra) => Promise<CallToolResult>,
-): (params: P, extra: HandlerExtra) => Promise<CallToolResult> {
-  return async (params, extra) => {
+  fn: (params: P, ctx: HandlerContext) => Promise<CallToolResult>,
+): (params: P, ctx: HandlerContext) => Promise<CallToolResult> {
+  return async (params, ctx) => {
     try {
-      return await fn(params, extra);
+      return await fn(params, ctx);
     } catch (error) {
       return formatErrorResponse(error);
     }

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -4,7 +4,13 @@ import type { CallToolResult, ServerContext } from "@modelcontextprotocol/server
 
 export type HandlerContext = ServerContext;
 
-export function formatToolResponse(data: unknown): CallToolResult {
+/**
+ * Every tool advertises an `outputSchema`, so each result must carry a
+ * `structuredContent` matching it (SEP-2106) — the SDK rejects a result that
+ * omits it. The JSON text block is kept alongside for clients that only read
+ * `content`.
+ */
+export function formatToolResponse(data: object): CallToolResult {
   return {
     content: [
       {
@@ -12,6 +18,7 @@ export function formatToolResponse(data: unknown): CallToolResult {
         text: JSON.stringify(data),
       },
     ],
+    structuredContent: data as Record<string, unknown>,
   };
 }
 

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Injected at build time by `esbuild.config.js` (bundle) and `vitest.config.ts`
+ * (tests) from the `version` field of package.json. Using a define instead of
+ * `import packageJson from "../../package.json"` keeps esbuild from inlining
+ * the entire manifest — scripts, devDependencies and all — into the shipped
+ * `dist/mcp-server.js` bundle just to read one string.
+ */
+declare const __SYNC_WORKTREES_VERSION__: string;

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -6,6 +6,7 @@
     "jsx": "react"
   },
   "include": [
+    "src/types/globals.d.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.spec.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from "node:fs";
 import path from "path";
 
 import { defineConfig } from "vitest/config";
 
+const { version } = JSON.parse(readFileSync(path.resolve(__dirname, "./package.json"), "utf8"));
+
 export default defineConfig({
+  define: {
+    __SYNC_WORKTREES_VERSION__: JSON.stringify(version),
+  },
   test: {
     globals: false,
     environment: "node",


### PR DESCRIPTION
## Summary

- replace `@modelcontextprotocol/sdk` v1 with `@modelcontextprotocol/server` v2
- serve stdio through `serveStdio(..., { legacy: "serve" })`, so 2026-07-28 and 2025-era clients are both served from the same tool registry
- migrate handler context and progress notifications to `ctx.mcpReq`
- use v2 Standard Schema objects, advertise `outputSchema` on all nine tools, and return `structuredContent`
- set cache hints on the listing operations, and pin the live workspace resource to no caching
- report transport errors to stderr and close the stdio handle on `SIGINT`/`SIGTERM`
- derive server identity from a build-time version define instead of importing `package.json`
- add protocol-level coverage for discovery, tool listing/calls, output schemas, cache fields, and 2025-era compatibility

## Why

MCP 2026-07-28 removes the legacy initialization handshake and moves request metadata into a per-request envelope. The stdio server now speaks that revision natively.

It keeps serving 2025-era clients rather than rejecting them. `serveStdio`'s `legacy: "serve"` pins a 2025-era instance from the same factory, so compatibility costs nothing — the same tools, instructions and resource are served either way. The 2026-07-28 revision keeps older revisions alive for at least twelve months under its new deprecation policy, and most MCP clients have not shipped 2026-07-28 support yet, so rejecting them would strand existing installs.

## Impact

Not a breaking change. Tool names, arguments, results, the resource URI, and CLI commands are unchanged, and clients on either protocol era keep working — hence a minor Changesets entry.

Tool results now additionally carry `structuredContent` alongside the existing JSON text block. `tools/list` and `resources/list` are advertised as publicly cacheable for an hour, since the registry is fixed at construction; `server/discover` stays private because its instructions embed connect-time workspace paths; the `workspace` resource is pinned to `ttlMs: 0` because it re-probes live git state on every read.

## Validation

- full suite: 1,545 passed, 5 skipped
- `pnpm typecheck`, `pnpm lint`, `pnpm build`
- built stdio server driven over a **real git repository** through all nine tools: every result validated against its advertised `outputSchema` and returned `structuredContent`, against populated payloads (both `created` and `noop` sync actions, non-null worktree status, enriched `detect_context` entries, detailed repo summaries)
- built stdio smoke verified the 2026-07-28 envelope path, the 2025-era handshake, matching tool registries across both eras, the configured cache fields, and `sync-worktrees@5.2.0` identity
- verified `dist/mcp-server.js` no longer embeds the package manifest

Skipped tests are pre-existing: four opt-in network E2E cases requiring `RUN_NETWORK_E2E=true`, plus the hard-skipped config-file `runOnce` case.

### Note on output schemas

The v2 SDK **enforces** advertised output schemas — a missing or mismatched `structuredContent` silently turns a successful tool call into an error result. The schemas therefore mirror the handler return types: a field is `required` only where the TypeScript type guarantees it, and every object is loose so adding a response field is never a breaking wire change. Error results (`isError: true`) carry no `structuredContent` and are exempt.

## Summary by CodeRabbit

* **New Features**
  * Added support for the MCP 2026-07-28 protocol, while continuing to serve clients on the previous protocol revision.
  * Tools now publish structured output schemas and return structured results alongside text.
  * Listing responses carry cache hints so clients can avoid re-fetching a static registry.
  * Improved progress updates with clearer tokens, phases, counters, and messages.
  * Updated tool descriptions to clarify server-process scope.

* **Chores**
  * Updated the MCP server integration to the latest runtime implementation.
  * Transport errors are reported and the server shuts down cleanly on termination signals.
