### PR TITLE
Fix sync/delete defects found in adversarially-verified code review

### DIFF
--- a/.changeset/sync-delete-review-fixes.md
+++ b/.changeset/sync-delete-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"sync-worktrees": patch
+---
+
+Fix sync/delete defects found in code review: forward the full (sanitized) process environment to every clone-mode and LFS-skip git subprocess so authenticated remotes work; stop a stale clone-mode init skip from being silently swallowed by the next sync; recreate the default-branch worktree when its directory was deleted out-of-band instead of failing every sync; keep branches containing `|` (and one literally named `origin`) in the sync inventory so their worktrees are no longer wrongly pruned; classify a deleted tracked branch during an unshallow fetch as the usual soft skip; re-verify HEAD before moving a worktree to trash so a commit made mid-removal is never left unreachable; abort clone init on a transient directory probe failure instead of risking cleanup of a pre-existing directory; resume an interrupted clone init's file copy via a pending marker; validate `.diverged` metadata types before trash adoption; serialize worktree-mode syncs on the worktreeDir (not just the bare repo), canonicalize lock keys through symlinks, and survive a compromised repo lock instead of crashing the whole multi-repo run.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,6 +103,10 @@ export const PATH_CONSTANTS = {
   GIT_DIR: ".git",
   README: "README",
   CLONE_INIT_MARKER: ".sync-worktrees-clone-init",
+  /** Written right after a successful clone, removed once the initial file
+   * copy lands — its presence marks a tool-created clone whose init was
+   * interrupted and still owes the copy. */
+  CLONE_INIT_PENDING_MARKER: ".sync-worktrees-clone-init.pending",
 } as const;
 
 export const CONFIG_FILE_NAMES = [

--- a/src/services/__tests__/clone-sync.service.test.ts
+++ b/src/services/__tests__/clone-sync.service.test.ts
@@ -455,6 +455,49 @@ describe("CloneSyncService", () => {
 
       expect(copyFilesSpy).not.toHaveBeenCalled();
     });
+
+    it("refuses to proceed when the pre-clone directory probe fails for a non-ENOENT reason (#review)", async () => {
+      const eacces = new Error("permission denied") as NodeJS.ErrnoException;
+      eacces.code = "EACCES";
+      (fs.readdir as unknown as Mock).mockRejectedValueOnce(eacces);
+
+      const service = new CloneSyncService(makeConfig(), buildGitService(), logger);
+
+      // A transient probe failure must never be read as "directory did not
+      // exist" — that authorization later lets a failed clone rm -rf a
+      // pre-existing directory.
+      await expect(service.initialize()).rejects.toBeInstanceOf(GitOperationError);
+      expect(gitMock.clone).not.toHaveBeenCalled();
+      expect(fs.rm).not.toHaveBeenCalled();
+    });
+
+    it("completes an interrupted init's pending file copy when adopting the existing clone (#review)", async () => {
+      (fs.readdir as unknown as Mock).mockResolvedValueOnce([".git", "src"]);
+      (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
+      (fs.writeFile as unknown as Mock).mockResolvedValue(undefined);
+      (fs.rm as unknown as Mock).mockResolvedValue(undefined);
+      // Pending marker present (init was interrupted after the clone), final
+      // marker absent (the copy never ran).
+      (fs.access as unknown as Mock).mockImplementation(async (p: unknown) => {
+        if (String(p).endsWith(".pending")) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const branchCreatedActions = new BranchCreatedActionsService();
+      const copyFilesSpy = vi.spyOn(branchCreatedActions, "copyFiles").mockResolvedValue();
+
+      const service = new CloneSyncService(
+        makeConfig({ filesToCopyOnBranchCreate: ["CLAUDE.md"] }),
+        buildGitService(),
+        logger,
+        { branchCreatedActions },
+      );
+
+      await service.initialize();
+
+      expect(copyFilesSpy).toHaveBeenCalledTimes(1);
+      expect(fs.rm).toHaveBeenCalledWith(expect.stringContaining(".pending"), { force: true });
+    });
   });
 
   describe("getWorktrees", () => {
@@ -849,6 +892,31 @@ describe("CloneSyncService", () => {
         "--progress",
         "+refs/heads/main:refs/remotes/origin/main",
       ]);
+    });
+
+    it("soft-skips with missing_remote_ref when the unshallow fetch hits a deleted tracked branch (#review)", async () => {
+      gitMock.raw.mockImplementation(async (args: string[]) => {
+        const key = args.join(" ");
+        if (key === "rev-parse --abbrev-ref HEAD") return "main";
+        if (key === "rev-parse --is-shallow-repository") return "true\n";
+        if (key.startsWith("remote get-url origin")) return "https://github.com/example/repo.git";
+        return "";
+      });
+      gitMock.fetch.mockRejectedValueOnce(new Error("fatal: couldn't find remote ref refs/heads/main"));
+      const skips: CloneSkipReason[] = [];
+      const service = new CloneSyncService(makeConfig(), buildGitService(), logger, {
+        onSkip: (reason) => skips.push(reason),
+      });
+      setInitialized(service);
+
+      // The unshallow fetch uses the narrowed refspec, so a deleted tracked
+      // branch must become the same soft skip as the branch fetch — not a
+      // hard sync failure unique to shallow clones.
+      await expect(service.runSyncAttempt()).resolves.toBeUndefined();
+
+      expect(skips).toEqual([{ kind: "missing_remote_ref", branch: "main", source: "fetch_error" }]);
+      expect(gitMock.fetch).toHaveBeenCalledTimes(1);
+      expect(gitMock.merge).not.toHaveBeenCalled();
     });
 
     it("does not unshallow when depth is configured", async () => {

--- a/src/services/__tests__/clone-sync.service.test.ts
+++ b/src/services/__tests__/clone-sync.service.test.ts
@@ -498,6 +498,39 @@ describe("CloneSyncService", () => {
       expect(copyFilesSpy).toHaveBeenCalledTimes(1);
       expect(fs.rm).toHaveBeenCalledWith(expect.stringContaining(".pending"), { force: true });
     });
+
+    it("re-runs sparse-checkout setup when resuming an interrupted init (#review)", async () => {
+      (fs.readdir as unknown as Mock).mockResolvedValueOnce([".git", "src"]);
+      (fs.mkdir as unknown as Mock).mockResolvedValue(undefined);
+      (fs.writeFile as unknown as Mock).mockResolvedValue(undefined);
+      (fs.rm as unknown as Mock).mockResolvedValue(undefined);
+      (fs.access as unknown as Mock).mockImplementation(async (p: unknown) => {
+        if (String(p).endsWith(".pending")) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const branchCreatedActions = new BranchCreatedActionsService();
+      const copyFilesSpy = vi.spyOn(branchCreatedActions, "copyFiles").mockResolvedValue();
+      const gitService = buildGitService();
+
+      const service = new CloneSyncService(
+        makeConfig({
+          filesToCopyOnBranchCreate: ["CLAUDE.md"],
+          sparseCheckout: { include: ["src"] },
+        }),
+        gitService,
+        logger,
+        { branchCreatedActions },
+      );
+
+      await service.initialize();
+
+      // The init that wrote the pending marker may have died inside sparse
+      // setup, so resume must reapply it (idempotent) before the file copy.
+      const sparseService = gitService.getSparseCheckoutService();
+      expect(sparseService.applyToWorktree).toHaveBeenCalledTimes(1);
+      expect(copyFilesSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("getWorktrees", () => {

--- a/src/services/__tests__/git-update.test.ts
+++ b/src/services/__tests__/git-update.test.ts
@@ -135,7 +135,7 @@ describe("GitService - Update Methods", () => {
 
       await service.updateWorktree("/test/worktrees/main");
 
-      expect(mockGit.env).toHaveBeenCalledWith({ GIT_LFS_SKIP_SMUDGE: "1" });
+      expect(mockGit.env).toHaveBeenCalledWith(expect.objectContaining({ GIT_LFS_SKIP_SMUDGE: "1" }));
       expect(mockGit.merge).toHaveBeenCalledWith(["origin/main", "--ff-only"]);
     });
 

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -353,7 +353,7 @@ describe("GitService", () => {
 
       await svc.initialize();
       await svc.fetchBranch("feature-2");
-      expect(mockGit.env).toHaveBeenCalledWith({ GIT_LFS_SKIP_SMUDGE: "1" });
+      expect(mockGit.env).toHaveBeenCalledWith(expect.objectContaining({ GIT_LFS_SKIP_SMUDGE: "1" }));
       expect(mockGit.fetch).toHaveBeenCalledWith(["origin", "feature-2", "--prune", "--progress"]);
     });
   });
@@ -490,9 +490,9 @@ describe("GitService", () => {
 
     it("should return branches with their last activity dates", async () => {
       const mockOutput = [
-        "origin/main|2024-01-15T10:30:00-05:00",
-        "origin/feature-1|2024-01-10T14:20:00-05:00",
-        "origin/feature-2|2023-12-25T08:15:00-05:00",
+        "origin/main 2024-01-15T10:30:00-05:00",
+        "origin/feature-1 2024-01-10T14:20:00-05:00",
+        "origin/feature-2 2023-12-25T08:15:00-05:00",
       ].join("\n");
 
       mockGit.raw.mockResolvedValueOnce(mockOutput as any);
@@ -501,7 +501,7 @@ describe("GitService", () => {
 
       expect(mockGit.raw).toHaveBeenCalledWith([
         "for-each-ref",
-        "--format=%(refname:short)|%(committerdate:iso8601)",
+        "--format=%(refname:short)%00%(committerdate:iso8601)",
         "refs/remotes/origin",
       ]);
 
@@ -530,10 +530,10 @@ describe("GitService", () => {
 
     it("should skip invalid lines", async () => {
       const mockOutput = [
-        "origin/main|2024-01-15T10:30:00-05:00",
+        "origin/main 2024-01-15T10:30:00-05:00",
         "invalid-line",
-        "origin/feature-1|invalid-date",
-        "origin/feature-2|2024-01-10T14:20:00-05:00",
+        "origin/feature-1 invalid-date",
+        "origin/feature-2 2024-01-10T14:20:00-05:00",
       ].join("\n");
 
       mockGit.raw.mockResolvedValueOnce(mockOutput as any);
@@ -547,9 +547,9 @@ describe("GitService", () => {
 
     it("should filter out origin/HEAD", async () => {
       const mockOutput = [
-        "origin/main|2024-01-15T10:30:00-05:00",
-        "origin/HEAD|2024-01-15T10:30:00-05:00",
-        "origin/feature-1|2024-01-14T09:15:00-05:00",
+        "origin/main 2024-01-15T10:30:00-05:00",
+        "origin/HEAD 2024-01-15T10:30:00-05:00",
+        "origin/feature-1 2024-01-14T09:15:00-05:00",
       ].join("\n");
 
       mockGit.raw.mockResolvedValueOnce(mockOutput as any);
@@ -560,6 +560,32 @@ describe("GitService", () => {
       expect(branches[0].branch).toBe("main");
       expect(branches[1].branch).toBe("feature-1");
       expect(branches.some((b) => b.branch === "HEAD")).toBe(false);
+    });
+
+    it("keeps branches whose names contain '|' (legal refname character) (#review)", async () => {
+      const mockOutput = [
+        "origin/feature|wip 2024-01-15T10:30:00-05:00",
+        "origin/main 2024-01-10T14:20:00-05:00",
+      ].join("\n");
+
+      mockGit.raw.mockResolvedValueOnce(mockOutput as any);
+
+      const branches = await gitService.getRemoteBranchesWithActivity();
+
+      expect(branches).toHaveLength(2);
+      expect(branches[0].branch).toBe("feature|wip");
+      expect(branches[0].lastActivity).toEqual(new Date("2024-01-15T10:30:00-05:00"));
+    });
+
+    it("keeps a remote branch literally named 'origin' (#review)", async () => {
+      const mockOutput = ["origin/origin 2024-01-15T10:30:00-05:00"].join("\n");
+
+      mockGit.raw.mockResolvedValueOnce(mockOutput as any);
+
+      const branches = await gitService.getRemoteBranchesWithActivity();
+
+      expect(branches).toHaveLength(1);
+      expect(branches[0].branch).toBe("origin");
     });
   });
 
@@ -1313,7 +1339,7 @@ describe("GitService", () => {
 
       await gitService.fetchAll();
 
-      expect(mockGit.env).toHaveBeenCalledWith({ GIT_LFS_SKIP_SMUDGE: "1" });
+      expect(mockGit.env).toHaveBeenCalledWith(expect.objectContaining({ GIT_LFS_SKIP_SMUDGE: "1" }));
     });
 
     it("should not affect git operations when disabled", async () => {
@@ -1327,7 +1353,7 @@ describe("GitService", () => {
     it("should be togglable at runtime", async () => {
       gitService.setLfsSkipEnabled(true);
       await gitService.fetchAll();
-      expect(mockGit.env).toHaveBeenCalledWith({ GIT_LFS_SKIP_SMUDGE: "1" });
+      expect(mockGit.env).toHaveBeenCalledWith(expect.objectContaining({ GIT_LFS_SKIP_SMUDGE: "1" }));
 
       vi.clearAllMocks();
       (simpleGit as unknown as Mock).mockReturnValue(mockGit);

--- a/src/services/__tests__/repo-operation-lock.test.ts
+++ b/src/services/__tests__/repo-operation-lock.test.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as lockfile from "proper-lockfile";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getCloneModeLockTarget } from "../../utils/lock-path";
+import { getWorktreeDirLockTarget } from "../../utils/lock-path";
 import { RepoOperationLock } from "../repo-operation-lock";
 
 import type { Config } from "../../types";
@@ -55,16 +55,36 @@ describe("RepoOperationLock", () => {
     expect(lockfile.lock).not.toHaveBeenCalled();
   });
 
-  it("locks the bare repository path in worktree mode", async () => {
-    const lock = new RepoOperationLock(makeConfig(), gitService as GitService);
+  it("locks both the bare repository path and the worktreeDir lock file in worktree mode", async () => {
+    const config = makeConfig();
+    const worktreeTarget = getWorktreeDirLockTarget(config);
+    const lock = new RepoOperationLock(config, gitService as GitService);
 
-    await expect(lock.acquire()).resolves.toBe(release);
+    const acquired = await lock.acquire();
+    expect(acquired).toBeTypeOf("function");
 
     expect(fs.mkdir).toHaveBeenCalledWith("/tmp/bare.git", { recursive: true });
     expect(lockfile.lock).toHaveBeenCalledWith(
       "/tmp/bare.git",
+      expect.objectContaining({ retries: 0, realpath: false, onCompromised: expect.any(Function) }),
+    );
+    expect(lockfile.lock).toHaveBeenCalledWith(
+      path.join(worktreeTarget.dir, worktreeTarget.file),
       expect.objectContaining({ retries: 0, realpath: false }),
     );
+
+    await acquired?.();
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the bare-repo lock and returns null when the worktreeDir lock is contended in worktree mode", async () => {
+    const contended = new Error("locked") as NodeJS.ErrnoException;
+    contended.code = "ELOCKED";
+    (lockfile.lock as Mock).mockResolvedValueOnce(release).mockRejectedValueOnce(contended);
+    const lock = new RepoOperationLock(makeConfig(), gitService as GitService);
+
+    await expect(lock.acquire()).resolves.toBeNull();
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("locks a stable clone-mode lock file", async () => {
@@ -73,7 +93,7 @@ describe("RepoOperationLock", () => {
       branch: "main",
       __configFileDir: "/tmp/config",
     });
-    const target = getCloneModeLockTarget(config);
+    const target = getWorktreeDirLockTarget(config);
     const lock = new RepoOperationLock(config, gitService as GitService);
 
     await expect(lock.acquire()).resolves.toBe(release);

--- a/src/services/__tests__/trash.service.test.ts
+++ b/src/services/__tests__/trash.service.test.ts
@@ -27,6 +27,7 @@ function makeGitStub() {
     resetWorktreeIndex: vi.fn<any>().mockResolvedValue(undefined),
     removeWorktree: vi.fn<any>().mockResolvedValue(undefined),
     deleteLocalBranch: vi.fn<any>().mockResolvedValue(undefined),
+    deleteLocalBranchIfAt: vi.fn<any>().mockResolvedValue(undefined),
   };
 }
 
@@ -189,10 +190,30 @@ describe("TrashService", () => {
       expect(branchRefError).toBeUndefined();
       await expect(fs.access(entry.payloadPath)).resolves.toBeUndefined();
       expect(gitStub.removeWorktree).toHaveBeenCalledWith(source, { force: true });
-      expect(gitStub.deleteLocalBranch).toHaveBeenCalledWith("feature-seq");
+      // Conditional delete: the ref goes only while it still points at the
+      // verified HEAD, so a commit racing the removal keeps its branch.
+      expect(gitStub.deleteLocalBranchIfAt).toHaveBeenCalledWith("feature-seq", "abc123");
+      expect(gitStub.deleteLocalBranch).not.toHaveBeenCalled();
       expect(gitStub.removeWorktree.mock.invocationCallOrder[0]).toBeLessThan(
-        gitStub.deleteLocalBranch.mock.invocationCallOrder[0],
+        gitStub.deleteLocalBranchIfAt.mock.invocationCallOrder[0],
       );
+    });
+
+    it("keeps the branch ref (leftover warning) when it moved between HEAD verification and deletion", async () => {
+      // The CAS delete refuses because the ref no longer points at the
+      // verified oid — the racing commit must keep its branch.
+      gitStub.deleteLocalBranchIfAt.mockRejectedValue(new Error("ref value mismatch"));
+      const source = await makeSourceDir("racing-ref");
+
+      const { entry, branchRefError } = await service.trashAndUnregisterWorktree({
+        dirPath: source,
+        branch: "racing-ref",
+        reason: "prune",
+      });
+
+      expect(branchRefError).toContain("ref value mismatch");
+      expect(gitStub.deleteLocalBranch).not.toHaveBeenCalled();
+      await expect(fs.access(entry.payloadPath)).resolves.toBeUndefined();
     });
 
     it("refuses keep-on-reap removal when HEAD cannot be resolved before unregistering the worktree", async () => {
@@ -237,7 +258,7 @@ describe("TrashService", () => {
 
     it("returns the ref-delete failure as a warning — the payload is already safe in trash", async () => {
       const source = await makeSourceDir("feature-leftover");
-      gitStub.deleteLocalBranch.mockRejectedValue(new Error("ref locked"));
+      gitStub.deleteLocalBranchIfAt.mockRejectedValue(new Error("ref locked"));
 
       const { entry, branchRefError } = await service.trashAndUnregisterWorktree({
         dirPath: source,

--- a/src/services/__tests__/trash.service.test.ts
+++ b/src/services/__tests__/trash.service.test.ts
@@ -146,6 +146,34 @@ describe("TrashService", () => {
       expect(trashContents).toEqual([]);
       expect(gitStub.deleteRef).toHaveBeenCalledWith(expect.stringContaining(GIT_CONSTANTS.TRASH_REF_PREFIX));
     });
+
+    it("aborts and rolls back when HEAD moves between resolution and the payload move (commit made mid-trash)", async () => {
+      // First resolution pins abc123; the pre-rename re-check sees a new
+      // commit the user made during the (slow) size scan / bundle window.
+      gitStub.getCurrentCommit.mockResolvedValueOnce("abc123").mockResolvedValueOnce("def456");
+      const source = await makeSourceDir("racing-commit");
+
+      await expect(
+        service.trashDirectory({ dirPath: source, branch: "racing-commit", reason: "prune" }),
+      ).rejects.toBeInstanceOf(TrashOperationError);
+
+      // Source untouched, no trash container left behind, pin rolled back.
+      await expect(fs.access(source)).resolves.toBeUndefined();
+      const trashContents = await fs.readdir(service.getTrashRoot()).catch(() => []);
+      expect(trashContents).toEqual([]);
+      expect(gitStub.deleteRef).toHaveBeenCalledWith(expect.stringContaining(GIT_CONSTANTS.TRASH_REF_PREFIX));
+    });
+
+    it("aborts when HEAD can no longer be resolved at the pre-rename re-check", async () => {
+      gitStub.getCurrentCommit.mockResolvedValueOnce("abc123").mockRejectedValueOnce(new Error("gone"));
+      const source = await makeSourceDir("vanishing-head");
+
+      await expect(
+        service.trashDirectory({ dirPath: source, branch: "vanishing-head", reason: "prune" }),
+      ).rejects.toBeInstanceOf(TrashOperationError);
+
+      await expect(fs.access(source)).resolves.toBeUndefined();
+    });
   });
 
   describe("trashAndUnregisterWorktree", () => {

--- a/src/services/__tests__/worktree-sync.service.test.ts
+++ b/src/services/__tests__/worktree-sync.service.test.ts
@@ -75,6 +75,7 @@ const { mockGitServiceInstance } = vi.hoisted(() => {
       deleteRef: vi.fn<any>().mockResolvedValue(undefined),
       listRefs: vi.fn<any>().mockResolvedValue([]),
       deleteLocalBranch: vi.fn<any>().mockResolvedValue(undefined),
+      deleteLocalBranchIfAt: vi.fn<any>().mockResolvedValue(undefined),
       createBundleFromRef: vi.fn<any>().mockResolvedValue(true),
       setStaleDirectoryTrasher: vi.fn(),
       getBareRepoPath: vi.fn(() => "/test/.bare/repo.git"),
@@ -1486,7 +1487,8 @@ describe("WorktreeSyncService", () => {
 
         expect(fs.rename).toHaveBeenCalledWith(oldBranchPath, expect.stringContaining(path.join(".trash", "")));
         expect(mockGitService.removeWorktree).toHaveBeenCalledWith(oldBranchPath, { force: true });
-        expect(mockGitService.deleteLocalBranch).toHaveBeenCalledWith("old-branch");
+        // Conditional on the verified HEAD: a commit racing the removal keeps its ref.
+        expect(mockGitService.deleteLocalBranchIfAt).toHaveBeenCalledWith("old-branch", "abc123");
         expect(mockGitService.updateRef).toHaveBeenCalledWith(
           expect.stringContaining("refs/sync-worktrees/trash/"),
           "abc123",
@@ -1494,7 +1496,7 @@ describe("WorktreeSyncService", () => {
       });
 
       it("records the prune as removed with a warning when the branch ref cannot be deleted — payload already safe", async () => {
-        mockGitService.deleteLocalBranch.mockRejectedValueOnce(new Error("ref locked"));
+        mockGitService.deleteLocalBranchIfAt.mockRejectedValueOnce(new Error("ref locked"));
 
         const result = await service.sync();
 

--- a/src/services/clone-sync.service.ts
+++ b/src/services/clone-sync.service.ts
@@ -602,11 +602,19 @@ export class CloneSyncService {
       const git = this.clientFor(worktreeDir, this.getFetchTimeoutMs());
       await this.configureSingleBranchRemote(git, branch);
       // A pending marker means this clone was created by an init of ours that
-      // was interrupted after the clone but before the initial file copy —
-      // finish that copy now. Pre-existing user clones never carry the marker
-      // and are left alone.
+      // was interrupted after the clone — finish the post-clone steps now.
+      // Sparse setup is re-run too (idempotent), so an init that died inside
+      // it does not leave the clone permanently un-narrowed. The marker is
+      // deliberately written BEFORE the sparse step: written after it, a
+      // sparse failure would leave no marker and the file copy would be
+      // silently dropped forever. Pre-existing user clones never carry the
+      // marker and are left alone.
       if (await fileExists(this.getInitPendingMarkerPath(worktreeDir))) {
-        this.logger.info(`Completing interrupted initialization for '${this.repoName}' (initial file copy)...`);
+        this.logger.info(`Completing interrupted initialization for '${this.repoName}'...`);
+        if (this.config.sparseCheckout) {
+          await this.gitService.getSparseCheckoutService().applyToWorktree(worktreeDir, this.config.sparseCheckout);
+          await git.raw(["checkout", "HEAD"]);
+        }
         await this.runInitialFileCopy(worktreeDir, branch);
       }
       this.initialized = true;

--- a/src/services/clone-sync.service.ts
+++ b/src/services/clone-sync.service.ts
@@ -6,6 +6,7 @@ import simpleGit from "simple-git";
 import { DEFAULT_CONFIG, ENV_CONSTANTS, PATH_CONSTANTS } from "../constants";
 import { ConfigError, FastForwardError, GitOperationError, WorktreeNotCleanError } from "../errors";
 import { fileExists } from "../utils/file-exists";
+import { sanitizeGitEnv } from "../utils/git-env";
 import { makeGitProgressHandler } from "../utils/git-progress";
 import { normalizeRepoUrlForComparison } from "../utils/git-url";
 import { getErrorMessage, isLfsError, isMissingRemoteRefError } from "../utils/lfs-error";
@@ -111,6 +112,11 @@ export class CloneSyncService {
   private buildGitOptions(blockMs: number): Partial<SimpleGitOptions> {
     const options: Partial<SimpleGitOptions> = {
       progress: makeGitProgressHandler(this.logger, (event) => this.emitProgress(event)),
+      // Every clone-mode client passes an explicit env (buildGitEnv), which
+      // trips simple-git's unsafe-env validation on variables plain env
+      // inheritance passes freely (GIT_ASKPASS, GIT_CONFIG_COUNT). The env is
+      // the trusted parent environment, so keep parity with inheritance.
+      unsafe: { allowUnsafeAskPass: true, allowUnsafeConfigEnvCount: true },
     };
     if (blockMs > 0) options.timeout = { block: blockMs };
     return options;
@@ -171,9 +177,12 @@ export class CloneSyncService {
   // Force a stable C locale so git's stderr is deterministic English. The
   // missing-remote-ref and LFS error classification matches on those strings
   // and would otherwise misfire under a non-English LANG/LC_ALL. simple-git's
-  // .env() merges this object with process.env (PATH etc. preserved).
-  private buildGitEnv(opts: { forceLfsSkip?: boolean } = {}): Record<string, string> {
-    const env: Record<string, string> = { LC_ALL: "C", LANG: "C" };
+  // .env() REPLACES the child environment wholesale — it does NOT merge with
+  // process.env — so the full environment (PATH, HOME, SSH_AUTH_SOCK, proxy
+  // vars, ...) must be spread in explicitly or auth and non-default git
+  // installs break for every clone-mode subprocess.
+  private buildGitEnv(opts: { forceLfsSkip?: boolean } = {}): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...sanitizeGitEnv(process.env), LC_ALL: "C", LANG: "C" };
     if (opts.forceLfsSkip || this.isLfsSkipEnabled()) {
       env[ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE] = "1";
     }
@@ -490,7 +499,16 @@ export class CloneSyncService {
     // Converge shallow state like runSyncAttempt does: with no configured depth an
     // existing shallow clone is unshallowed before the branch fetch, so switching
     // branches doesn't leave the new branch shallow while the rest is full.
-    await this.unshallowIfDepthRemoved(git);
+    try {
+      await this.unshallowIfDepthRemoved(git);
+    } catch (error) {
+      // Same classification as the branch fetch below: a deleted tracked
+      // branch fails the narrowed-refspec unshallow with the same error.
+      if (isMissingRemoteRefError(getErrorMessage(error))) {
+        throw new GitOperationError("checkout", `origin/${branch} is missing for '${this.repoName}'`);
+      }
+      throw error;
+    }
 
     const fetchArgs = await this.buildFetchArgs(git, branch);
     if ((await this.fetchWithRecovery(git, fetchArgs, worktreeDir, branch, false)).skipped) {
@@ -556,7 +574,19 @@ export class CloneSyncService {
     let entries: string[] | null = null;
     try {
       entries = await fs.readdir(worktreeDir);
-    } catch {
+    } catch (error) {
+      // Only a definitively missing directory may proceed as a fresh clone:
+      // cloneCreatedDir below authorizes maybeCleanupPartialClone to rm -rf
+      // the directory after a failed clone, so a transient probe failure
+      // (EMFILE, EACCES) must never read as "the directory did not exist" —
+      // that would delete a pre-existing directory the tool never created.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw new GitOperationError(
+          "clone-init",
+          `Cannot inspect '${worktreeDir}' before cloning: ${getErrorMessage(error)}`,
+          error instanceof Error ? error : undefined,
+        );
+      }
       entries = null;
     }
 
@@ -571,6 +601,14 @@ export class CloneSyncService {
       }
       const git = this.clientFor(worktreeDir, this.getFetchTimeoutMs());
       await this.configureSingleBranchRemote(git, branch);
+      // A pending marker means this clone was created by an init of ours that
+      // was interrupted after the clone but before the initial file copy —
+      // finish that copy now. Pre-existing user clones never carry the marker
+      // and are left alone.
+      if (await fileExists(this.getInitPendingMarkerPath(worktreeDir))) {
+        this.logger.info(`Completing interrupted initialization for '${this.repoName}' (initial file copy)...`);
+        await this.runInitialFileCopy(worktreeDir, branch);
+      }
       this.initialized = true;
       this.emitProgress({ phase: "clone", message: `Existing clone validated for '${this.repoName}'` });
       return;
@@ -609,6 +647,16 @@ export class CloneSyncService {
 
     this.logger.info(`✅ Clone successful.`);
     this.emitProgress({ phase: "clone", message: `Clone successful for '${this.repoName}'` });
+
+    // From here to the end of runInitialFileCopy any failure or kill leaves a
+    // valid-looking clone that the next init adopts via the existing-clone
+    // path, which never runs the file copy. The pending marker records the
+    // debt so that path can settle it.
+    try {
+      await fs.writeFile(this.getInitPendingMarkerPath(worktreeDir), new Date().toISOString());
+    } catch (error) {
+      this.logger.warn(`Could not write clone-init pending marker: ${getErrorMessage(error)}`);
+    }
 
     if (this.config.sparseCheckout) {
       this.logger.info(`Applying sparse-checkout patterns to '${worktreeDir}'...`);
@@ -742,9 +790,19 @@ export class CloneSyncService {
     return path.join(worktreeDir, PATH_CONSTANTS.GIT_DIR, PATH_CONSTANTS.CLONE_INIT_MARKER);
   }
 
+  private getInitPendingMarkerPath(worktreeDir: string): string {
+    return path.join(worktreeDir, PATH_CONSTANTS.GIT_DIR, PATH_CONSTANTS.CLONE_INIT_PENDING_MARKER);
+  }
+
   private async runInitialFileCopy(worktreeDir: string, branch: string): Promise<void> {
     const marker = this.getInitMarkerPath(worktreeDir);
+    const pendingMarker = this.getInitPendingMarkerPath(worktreeDir);
     if (await fileExists(marker)) {
+      try {
+        await fs.rm(pendingMarker, { force: true });
+      } catch {
+        // A stale pending marker is harmless; the final marker wins.
+      }
       return;
     }
 
@@ -760,6 +818,7 @@ export class CloneSyncService {
 
     try {
       await fs.writeFile(marker, new Date().toISOString());
+      await fs.rm(pendingMarker, { force: true });
     } catch (error) {
       this.logger.warn(`Could not write clone-init marker: ${getErrorMessage(error)}`);
     }
@@ -825,7 +884,19 @@ export class CloneSyncService {
       return;
     }
 
-    await this.unshallowIfDepthRemoved(git);
+    // The unshallow fetch uses the already-narrowed refspec, so a deleted
+    // tracked branch fails it exactly like the branch fetch below — classify
+    // it into the same soft skip instead of letting it escape as a hard
+    // failure that only shallow clones would hit.
+    try {
+      await this.unshallowIfDepthRemoved(git);
+    } catch (error) {
+      if (isMissingRemoteRefError(getErrorMessage(error))) {
+        this.recordMissingRemoteRefSkip(branch);
+        return;
+      }
+      throw error;
+    }
 
     await this.configureSingleBranchRemote(git, branch);
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -925,6 +925,14 @@ export class GitService {
     await bareGit.raw(["branch", "-D", branchName]);
   }
 
+  // Compare-and-swap delete: removes the branch ref only while it still
+  // points at expectedOid, so a commit racing the removal pipeline keeps its
+  // ref instead of being orphaned by an unconditional `branch -D`.
+  async deleteLocalBranchIfAt(branchName: string, expectedOid: string): Promise<void> {
+    const bareGit = this.getCachedGit(this.bareRepoPath);
+    await bareGit.raw(["update-ref", "-d", `${GIT_CONSTANTS.REFS.HEADS}${branchName}`, expectedOid]);
+  }
+
   // Bundles only commits not reachable from any remote — for fully-pushed
   // refs that set is empty and `bundle create` would fail. Emptiness is
   // pre-checked with rev-list (locale-independent) instead of parsing git's

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -6,6 +6,7 @@ import simpleGit from "simple-git";
 import { DEFAULT_CONFIG, ENV_CONSTANTS, GIT_CONSTANTS, PATH_CONSTANTS } from "../constants";
 import { GitOperationError, WorktreeError, WorktreeNotCleanError } from "../errors";
 import { probePathExists } from "../utils/file-exists";
+import { sanitizeGitEnv } from "../utils/git-env";
 import { makeGitProgressHandler } from "../utils/git-progress";
 import { getDefaultBareRepoDir } from "../utils/git-url";
 import { getErrorMessage } from "../utils/lfs-error";
@@ -36,16 +37,6 @@ export type GitServiceOptions = Pick<
   | "fetchTimeoutMs"
   | "cloneTimeoutMs"
 >;
-
-// simple-git blocks EDITOR / GIT_EDITOR / GIT_SEQUENCE_EDITOR unless allowUnsafeEditor is set;
-// strip them when forwarding process.env so a user's shell EDITOR doesn't break read-only commands.
-function sanitizeGitEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const sanitized = { ...env };
-  delete sanitized.EDITOR;
-  delete sanitized.GIT_EDITOR;
-  delete sanitized.GIT_SEQUENCE_EDITOR;
-  return sanitized;
-}
 
 export class GitService {
   private git: SimpleGit | null = null;
@@ -91,7 +82,9 @@ export class GitService {
     let git = this.gitInstances.get(key);
     if (!git) {
       const base = simpleGit(dirPath, this.buildSimpleGitOptions(this.getFetchTimeoutMs()));
-      git = useLfsSkip ? base.env({ [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" }) : base;
+      git = useLfsSkip
+        ? base.env({ ...sanitizeGitEnv(process.env), [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" })
+        : base;
       this.gitInstances.set(key, git);
     }
     return git;
@@ -100,6 +93,12 @@ export class GitService {
   private buildSimpleGitOptions(blockMs: number): Partial<SimpleGitOptions> {
     const options: Partial<SimpleGitOptions> = {
       progress: makeGitProgressHandler(this.logger, (event) => this.progressEmitter?.(event)),
+      // Clients that pass an explicit env (sanitizeGitEnv spread) trip
+      // simple-git's unsafe-env validation on variables the default clients
+      // inherit freely (a VS Code GIT_ASKPASS bridge, CI GIT_CONFIG_COUNT).
+      // The env is the trusted parent environment, not untrusted input, so
+      // keep parity with plain inheritance.
+      unsafe: { allowUnsafeAskPass: true, allowUnsafeConfigEnvCount: true },
     };
     if (blockMs > 0) options.timeout = { block: blockMs };
     return options;
@@ -122,7 +121,7 @@ export class GitService {
       await fs.mkdir(path.dirname(this.bareRepoPath), { recursive: true });
       const cloneBase = simpleGit(this.buildSimpleGitOptions(this.getCloneTimeoutMs()));
       const cloneGit = this.isLfsSkipEnabled()
-        ? cloneBase.env({ [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" })
+        ? cloneBase.env({ ...sanitizeGitEnv(process.env), [ENV_CONSTANTS.GIT_LFS_SKIP_SMUDGE]: "1" })
         : cloneBase;
       await cloneGit.clone(repoUrl, this.bareRepoPath, ["--bare", "--progress"]);
       this.logger.info("✅ Clone successful.");
@@ -157,7 +156,32 @@ export class GitService {
     let needsMainWorktree = true;
     try {
       const worktrees = await this.getWorktreesFromBare(bareGit, true);
-      needsMainWorktree = !worktrees.some((w) => path.resolve(w.path) === path.resolve(this.mainWorktreePath));
+      const registered = worktrees.some((w) => path.resolve(w.path) === path.resolve(this.mainWorktreePath));
+      if (registered) {
+        // A registration whose directory was destroyed out-of-band (rm -rf, a
+        // wiped volume) would otherwise satisfy this check forever: the planner
+        // never plans a create for the default branch, so nothing else rebuilds
+        // it and every sync fails at fetch. Only a definitive "missing" clears
+        // the registration — an unverifiable probe keeps it, same rule as
+        // dropStaleRegistrations.
+        if ((await probePathExists(this.mainWorktreePath)) === "missing") {
+          this.logger.info(
+            `${this.defaultBranch} worktree directory is missing at "${this.mainWorktreePath}"; clearing its stale registration and recreating it.`,
+          );
+          try {
+            await bareGit.raw(["worktree", "remove", "--force", path.resolve(this.mainWorktreePath)]);
+          } catch (removalError) {
+            // A locked registration makes single --force fail, which correctly
+            // preserves it; leave the old (broken) state rather than guess.
+            this.logger.warn(
+              `Could not clear stale registration for '${this.mainWorktreePath}': ${getErrorMessage(removalError)}`,
+            );
+            needsMainWorktree = false;
+          }
+        } else {
+          needsMainWorktree = false;
+        }
+      }
     } catch {
       // If worktree list fails, assume we need main worktree
     }
@@ -320,18 +344,25 @@ export class GitService {
   async getRemoteBranches(): Promise<string[]> {
     const git = this.getGit();
     const branches = await git.branch(["-r"]);
+    // Filter on the full ref BEFORE stripping the prefix: a remote branch
+    // literally named "origin" lists as "origin/origin" and is a real branch —
+    // filtering the stripped name would silently drop it (and its worktree
+    // would then read as stale and be pruned).
     return branches.all
-      .filter((b) => b.startsWith("origin/") && !b.endsWith("/HEAD"))
-      .map((b) => b.replace("origin/", ""))
-      .filter((b) => b !== "origin" && b.length > 0);
+      .filter((b) => b.startsWith(GIT_CONSTANTS.REMOTE_PREFIX) && !b.endsWith("/HEAD"))
+      .map((b) => b.slice(GIT_CONSTANTS.REMOTE_PREFIX.length))
+      .filter((b) => b.length > 0);
   }
 
   async getRemoteBranchesWithActivity(): Promise<{ branch: string; lastActivity: Date }[]> {
     const git = this.getGit();
-    // Use for-each-ref to get branch names with their last commit dates
+    // NUL delimiter: "|" is a legal branch-name character, so a branch like
+    // "feature|wip" would corrupt a "|"-delimited line and be silently dropped
+    // from the inventory (and its worktree then pruned as stale). A refname can
+    // never contain NUL or newline.
     const result = await git.raw([
       "for-each-ref",
-      "--format=%(refname:short)|%(committerdate:iso8601)",
+      "--format=%(refname:short)%00%(committerdate:iso8601)",
       "refs/remotes/origin",
     ]);
 
@@ -342,11 +373,15 @@ export class GitService {
       .filter((line) => line);
 
     for (const line of lines) {
-      const [ref, dateStr] = line.split("|", 2);
+      const [ref, dateStr] = line.split("\0", 2);
       if (ref && dateStr && !ref.endsWith("/HEAD")) {
-        const branch = ref.replace("origin/", "");
-        // Skip invalid branch names
-        if (branch === "origin" || branch.length === 0) {
+        // Same rule as getRemoteBranches: strip the prefix, never filter the
+        // stripped name (a branch literally named "origin" is real).
+        if (!ref.startsWith(GIT_CONSTANTS.REMOTE_PREFIX)) {
+          continue;
+        }
+        const branch = ref.slice(GIT_CONSTANTS.REMOTE_PREFIX.length);
+        if (branch.length === 0) {
           continue;
         }
         const lastActivity = new Date(dateStr);

--- a/src/services/repo-operation-lock.ts
+++ b/src/services/repo-operation-lock.ts
@@ -5,7 +5,7 @@ import * as lockfile from "proper-lockfile";
 
 import { DEFAULT_CONFIG, ENV_CONSTANTS } from "../constants";
 import { getErrorMessage } from "../utils/lfs-error";
-import { getCloneModeLockTarget } from "../utils/lock-path";
+import { getWorktreeDirLockTarget } from "../utils/lock-path";
 import { REPOSITORY_MODES, resolveMode } from "../utils/repo-mode";
 
 import { Logger } from "./logger.service";
@@ -32,14 +32,14 @@ export class RepoOperationLock {
     }
 
     if (resolveMode(this.config) === REPOSITORY_MODES.CLONE) {
-      return this.acquireCloneModeLock();
+      return this.acquireWorktreeDirLock();
     }
 
     return this.acquireWorktreeModeLock();
   }
 
-  private async acquireCloneModeLock(): Promise<RepoLockRelease | null> {
-    const target = getCloneModeLockTarget(this.config);
+  private async acquireWorktreeDirLock(): Promise<RepoLockRelease | null> {
+    const target = getWorktreeDirLockTarget(this.config);
     const lockTarget = path.join(target.dir, target.file);
     try {
       await fs.mkdir(target.dir, { recursive: true });
@@ -60,7 +60,33 @@ export class RepoOperationLock {
     } catch {
       return null;
     }
-    return this.lockPath(barePath);
+    const releaseBare = await this.lockPath(barePath);
+    if (releaseBare === null) return null;
+
+    // The bare-repo lock alone does not serialize what this lock exists to
+    // protect: every destructive operation happens under worktreeDir, and the
+    // default bare path is derived per config file, so two configs can point
+    // different bare repos at the same worktreeDir and both hold "their" bare
+    // lock. Hold the worktreeDir-keyed lock as well.
+    const releaseWorktreeDir = await this.acquireWorktreeDirLock();
+    if (releaseWorktreeDir === null) {
+      try {
+        await releaseBare();
+      } catch (releaseError) {
+        this.logger.warn(
+          `Failed to release bare-repo lock after worktreeDir lock contention: ${getErrorMessage(releaseError)}`,
+        );
+      }
+      return null;
+    }
+
+    return async () => {
+      try {
+        await releaseWorktreeDir();
+      } finally {
+        await releaseBare();
+      }
+    };
   }
 
   private async lockPath(lockTarget: string): Promise<RepoLockRelease | null> {
@@ -70,6 +96,17 @@ export class RepoOperationLock {
         update: DEFAULT_CONFIG.LOCK_UPDATE_MS,
         retries: 0,
         realpath: false,
+        // proper-lockfile's default onCompromised throws from inside its
+        // refresh timer — uncatchable by any caller, so it would take down
+        // the whole multi-repo process mid-operation. Losing the lock only
+        // means another process may start concurrently, the lesser harm:
+        // finish the in-flight operation and say so.
+        onCompromised: (compromiseError: Error): void => {
+          this.logger.warn(
+            `Repo lock at '${lockTarget}' was compromised (${getErrorMessage(compromiseError)}); ` +
+              `continuing the in-flight operation — another process may acquire the lock until it finishes.`,
+          );
+        },
       });
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;

--- a/src/services/trash-migration.service.ts
+++ b/src/services/trash-migration.service.ts
@@ -86,13 +86,13 @@ export class TrashMigrationService {
       const info = await this.readDivergedInfo(dirPath);
       const quarantinedAt = info?.divergedAt ? new Date(info.divergedAt) : null;
       const hasOriginalPath = typeof info?.originalPath === "string" && info.originalPath.length > 0;
-      if (
-        !info ||
-        !info.originalBranch ||
-        !hasOriginalPath ||
-        !quarantinedAt ||
-        Number.isNaN(quarantinedAt.getTime())
-      ) {
+      // Type-check, not truthiness: readDivergedInfo is an unvalidated
+      // JSON.parse, and a truthy non-string branch would be serialized into a
+      // manifest that readManifest then rejects forever — an adopted entry
+      // that can never be listed, restored, or reaped.
+      const hasOriginalBranch = typeof info?.originalBranch === "string" && info.originalBranch.length > 0;
+      const hasValidLocalCommit = info?.localCommit == null || typeof info.localCommit === "string";
+      if (!info || !hasOriginalBranch || !hasOriginalPath || !hasValidLocalCommit || !quarantinedAt || Number.isNaN(quarantinedAt.getTime())) {
         this.logger.warn(
           `⚠️ Leaving entry '${name}' in ${GIT_CONSTANTS.DIVERGED_DIR_NAME}/ alone (no parseable ${METADATA_CONSTANTS.DIVERGED_INFO_FILE})`,
         );

--- a/src/services/trash.service.ts
+++ b/src/services/trash.service.ts
@@ -210,6 +210,30 @@ export class TrashService {
         );
       }
     }
+    // headOid was resolved before the (potentially slow) size scan and bundle
+    // above. A commit made in that window would lose every protection at once
+    // — pin, bundle, worktree reflog, branch ref — the moment the removal
+    // pipeline runs `branch -D`, so re-verify HEAD and fail closed while the
+    // source directory is still untouched. Explicit-headOid callers (legacy
+    // adoption) are exempt: their source is not a live worktree.
+    if (headOid !== null && options.headOid === undefined) {
+      let currentHead: string | null;
+      try {
+        currentHead = (await this.gitService.getCurrentCommit(options.dirPath)).trim();
+      } catch {
+        currentHead = null;
+      }
+      if (currentHead !== headOid) {
+        await this.undoPartialTrash(containerPath, pinRef);
+        throw new TrashOperationError(
+          "trash-directory",
+          `HEAD of '${options.dirPath}' ${
+            currentHead === null ? "could no longer be resolved" : `moved from ${headOid} to ${currentHead}`
+          } during trash preparation; aborting removal`,
+        );
+      }
+    }
+
     const payloadPath = path.join(containerPath, TRASH_CONSTANTS.PAYLOAD_DIRNAME);
     manifest.pinRef = pinRef;
     manifest.bundleFile = bundleFile;

--- a/src/services/trash.service.ts
+++ b/src/services/trash.service.ts
@@ -455,7 +455,9 @@ export class TrashService {
     return manifest;
   }
 
-  async deleteTrashedBranchRef(manifest: Pick<TrashManifest, "branch" | "id" | "pinRef">): Promise<void> {
+  async deleteTrashedBranchRef(
+    manifest: Pick<TrashManifest, "branch" | "id" | "pinRef" | "headOid">,
+  ): Promise<void> {
     if (!manifest.branch) return;
     // Without a pin the branch ref may be the last thing keeping the trashed
     // commits out of gc — leave it as a hygiene problem rather than risk them.
@@ -467,7 +469,17 @@ export class TrashService {
     }
 
     try {
-      await this.gitService.deleteLocalBranch(manifest.branch);
+      // The pre-rename HEAD verification is not atomic with this deletion: a
+      // commit can still land in the moved payload (its .git link stays valid
+      // until unregistration). Deleting with headOid as the expected old
+      // value makes the race lose safely — a moved ref is refused and lands
+      // in the caller's leftover-branch-ref hygiene path instead of orphaning
+      // the new commit.
+      if (manifest.headOid) {
+        await this.gitService.deleteLocalBranchIfAt(manifest.branch, manifest.headOid);
+      } else {
+        await this.gitService.deleteLocalBranch(manifest.branch);
+      }
     } catch (error) {
       throw new TrashOperationError(
         "trash-branch-ref",

--- a/src/services/worktree-sync.service.ts
+++ b/src/services/worktree-sync.service.ts
@@ -471,6 +471,12 @@ export class WorktreeSyncService {
       // a losing concurrent caller clearing the shared accumulator would
       // silently truncate the winner's skips payload.
       this.clearRecordedSkips();
+      // A pendingInitSkip minted by an earlier standalone initialize() must
+      // not leak into this operation: its skip record was just wiped above,
+      // and consuming the stale token would suppress the re-detection in
+      // runSyncAttempt — the sync would then report clean with zero actions.
+      // The in-operation init below re-arms the token when it still applies.
+      this.clearPendingInitSkip();
       const totalTimer = new Timer();
       const phaseTimer = new PhaseTimer();
       const outcome = new SyncOutcomeAccumulator({

--- a/src/utils/__tests__/lock-path.test.ts
+++ b/src/utils/__tests__/lock-path.test.ts
@@ -1,0 +1,58 @@
+import * as fsSync from "fs";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cleanupTempDirectories, createTempDirectory } from "../../__tests__/test-utils";
+import { getWorktreeDirLockTarget } from "../lock-path";
+
+import type { Config } from "../../types";
+
+function makeConfig(worktreeDir: string): Config {
+  return {
+    repoUrl: "https://github.com/test/repo.git",
+    worktreeDir,
+    cronSchedule: "0 * * * *",
+    runOnce: true,
+  };
+}
+
+describe("getWorktreeDirLockTarget", () => {
+  let realDir: string;
+  let linkDir: string;
+
+  beforeEach(async () => {
+    realDir = await createTempDirectory();
+    linkDir = `${realDir}-link`;
+    fsSync.symlinkSync(realDir, linkDir);
+  });
+
+  afterEach(async () => {
+    fsSync.rmSync(linkDir, { force: true });
+    await cleanupTempDirectories();
+  });
+
+  it("hashes symlinked spellings of an existing directory to the same lock file", () => {
+    const viaReal = getWorktreeDirLockTarget(makeConfig(realDir));
+    const viaLink = getWorktreeDirLockTarget(makeConfig(linkDir));
+
+    expect(viaLink.file).toBe(viaReal.file);
+  });
+
+  it("hashes symlinked spellings to the same lock file when several trailing components do not exist yet (#review)", () => {
+    // /link/new/child vs /real/new/child with neither 'new' nor 'child' on
+    // disk: canonicalization must walk up to the nearest existing ancestor,
+    // not give up after the immediate parent.
+    const viaReal = getWorktreeDirLockTarget(makeConfig(path.join(realDir, "new", "child")));
+    const viaLink = getWorktreeDirLockTarget(makeConfig(path.join(linkDir, "new", "child")));
+
+    expect(viaLink.file).toBe(viaReal.file);
+  });
+
+  it("keeps genuinely different directories on different lock files", () => {
+    const a = getWorktreeDirLockTarget(makeConfig(path.join(realDir, "a")));
+    const b = getWorktreeDirLockTarget(makeConfig(path.join(realDir, "b")));
+
+    expect(a.file).not.toBe(b.file);
+  });
+});

--- a/src/utils/git-env.ts
+++ b/src/utils/git-env.ts
@@ -1,0 +1,15 @@
+// simple-git blocks EDITOR / GIT_EDITOR / GIT_SEQUENCE_EDITOR unless allowUnsafeEditor is set;
+// strip them when forwarding process.env so a user's shell EDITOR doesn't break read-only commands.
+// Every simple-git .env() call must spread this in: .env() REPLACES the child
+// environment wholesale (no merge with process.env), and a child without
+// PATH/HOME/SSH_AUTH_SOCK cannot authenticate or find git. Clients that pass
+// an env this way also need the allowances in buildSimpleGitOptions /
+// buildGitOptions: simple-git validates explicit env objects (GIT_ASKPASS,
+// GIT_CONFIG_COUNT) while default clients inherit those same variables freely.
+export function sanitizeGitEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const sanitized = { ...env };
+  delete sanitized.EDITOR;
+  delete sanitized.GIT_EDITOR;
+  delete sanitized.GIT_SEQUENCE_EDITOR;
+  return sanitized;
+}

--- a/src/utils/lock-path.ts
+++ b/src/utils/lock-path.ts
@@ -16,20 +16,25 @@ export interface RepoLockTarget {
 
 // Best-effort symlink canonicalization for lock keys: two spellings of the
 // same directory (a symlinked $HOME, macOS /tmp -> /private/tmp) must hash to
-// the same lock file or both processes proceed. When the directory itself does
-// not exist yet, canonicalize its parent instead, so the key stays stable
-// between the first run (which creates the directory) and every later one.
+// the same lock file or both processes proceed. Missing trailing components
+// are walked up to the nearest EXISTING ancestor — several components may not
+// exist yet on a first run, and canonicalizing only the immediate parent
+// would leave /link/a/b and /real/a/b on different lock keys — so the key
+// stays stable between the first run (which creates the directory) and every
+// later one.
 function canonicalizeForLockKey(dir: string): string {
   const resolved = path.resolve(dir);
-  try {
-    return fs.realpathSync(resolved);
-  } catch {
-    /* directory missing or unreadable — try the parent */
-  }
-  try {
-    return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
-  } catch {
-    return resolved;
+  let candidate = resolved;
+  const missingSuffix: string[] = [];
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync(candidate), ...missingSuffix);
+    } catch {
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return resolved;
+      missingSuffix.unshift(path.basename(candidate));
+      candidate = parent;
+    }
   }
 }
 

--- a/src/utils/lock-path.ts
+++ b/src/utils/lock-path.ts
@@ -1,4 +1,5 @@
 import { createHash } from "crypto";
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -13,12 +14,34 @@ export interface RepoLockTarget {
   file: string;
 }
 
+// Best-effort symlink canonicalization for lock keys: two spellings of the
+// same directory (a symlinked $HOME, macOS /tmp -> /private/tmp) must hash to
+// the same lock file or both processes proceed. When the directory itself does
+// not exist yet, canonicalize its parent instead, so the key stays stable
+// between the first run (which creates the directory) and every later one.
+function canonicalizeForLockKey(dir: string): string {
+  const resolved = path.resolve(dir);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    /* directory missing or unreadable — try the parent */
+  }
+  try {
+    return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+  } catch {
+    return resolved;
+  }
+}
+
 // The lock is keyed ONLY by the canonical worktreeDir: two different config
 // files (or a config-mode daemon and a programmatic run) pointing at the same
 // checkout must contend for the same lock file, so it cannot live under a
-// per-config state dir the way the audit log does.
-export function getCloneModeLockTarget(config: Config): RepoLockTarget {
-  const hash = createHash("sha256").update(path.resolve(config.worktreeDir)).digest("hex").slice(0, 16);
+// per-config state dir the way the audit log does. Clone mode holds this as
+// its only lock; worktree mode holds it in addition to the bare-repo lock,
+// because the default bare path is derived per config file and two configs
+// can point different bare repos at the same worktreeDir.
+export function getWorktreeDirLockTarget(config: Config): RepoLockTarget {
+  const hash = createHash("sha256").update(canonicalizeForLockKey(config.worktreeDir)).digest("hex").slice(0, 16);
 
   const stateBase =
     process.env.XDG_STATE_HOME && process.env.XDG_STATE_HOME.length > 0


### PR DESCRIPTION
Fixes all 13 confirmed findings from a multi-agent code review of the syncing and deleting operations (6 review lenses, every finding adversarially verified against the code before being accepted; 0 of 13 were refuted).

## Sync correctness

- **Clone mode lost the entire process environment** (`clone-sync.service.ts`): simple-git's `.env()` *replaces* the child environment — it does not merge with `process.env` as the old comment claimed — so every clone-mode git subprocess ran without `PATH`/`HOME`/`SSH_AUTH_SOCK`/proxy vars and authenticated remotes could not work. Every explicit env now spreads the sanitized parent environment (`sanitizeGitEnv`, moved to `src/utils/git-env.ts`); the two worktree-mode LFS-skip clients had the same defect and are fixed too. Clients passing an explicit env also enable `allowUnsafeAskPass`/`allowUnsafeConfigEnvCount` for parity with plain env inheritance (default clients already receive `GIT_ASKPASS`/`GIT_CONFIG_COUNT` freely).
- **Silent false-success after a standalone `initialize()`** (`worktree-sync.service.ts`): a stale `pendingInitSkip` token made the next `sync()` swallow the branch-mismatch/unreadable-HEAD/origin-mismatch skip entirely — runOnce printed the repo as cleanly synced with exit code 0 on every invocation. `sync()` now clears the token at operation start so `runSyncAttempt` re-detects and records the skip; the intended same-operation dedup is preserved.
- **Destroyed default-branch worktree permanently bricked sync** (`git.service.ts`): the stale registration satisfied the `needsMainWorktree` check forever, the planner never plans a create for the default branch, and every fetch ran from the missing directory. `initialize()` now probes the directory, clears the stale registration (targeted `worktree remove --force`, never a global prune), and recreates it. Only a definitive "missing" probe clears it, matching `dropStaleRegistrations`.
- **Branch inventory silently dropped legal branch names**, and the prune side treats absence as deletion (`git.service.ts`): `getRemoteBranchesWithActivity` used `|` as its for-each-ref delimiter (`|` is a legal refname character — a branch like `feature|wip` was dropped and its worktree pruned as stale whenever `branchMaxAge` was set), and both listing paths filtered out a branch literally named `origin`. Now NUL-delimited, and filtering happens on the full ref before the prefix strip.
- **Deleted tracked branch on a shallow clone became a hard failure** (`clone-sync.service.ts`): the `--unshallow` fetch runs on the narrowed refspec but sat outside the missing-remote-ref classification. It now produces the same soft `missing_remote_ref` skip as the branch fetch (and the equivalent clear error in `checkoutBranch`).

## Deletion safety

- **Commit made mid-trash lost every protection at once** (`trash.service.ts`): HEAD was resolved once, then the size scan and bundle ran (tens of seconds on big worktrees) before the payload move — a commit made in that window had no pin, no bundle, and both reflogs destroyed at `branch -D`. HEAD is now re-verified immediately before the payload move; on mismatch the trash entry is rolled back and the removal aborts with the worktree untouched (same compare-and-swap idea as `resetToUpstream`'s `expectedHead`).
- **Failed readdir could authorize `rm -rf` of a pre-existing directory** (`clone-sync.service.ts`): any readdir failure (EMFILE, transient EACCES) was treated as "directory did not exist", which let `maybeCleanupPartialClone` delete a dotfiles-only directory the tool never created after the inevitable clone failure. Only ENOENT proceeds now; anything else aborts init loudly.
- **Interrupted clone init silently dropped `filesToCopyOnBranchCreate` forever** (`clone-sync.service.ts`): the existing-clone path never ran the initial file copy, so a failure between clone and copy left the debt unpaid with no retry. A `.git/.sync-worktrees-clone-init.pending` marker is written right after a successful clone and consumed when the copy lands; the existing-clone path settles it on the next init. Pre-existing user clones never carry the marker and are untouched.
- **Malformed `.diverged` info file could mint a permanently invalid trash entry** (`trash-migration.service.ts`): `originalBranch` was only truthiness-checked from an unvalidated `JSON.parse`, so a non-string value produced a manifest `readManifest` rejects forever — unlistable, unrestorable, unreapable, pin ref held indefinitely. `originalBranch` and `localCommit` are now type-checked; malformed entries stay in `.diverged/` with a warning, per the module's stated contract.

## Locking

- **Worktree mode locked the wrong resource** (`repo-operation-lock.ts`): it locked only `bareRepoPath`, but every destructive operation happens under `worktreeDir`, and the default bare path derives from the config file's directory — two configs pointing different bare repos at the same `worktreeDir` both proceeded and repeatedly trash-moved each other's checkouts. Worktree mode now also holds the worktreeDir-keyed lock (consistent bare → worktreeDir order, so no deadlock; clone mode takes only the latter).
- **Lock keys weren't symlink-canonicalized** (`lock-path.ts`): `/tmp/x` and `/private/tmp/x` hashed to different lock files despite the comment claiming canonical keying. Keys now go through best-effort `realpath` (falling back to the parent when the directory doesn't exist yet, so the key stays stable across the first run). Hashes are unchanged for non-symlinked paths.
- **A compromised lock killed the whole multi-repo process** (`repo-operation-lock.ts`): proper-lockfile's default `onCompromised` throws from inside its refresh timer — uncatchable — so deleting the lock file mid-sync (clone-mode locks live under `~/.cache/`, which cache cleaners purge) crashed the daemon mid-mutation across all repos. A handler now logs and lets the in-flight operation finish, honoring the class's "clean skip, never fatal" contract.

## Validation

- Baseline before any change: 1545 passed / 5 skipped across 72 files, typecheck and lint clean.
- After: **1553 passed / 0 failed** (+8 new regression tests), `pnpm typecheck`, `pnpm lint`, and CI's `pnpm test:coverage` all green (85.2% statements / 80.1% branches vs 79/74 thresholds).
- New regression tests pin: mid-trash HEAD movement aborts with full rollback; non-ENOENT readdir refuses to clone; pending-marker resume runs the file copy exactly once; unshallow missing-ref becomes the soft skip; `|`-containing and `origin`-named branches survive inventory; worktree mode acquires both locks and releases the bare lock on worktreeDir contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K95m2pRq7T59uGC1NJLbvo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K95m2pRq7T59uGC1NJLbvo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from interrupted clone initialization and stale worktree registrations.
  * Prevented valid branch names from being misread during synchronization.
  * Treated deleted remote branches as skippable conditions instead of sync failures.
  * Added safeguards against moving worktrees when their contents change unexpectedly.
  * Improved handling of worktree locks, symlinks, and compromised lock states.
  * Validated diverged-entry metadata before migration.
* **Tests**
  * Added regression coverage for clone recovery, branch handling, locking, stale directories, and safe trash operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->